### PR TITLE
feat(backend): drag-to-reorder + preferences API

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -6,6 +6,31 @@ const pool = new Pool({
     ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
 });
 
+/**
+ * Run a callback inside a transaction, automatically committing or rolling back.
+ * Used by reorder endpoints which need SELECT ... FOR UPDATE + UPDATE atomicity.
+ *
+ * @param {(client: import('pg').PoolClient) => Promise<any>} fn
+ * @returns {Promise<any>} whatever fn returns
+ */
+async function withTransaction(fn) {
+    const client = await pool.connect();
+    try {
+        await client.query('BEGIN');
+        const result = await fn(client);
+        await client.query('COMMIT');
+        return result;
+    } catch (err) {
+        try { await client.query('ROLLBACK'); } catch (_) { /* ignore */ }
+        throw err;
+    } finally {
+        client.release();
+    }
+}
+
 module.exports = {
     query: (text, params) => pool.query(text, params),
+    getClient: () => pool.connect(),
+    withTransaction,
+    pool,
 };

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,17 @@ const fs = require('fs');
 const { chatToDrafts } = require('./ai/chatToDrafts');
 const draftStore = require('./ai/draftStore');
 
+// v2 refactor helpers
+const { z } = require('zod');
+const { computeNewPosition } = require('./reorderHelpers');
+const {
+    DEFAULT_PREFERENCES,
+    DEFAULT_WIDGETS,
+    preferencesPatchSchema,
+    deepMerge,
+    hydrateLayoutPreference,
+} = require('./preferences');
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -226,8 +237,13 @@ app.get('/api/todo-history', async (req, res) => {
 app.post('/api/todos', async (req, res) => {
     try {
         const { title, description, due_date, tag } = req.body;
+        // New rows go to the bottom of the global active-todos scope.
+        // COALESCE(MAX(...), 0) handles the empty-table case.
         const { rows } = await db.query(
-            'INSERT INTO todos (title, description, due_date, tag) VALUES ($1, $2, $3, $4) RETURNING *',
+            `INSERT INTO todos (title, description, due_date, tag, position)
+             VALUES ($1, $2, $3, $4,
+                     (SELECT COALESCE(MAX(position), 0) + 1000 FROM todos WHERE deleted_at IS NULL))
+             RETURNING *`,
             [title, description || null, due_date || null, tag || null]
         );
         const todo = rows[0];
@@ -372,7 +388,12 @@ app.get('/api/note-folders', async (req, res) => {
 app.post('/api/note-folders', async (req, res) => {
     try {
         const { name } = req.body;
-        const { rows } = await db.query('INSERT INTO note_folders (name) VALUES ($1) RETURNING *', [name]);
+        const { rows } = await db.query(
+            `INSERT INTO note_folders (name, position)
+             VALUES ($1, (SELECT COALESCE(MAX(position), 0) + 1000 FROM note_folders))
+             RETURNING *`,
+            [name]
+        );
         const folder = rows[0];
 
         // Log folder creation
@@ -488,10 +509,18 @@ app.get('/api/note-history', async (req, res) => {
 app.post('/api/notes', async (req, res) => {
     try {
         const { title, content, folder_id } = req.body;
-        console.log(`[NOTES] Creating note: title="${title}", folder_id=${folder_id}`);
+        const folderId = folder_id || null;
+        console.log(`[NOTES] Creating note: title="${title}", folder_id=${folderId}`);
+        // Per-folder MAX so notes append to the bottom of their folder (or
+        // unfiled bucket when folder_id IS NULL).
         const { rows } = await db.query(
-            'INSERT INTO notes (title, content, folder_id, updated_at) VALUES ($1, $2, $3, CURRENT_TIMESTAMP) RETURNING *',
-            [title, content, folder_id || null]
+            `INSERT INTO notes (title, content, folder_id, position, updated_at)
+             VALUES ($1, $2, $3,
+                     (SELECT COALESCE(MAX(position), 0) + 1000 FROM notes
+                      WHERE folder_id IS NOT DISTINCT FROM $3),
+                     CURRENT_TIMESTAMP)
+             RETURNING *`,
+            [title, content, folderId]
         );
         const note = rows[0];
         console.log(`[NOTES] Note created with id=${note.id}`);
@@ -626,7 +655,12 @@ app.get('/api/list-history', async (req, res) => {
 app.post('/api/lists', async (req, res) => {
     try {
         const { title, items } = req.body;
-        const { rows } = await db.query('INSERT INTO lists (title, items) VALUES ($1, $2) RETURNING *', [title, JSON.stringify(items)]);
+        const { rows } = await db.query(
+            `INSERT INTO lists (title, items, position)
+             VALUES ($1, $2, (SELECT COALESCE(MAX(position), 0) + 1000 FROM lists))
+             RETURNING *`,
+            [title, JSON.stringify(items)]
+        );
         const list = rows[0];
 
         // Log creation
@@ -806,16 +840,22 @@ app.get('/api/stats', async (req, res) => {
     }
 });
 
-// DASHBOARD CONFIG
+// =============================================================================
+// DASHBOARD CONFIG / PREFERENCES (v2)
+// =============================================================================
+// The dashboard_config row stores both the legacy `widgets` array and the new
+// nested `preferences` object (theme, default_view, density, etc.). The
+// merge/hydrate logic lives in ./preferences.js so tests can exercise it
+// without spinning up Express.
+
 app.get('/api/config', async (req, res) => {
     try {
-        const { rows } = await db.query('SELECT * FROM dashboard_config WHERE id = 1');
-        if (rows.length === 0) {
-            // Should not happen due to schema init, but just in case
-            res.json({ layout_preference: { widgets: ["todos", "notes", "lists"] } });
-        } else {
-            res.json(rows[0]);
-        }
+        const { rows } = await db.query('SELECT id, layout_preference FROM dashboard_config WHERE id = 1');
+        const stored = rows[0]?.layout_preference || null;
+        res.json({
+            id: rows[0]?.id || 1,
+            layout_preference: hydrateLayoutPreference(stored),
+        });
     } catch (err) {
         sendErrorResponse(res, err);
     }
@@ -824,8 +864,272 @@ app.get('/api/config', async (req, res) => {
 app.put('/api/config', async (req, res) => {
     try {
         const { layout_preference } = req.body;
-        const { rows } = await db.query('UPDATE dashboard_config SET layout_preference = $1 WHERE id = 1 RETURNING *', [JSON.stringify(layout_preference)]);
-        res.json(rows[0]);
+        // Pass the raw object straight through — full overwrite is the legacy
+        // contract. Callers that want partial updates use the PATCH endpoint
+        // below.
+        const { rows } = await db.query(
+            'UPDATE dashboard_config SET layout_preference = $1 WHERE id = 1 RETURNING id, layout_preference',
+            [JSON.stringify(layout_preference)]
+        );
+        res.json({
+            id: rows[0]?.id || 1,
+            layout_preference: hydrateLayoutPreference(rows[0]?.layout_preference || null),
+        });
+    } catch (err) {
+        sendErrorResponse(res, err);
+    }
+});
+
+// Friendly aliases used by the v2 frontend. Behaviour is identical to /api/config.
+app.get('/api/dashboard/config', async (req, res) => {
+    try {
+        const { rows } = await db.query('SELECT id, layout_preference FROM dashboard_config WHERE id = 1');
+        res.json({
+            id: rows[0]?.id || 1,
+            layout_preference: hydrateLayoutPreference(rows[0]?.layout_preference || null),
+        });
+    } catch (err) {
+        sendErrorResponse(res, err);
+    }
+});
+
+/**
+ * PATCH /api/dashboard/config/preferences
+ * Accepts a partial preferences object and deep-merges it into the stored
+ * preferences sub-object. Does NOT touch `widgets`. Returns the full
+ * hydrated layout_preference shape.
+ */
+app.patch('/api/dashboard/config/preferences', async (req, res) => {
+    try {
+        const parsed = preferencesPatchSchema.safeParse(req.body || {});
+        if (!parsed.success) {
+            return res.status(400).json({
+                error: 'Invalid preferences payload',
+                details: parsed.error.flatten(),
+            });
+        }
+        const patch = parsed.data;
+
+        // Read-modify-write inside a transaction so concurrent PATCHes don't
+        // clobber each other. Single-user app today, but cheap to do right.
+        const result = await db.withTransaction(async (client) => {
+            const { rows } = await client.query(
+                'SELECT layout_preference FROM dashboard_config WHERE id = 1 FOR UPDATE'
+            );
+            const stored = rows[0]?.layout_preference || {};
+            const next = {
+                widgets: Array.isArray(stored.widgets) ? stored.widgets : DEFAULT_WIDGETS.slice(),
+                preferences: deepMerge(deepMerge(DEFAULT_PREFERENCES, stored.preferences || {}), patch),
+            };
+            const upd = await client.query(
+                `INSERT INTO dashboard_config (id, layout_preference) VALUES (1, $1)
+                 ON CONFLICT (id) DO UPDATE SET layout_preference = EXCLUDED.layout_preference
+                 RETURNING id, layout_preference`,
+                [JSON.stringify(next)]
+            );
+            return upd.rows[0];
+        });
+
+        res.json({
+            id: result.id,
+            layout_preference: hydrateLayoutPreference(result.layout_preference),
+        });
+    } catch (err) {
+        sendErrorResponse(res, err);
+    }
+});
+
+// =============================================================================
+// REORDER ENDPOINTS (v2 drag-to-reorder)
+// =============================================================================
+// All four endpoints share the same body schema and the same midpoint /
+// renumber strategy via computeNewPosition. The transaction makes
+// SELECT ... FOR UPDATE + UPDATE atomic so concurrent reorders on the same
+// scope don't fight.
+
+const reorderBodySchema = z.object({
+    before_id: z.number().int().nullable().optional(),
+    after_id: z.number().int().nullable().optional(),
+}).strict();
+
+const noteReorderBodySchema = reorderBodySchema.extend({
+    folder_id: z.number().int().nullable().optional(), // optional cross-folder move
+});
+
+/**
+ * Shared reorder runner. Returns the updated row.
+ *
+ * @param {object} args
+ * @param {string} args.table         table name (allowlisted in reorderHelpers)
+ * @param {object} args.scopeFilter   columns that bound the ordering scope
+ * @param {number} args.movingId
+ * @param {number|null} args.beforeId
+ * @param {number|null} args.afterId
+ * @param {(client, newPos) => Promise<object>} args.applyUpdate updates the
+ *        row's position (and any other columns the route mutates, e.g. folder
+ *        moves on notes) and returns the updated row.
+ */
+async function runReorder({ table, scopeFilter, movingId, beforeId, afterId, applyUpdate }) {
+    return db.withTransaction(async (client) => {
+        const newPos = await computeNewPosition(client, table, scopeFilter, movingId, beforeId ?? null, afterId ?? null);
+        return applyUpdate(client, newPos);
+    });
+}
+
+app.patch('/api/todos/:id/reorder', async (req, res) => {
+    try {
+        const id = parseInt(req.params.id, 10);
+        if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });
+
+        const parsed = reorderBodySchema.safeParse(req.body || {});
+        if (!parsed.success) {
+            return res.status(400).json({ error: 'Invalid body', details: parsed.error.flatten() });
+        }
+        const { before_id = null, after_id = null } = parsed.data;
+
+        const updated = await runReorder({
+            table: 'todos',
+            scopeFilter: { deleted_at: null }, // active todos only; matches list-render filter
+            movingId: id,
+            beforeId: before_id,
+            afterId: after_id,
+            applyUpdate: async (client, newPos) => {
+                const { rows } = await client.query(
+                    `UPDATE todos SET position = $1, updated_at = CURRENT_TIMESTAMP
+                     WHERE id = $2 RETURNING *`,
+                    [newPos, id]
+                );
+                return rows[0];
+            }
+        });
+
+        if (!updated) return res.status(404).json({ error: 'Todo not found' });
+
+        await logTodoHistory(id, 'reorder', 'position', null, String(updated.position));
+        res.json(updated);
+    } catch (err) {
+        sendErrorResponse(res, err);
+    }
+});
+
+app.patch('/api/notes/:id/reorder', async (req, res) => {
+    try {
+        const id = parseInt(req.params.id, 10);
+        if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });
+
+        const parsed = noteReorderBodySchema.safeParse(req.body || {});
+        if (!parsed.success) {
+            return res.status(400).json({ error: 'Invalid body', details: parsed.error.flatten() });
+        }
+        const { before_id = null, after_id = null, folder_id } = parsed.data;
+
+        // Determine the destination folder. If folder_id is omitted from the
+        // body, the note stays in its current folder. We need this BEFORE
+        // computing the new position so the scope is correct.
+        const { rows: noteRows } = await db.query('SELECT folder_id FROM notes WHERE id = $1', [id]);
+        if (noteRows.length === 0) return res.status(404).json({ error: 'Note not found' });
+        const currentFolderId = noteRows[0].folder_id;
+        const targetFolderId = folder_id === undefined ? currentFolderId : folder_id;
+
+        const updated = await runReorder({
+            table: 'notes',
+            scopeFilter: { folder_id: targetFolderId }, // null is allowed and treated as IS NULL
+            movingId: id,
+            beforeId: before_id,
+            afterId: after_id,
+            applyUpdate: async (client, newPos) => {
+                const { rows } = await client.query(
+                    `UPDATE notes SET position = $1, folder_id = $2, updated_at = CURRENT_TIMESTAMP
+                     WHERE id = $3 RETURNING *`,
+                    [newPos, targetFolderId, id]
+                );
+                return rows[0];
+            }
+        });
+
+        if (!updated) return res.status(404).json({ error: 'Note not found' });
+
+        // Audit log: emit a folder move row when the folder actually changed,
+        // plus the reorder row so the position change is also recorded.
+        if (folder_id !== undefined && folder_id !== currentFolderId) {
+            await logNoteHistory(id, 'moved', 'folder_id',
+                currentFolderId === null ? null : String(currentFolderId),
+                targetFolderId === null ? null : String(targetFolderId)
+            );
+        }
+        await logNoteHistory(id, 'reorder', 'position', null, String(updated.position));
+
+        res.json(updated);
+    } catch (err) {
+        sendErrorResponse(res, err);
+    }
+});
+
+app.patch('/api/lists/:id/reorder', async (req, res) => {
+    try {
+        const id = parseInt(req.params.id, 10);
+        if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });
+
+        const parsed = reorderBodySchema.safeParse(req.body || {});
+        if (!parsed.success) {
+            return res.status(400).json({ error: 'Invalid body', details: parsed.error.flatten() });
+        }
+        const { before_id = null, after_id = null } = parsed.data;
+
+        const updated = await runReorder({
+            table: 'lists',
+            scopeFilter: {}, // global ordering
+            movingId: id,
+            beforeId: before_id,
+            afterId: after_id,
+            applyUpdate: async (client, newPos) => {
+                const { rows } = await client.query(
+                    `UPDATE lists SET position = $1 WHERE id = $2 RETURNING *`,
+                    [newPos, id]
+                );
+                return rows[0];
+            }
+        });
+
+        if (!updated) return res.status(404).json({ error: 'List not found' });
+
+        await logListHistory(id, 'reorder', 'position', null, String(updated.position));
+        res.json(updated);
+    } catch (err) {
+        sendErrorResponse(res, err);
+    }
+});
+
+app.patch('/api/note_folders/:id/reorder', async (req, res) => {
+    try {
+        const id = parseInt(req.params.id, 10);
+        if (!Number.isFinite(id)) return res.status(400).json({ error: 'Invalid id' });
+
+        const parsed = reorderBodySchema.safeParse(req.body || {});
+        if (!parsed.success) {
+            return res.status(400).json({ error: 'Invalid body', details: parsed.error.flatten() });
+        }
+        const { before_id = null, after_id = null } = parsed.data;
+
+        const updated = await runReorder({
+            table: 'note_folders',
+            scopeFilter: {},
+            movingId: id,
+            beforeId: before_id,
+            afterId: after_id,
+            applyUpdate: async (client, newPos) => {
+                const { rows } = await client.query(
+                    `UPDATE note_folders SET position = $1 WHERE id = $2 RETURNING *`,
+                    [newPos, id]
+                );
+                return rows[0];
+            }
+        });
+
+        if (!updated) return res.status(404).json({ error: 'Folder not found' });
+
+        await logNoteHistory(id, 'reorder', 'position', null, String(updated.position), 'folder');
+        res.json(updated);
     } catch (err) {
         sendErrorResponse(res, err);
     }
@@ -1602,7 +1906,14 @@ if (process.env.NODE_ENV === 'production') {
     });
 }
 
-app.listen(PORT, async () => {
-    console.log(`Server is running on port ${PORT}`);
-    await initDb();
-});
+// Only start the listener when run as the main entrypoint. Tests that need
+// the app for in-process HTTP exercise the `app` export and use a random
+// port via http.createServer(app).listen(0).
+if (require.main === module) {
+    app.listen(PORT, async () => {
+        console.log(`Server is running on port ${PORT}`);
+        await initDb();
+    });
+}
+
+module.exports = { app, initDb };

--- a/server/migration.sql
+++ b/server/migration.sql
@@ -1,10 +1,94 @@
 -- Migration script to update todos table with new fields
 -- Run this on existing databases to preserve data
 
--- Rename text column to title
-ALTER TABLE todos RENAME COLUMN text TO title;
+-- Rename text column to title (idempotent: only runs if `text` still exists)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'todos' AND column_name = 'text'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'todos' AND column_name = 'title'
+    ) THEN
+        ALTER TABLE todos RENAME COLUMN text TO title;
+    END IF;
+END $$;
 
 -- Add new columns
 ALTER TABLE todos ADD COLUMN IF NOT EXISTS description TEXT;
 ALTER TABLE todos ADD COLUMN IF NOT EXISTS due_date TIMESTAMP;
 ALTER TABLE todos ADD COLUMN IF NOT EXISTS tag TEXT;
+
+-- =============================================================================
+-- 2026-05-02: Add position columns for drag-to-reorder (refactor v2)
+-- =============================================================================
+-- Adds a nullable `position` integer to todos, notes, lists, and note_folders.
+-- Backfills existing rows with gap-1000 sequential values derived from
+-- created_at, so reorders between two rows can interpolate without renumbering
+-- the whole scope. For notes the position scope is per-folder (folder_id +
+-- position is the natural key); for everything else it is global.
+--
+-- Idempotent: re-running this script will NOT double-position rows. The backfill
+-- only writes a value into rows where position IS NULL, and indexes use IF NOT
+-- EXISTS. Columns remain nullable so future inserts that omit position succeed.
+
+ALTER TABLE todos        ADD COLUMN IF NOT EXISTS position INTEGER;
+ALTER TABLE notes        ADD COLUMN IF NOT EXISTS position INTEGER;
+ALTER TABLE lists        ADD COLUMN IF NOT EXISTS position INTEGER;
+ALTER TABLE note_folders ADD COLUMN IF NOT EXISTS position INTEGER;
+
+-- Backfill todos: global ordering by created_at, step 1000, base 1000
+WITH ranked AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY created_at ASC, id ASC) AS rn
+    FROM todos
+    WHERE position IS NULL
+)
+UPDATE todos t
+SET position = ranked.rn * 1000
+FROM ranked
+WHERE t.id = ranked.id;
+
+-- Backfill lists: global ordering by created_at, step 1000, base 1000
+WITH ranked AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY created_at ASC, id ASC) AS rn
+    FROM lists
+    WHERE position IS NULL
+)
+UPDATE lists l
+SET position = ranked.rn * 1000
+FROM ranked
+WHERE l.id = ranked.id;
+
+-- Backfill note_folders: global ordering by created_at, step 1000, base 1000
+WITH ranked AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY created_at ASC, id ASC) AS rn
+    FROM note_folders
+    WHERE position IS NULL
+)
+UPDATE note_folders f
+SET position = ranked.rn * 1000
+FROM ranked
+WHERE f.id = ranked.id;
+
+-- Backfill notes: ordering is PARTITIONED by folder_id (NULLs partition together
+-- as the unfiled scope), step 1000, base 1000.
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY folder_id
+               ORDER BY created_at ASC, id ASC
+           ) AS rn
+    FROM notes
+    WHERE position IS NULL
+)
+UPDATE notes n
+SET position = ranked.rn * 1000
+FROM ranked
+WHERE n.id = ranked.id;
+
+-- Indexes for the lookup paths used by reorder + list-render
+CREATE INDEX IF NOT EXISTS todos_position_idx        ON todos (position);
+CREATE INDEX IF NOT EXISTS lists_position_idx        ON lists (position);
+CREATE INDEX IF NOT EXISTS note_folders_position_idx ON note_folders (position);
+CREATE INDEX IF NOT EXISTS notes_folder_position_idx ON notes (folder_id, position);

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test --test-concurrency=1 tests/",
+    "migrate": "psql \"$DATABASE_URL\" -f migration.sql"
   },
   "keywords": [],
   "author": "",

--- a/server/preferences.js
+++ b/server/preferences.js
@@ -1,0 +1,74 @@
+/**
+ * Preferences helpers extracted so tests can exercise the merge/hydrate logic
+ * without standing up the whole Express app. The HTTP route in index.js
+ * imports the same functions so behaviour can't drift.
+ */
+
+const { z } = require('zod');
+
+const DEFAULT_PREFERENCES = {
+    theme: 'system',
+    default_view: 'today',
+    density: 'comfortable',
+    sidebar_collapsed_default: true,
+    wordmark: 'Dashy',
+    ai: {
+        stream: true,
+        model: 'gpt-4o',
+    },
+    dashboard_widget_order: ['todos', 'notes', 'lists'],
+};
+
+const DEFAULT_WIDGETS = ['todos', 'notes', 'lists'];
+
+const preferencesPatchSchema = z.object({
+    theme: z.enum(['light', 'dark', 'system']).optional(),
+    default_view: z.enum(['today', 'chat', 'dashboard', 'tasks', 'notes', 'lists']).optional(),
+    density: z.enum(['comfortable', 'compact']).optional(),
+    sidebar_collapsed_default: z.boolean().optional(),
+    wordmark: z.string().min(1).max(50).optional(),
+    ai: z.object({
+        stream: z.boolean().optional(),
+        model: z.string().min(1).max(100).optional(),
+    }).strict().optional(),
+    dashboard_widget_order: z.array(z.string().min(1)).optional(),
+}).strict();
+
+/**
+ * Deep-merge plain objects. Arrays and primitives replace. Returns a new
+ * object — does not mutate inputs.
+ */
+function deepMerge(base, patch) {
+    if (patch == null) return base;
+    if (typeof patch !== 'object' || Array.isArray(patch)) return patch;
+    const out = { ...(base || {}) };
+    for (const [k, v] of Object.entries(patch)) {
+        if (v && typeof v === 'object' && !Array.isArray(v)
+            && out[k] && typeof out[k] === 'object' && !Array.isArray(out[k])) {
+            out[k] = deepMerge(out[k], v);
+        } else {
+            out[k] = v;
+        }
+    }
+    return out;
+}
+
+/**
+ * Fill defaults into a stored layout_preference value. Always returns the
+ * full shape so the client never has to fall back.
+ */
+function hydrateLayoutPreference(stored) {
+    const base = stored && typeof stored === 'object' ? stored : {};
+    return {
+        widgets: Array.isArray(base.widgets) ? base.widgets : DEFAULT_WIDGETS.slice(),
+        preferences: deepMerge(DEFAULT_PREFERENCES, base.preferences || {}),
+    };
+}
+
+module.exports = {
+    DEFAULT_PREFERENCES,
+    DEFAULT_WIDGETS,
+    preferencesPatchSchema,
+    deepMerge,
+    hydrateLayoutPreference,
+};

--- a/server/reorderHelpers.js
+++ b/server/reorderHelpers.js
@@ -1,0 +1,219 @@
+/**
+ * Reorder helpers for drag-to-reorder endpoints.
+ *
+ * The position model is gap-1000 sparse integers per scope. To move a row
+ * between two neighbours we set its position to the midpoint of theirs. If
+ * the gap collapses to <= 1 we renumber the entire scope to step 1000 and
+ * place the moved row in the right slot.
+ *
+ * `scopeFilter` lets callers add an extra WHERE clause without exposing
+ * column lists from the route handler. It must be parameterized via the
+ * `params` slot to avoid SQL injection — a bare object of field=value pairs
+ * is the only shape accepted.
+ */
+
+const STEP = 1000;
+
+/**
+ * Build a parameterised WHERE fragment from a scopeFilter object.
+ * Returns { sql, params } where sql is `<col> = $N AND <col2> IS NULL ...`
+ * and params is the ordered values to splice into the calling query's
+ * params array. NULL values are emitted as `IS NULL` rather than `= NULL`.
+ *
+ * Caller passes its own paramOffset so the placeholders line up with the
+ * surrounding query's existing params.
+ *
+ * @param {Object} scopeFilter
+ * @param {number} paramOffset existing params already in the query
+ * @returns {{ sql: string, params: any[] }}
+ */
+function buildScopeWhere(scopeFilter, paramOffset = 0) {
+    const parts = [];
+    const params = [];
+    let i = paramOffset;
+    for (const [col, val] of Object.entries(scopeFilter)) {
+        // Hard guard: only allow simple identifiers as column names. This is
+        // a defence-in-depth check — callers always pass literal strings — but
+        // it ensures a typo never becomes an injection vector.
+        if (!/^[a-z_][a-z0-9_]*$/i.test(col)) {
+            throw new Error(`Invalid scope column: ${col}`);
+        }
+        if (val === null) {
+            parts.push(`${col} IS NULL`);
+        } else {
+            i += 1;
+            parts.push(`${col} = $${i}`);
+            params.push(val);
+        }
+    }
+    return { sql: parts.length ? parts.join(' AND ') : 'TRUE', params };
+}
+
+/**
+ * Allowlist of tables we accept. Identifier interpolation in SQL is otherwise
+ * a footgun; this is the cheapest way to make it safe.
+ */
+const ALLOWED_TABLES = new Set(['todos', 'notes', 'lists', 'note_folders']);
+
+function assertTable(table) {
+    if (!ALLOWED_TABLES.has(table)) {
+        throw new Error(`Reorder not supported for table: ${table}`);
+    }
+}
+
+/**
+ * Renumber every row in scope to step-1000 positions in current ascending
+ * position order. Inserts the moving row (`movingId`) at the right slot
+ * relative to before/after neighbours. Caller is responsible for the
+ * surrounding transaction.
+ *
+ * Returns the new position of the moving row.
+ *
+ * @param {import('pg').PoolClient} client
+ * @param {string} table
+ * @param {Object} scopeFilter
+ * @param {number} movingId
+ * @param {number|null} beforeId row that should end up immediately above
+ * @param {number|null} afterId row that should end up immediately below
+ */
+async function renumberScope(client, table, scopeFilter, movingId, beforeId, afterId) {
+    assertTable(table);
+    const { sql: scopeSql, params: scopeParams } = buildScopeWhere(scopeFilter);
+    // Lock and read the current order. Excluding the moving row from the
+    // sorted snapshot and re-inserting it at the desired slot is simpler
+    // than computing offsets afterwards.
+    const { rows } = await client.query(
+        `SELECT id, position FROM ${table}
+         WHERE ${scopeSql} AND id <> $${scopeParams.length + 1}
+         ORDER BY position ASC NULLS LAST, id ASC
+         FOR UPDATE`,
+        [...scopeParams, movingId]
+    );
+    const ordered = rows.map(r => r.id);
+
+    // Resolve the slot index where `movingId` should land.
+    let insertIdx;
+    if (beforeId == null && afterId == null) {
+        // No neighbours specified — append to the end.
+        insertIdx = ordered.length;
+    } else if (beforeId == null) {
+        // afterId only — place at the very top.
+        insertIdx = 0;
+    } else if (afterId == null) {
+        // beforeId only — place at the very end.
+        insertIdx = ordered.length;
+    } else {
+        // Place between beforeId and afterId. Find beforeId and put us right after.
+        const idx = ordered.indexOf(beforeId);
+        insertIdx = idx === -1 ? ordered.length : idx + 1;
+    }
+
+    ordered.splice(insertIdx, 0, movingId);
+
+    // Single round-trip update via UPDATE ... FROM (VALUES ...).
+    if (ordered.length === 0) {
+        return STEP; // nothing to update; should not happen because movingId exists
+    }
+    const valuesClauses = [];
+    const updateParams = [];
+    let p = 0;
+    ordered.forEach((id, i) => {
+        const pos = (i + 1) * STEP;
+        valuesClauses.push(`($${++p}::int, $${++p}::int)`);
+        updateParams.push(id, pos);
+    });
+    await client.query(
+        `UPDATE ${table} AS t
+         SET position = v.pos
+         FROM (VALUES ${valuesClauses.join(', ')}) AS v(id, pos)
+         WHERE t.id = v.id`,
+        updateParams
+    );
+
+    return (insertIdx + 1) * STEP;
+}
+
+/**
+ * Compute the new position for a row given before/after neighbour ids.
+ * Locks the involved rows for update. Renumbers the scope when the gap is
+ * too tight (<= 1).
+ *
+ * @param {import('pg').PoolClient} client
+ * @param {string} table
+ * @param {Object} scopeFilter columns + values that define the ordering scope
+ * @param {number} movingId the id of the row being reordered
+ * @param {number|null} beforeId row that should end up immediately above the
+ *        moving row in the final order. null means "moving to the very top".
+ * @param {number|null} afterId row that should end up immediately below the
+ *        moving row. null means "moving to the very end".
+ * @returns {Promise<number>} new position value to write
+ */
+async function computeNewPosition(client, table, scopeFilter, movingId, beforeId, afterId) {
+    assertTable(table);
+
+    // Lock the moving row first to serialize concurrent reorder calls on the same id.
+    await client.query(`SELECT id FROM ${table} WHERE id = $1 FOR UPDATE`, [movingId]);
+
+    // Both null => place at the bottom of the scope.
+    if (beforeId == null && afterId == null) {
+        const { sql: scopeSql, params: scopeParams } = buildScopeWhere(scopeFilter);
+        const { rows } = await client.query(
+            `SELECT COALESCE(MAX(position), 0) AS max_pos FROM ${table} WHERE ${scopeSql} AND id <> $${scopeParams.length + 1}`,
+            [...scopeParams, movingId]
+        );
+        return Number(rows[0].max_pos) + STEP;
+    }
+
+    // afterId only => place at the very top of the scope.
+    if (beforeId == null) {
+        const { sql: scopeSql, params: scopeParams } = buildScopeWhere(scopeFilter);
+        // Find the smallest position in scope (excluding the moving row).
+        const { rows } = await client.query(
+            `SELECT MIN(position) AS min_pos FROM ${table} WHERE ${scopeSql} AND id <> $${scopeParams.length + 1}`,
+            [...scopeParams, movingId]
+        );
+        const minPos = rows[0].min_pos == null ? STEP * 2 : Number(rows[0].min_pos);
+        if (minPos > 1) {
+            return Math.floor(minPos / 2);
+        }
+        // Min position is already at floor — renumber.
+        return await renumberScope(client, table, scopeFilter, movingId, null, afterId);
+    }
+
+    // beforeId only => place at the very end. Same as both-null but anchored
+    // by an explicit before so we still validate that beforeId is in scope.
+    if (afterId == null) {
+        const { sql: scopeSql, params: scopeParams } = buildScopeWhere(scopeFilter);
+        const { rows } = await client.query(
+            `SELECT COALESCE(MAX(position), 0) AS max_pos FROM ${table} WHERE ${scopeSql} AND id <> $${scopeParams.length + 1}`,
+            [...scopeParams, movingId]
+        );
+        return Number(rows[0].max_pos) + STEP;
+    }
+
+    // Both neighbours present — interpolate.
+    const { rows: neighbourRows } = await client.query(
+        `SELECT id, position FROM ${table} WHERE id = ANY($1::int[]) FOR UPDATE`,
+        [[beforeId, afterId]]
+    );
+    const before = neighbourRows.find(r => r.id === beforeId);
+    const after = neighbourRows.find(r => r.id === afterId);
+    if (!before || !after || before.position == null || after.position == null) {
+        // Stale neighbour ids — fall back to renumbering, which is robust to
+        // missing rows (it just orders whatever is in scope).
+        return await renumberScope(client, table, scopeFilter, movingId, beforeId, afterId);
+    }
+    const lo = Math.min(before.position, after.position);
+    const hi = Math.max(before.position, after.position);
+    if (hi - lo <= 1) {
+        return await renumberScope(client, table, scopeFilter, movingId, beforeId, afterId);
+    }
+    return Math.floor((lo + hi) / 2);
+}
+
+module.exports = {
+    computeNewPosition,
+    renumberScope,
+    buildScopeWhere,
+    STEP,
+};

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -5,10 +5,13 @@ CREATE TABLE IF NOT EXISTS todos (
     completed BOOLEAN DEFAULT FALSE,
     due_date TIMESTAMP,
     tag TEXT,
+    position INTEGER, -- ordering for drag-to-reorder; NULL allowed so legacy inserts still work
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP DEFAULT NULL
 );
+
+CREATE INDEX IF NOT EXISTS todos_position_idx ON todos (position);
 
 -- Add updated_at and deleted_at columns if they don't exist (for existing databases)
 DO $$
@@ -55,17 +58,23 @@ END $$;
 CREATE TABLE IF NOT EXISTS note_folders (
     id SERIAL PRIMARY KEY,
     name TEXT NOT NULL,
+    position INTEGER, -- ordering for drag-to-reorder; NULL allowed so legacy inserts still work
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE INDEX IF NOT EXISTS note_folders_position_idx ON note_folders (position);
 
 CREATE TABLE IF NOT EXISTS notes (
     id SERIAL PRIMARY KEY,
     folder_id INTEGER REFERENCES note_folders(id) ON DELETE CASCADE,
     title TEXT,
     content TEXT,
+    position INTEGER, -- ordering within a folder (or unfiled scope when folder_id IS NULL)
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE INDEX IF NOT EXISTS notes_folder_position_idx ON notes (folder_id, position);
 
 -- Add folder_id and updated_at columns if they don't exist (for existing databases)
 DO $$
@@ -82,8 +91,11 @@ CREATE TABLE IF NOT EXISTS lists (
     id SERIAL PRIMARY KEY,
     title TEXT NOT NULL,
     items JSONB DEFAULT '[]',
+    position INTEGER, -- ordering for drag-to-reorder; NULL allowed so legacy inserts still work
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE INDEX IF NOT EXISTS lists_position_idx ON lists (position);
 
 -- List history/audit log table
 CREATE TABLE IF NOT EXISTS list_history (

--- a/server/tests/helpers.js
+++ b/server/tests/helpers.js
@@ -1,0 +1,137 @@
+/**
+ * Shared test helpers.
+ *
+ * Tests run against a dedicated DB (default: personal_dashboard_test).
+ * Set TEST_DATABASE_URL to override. Tables are truncated before each
+ * suite — never against the dev DB.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { Pool } = require('pg');
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+    || 'postgres://localhost:5432/personal_dashboard_test';
+
+// Set DATABASE_URL to the test URL BEFORE the server's db module is required
+// so the same connection pool serves the app and the test harness. Tests must
+// require this helpers module before any server code.
+process.env.DATABASE_URL = TEST_DATABASE_URL;
+process.env.NODE_ENV = 'test';
+// AI streaming tests stub streamText, but the real openaiClient still
+// constructs a model handle eagerly — supply any non-empty value.
+if (!process.env.OPENAI_API_KEY) process.env.OPENAI_API_KEY = 'test-key-not-used';
+
+const pool = new Pool({ connectionString: TEST_DATABASE_URL });
+
+const SCHEMA_PATH = path.join(__dirname, '..', 'schema.sql');
+const MIGRATION_PATH = path.join(__dirname, '..', 'migration.sql');
+
+async function applySchema() {
+    const sql = fs.readFileSync(SCHEMA_PATH, 'utf8');
+    await pool.query(sql);
+}
+
+async function applyMigration() {
+    const sql = fs.readFileSync(MIGRATION_PATH, 'utf8');
+    await pool.query(sql);
+}
+
+/**
+ * Reset every table the test suite touches. Order matters: notes -> folders
+ * because notes.folder_id references folders. ai_messages and draft_actions
+ * are also wiped since the streaming tests insert into them.
+ */
+async function resetDb() {
+    await pool.query(`
+        TRUNCATE TABLE
+            todo_history, note_history, list_history,
+            todos, notes, lists, note_folders,
+            draft_actions, ai_messages, dashboard_config
+        RESTART IDENTITY CASCADE
+    `);
+}
+
+async function close() {
+    await pool.end();
+}
+
+/**
+ * Insert N todos with sequential created_at values (1 second apart). Returns
+ * the inserted rows. Tests use this to seed predictable orderings.
+ */
+async function seedTodos(n, opts = {}) {
+    const rows = [];
+    for (let i = 0; i < n; i++) {
+        const created = new Date(Date.UTC(2026, 0, 1, 0, 0, i));
+        const { rows: r } = await pool.query(
+            `INSERT INTO todos (title, completed, created_at, updated_at, position)
+             VALUES ($1, false, $2, $2, $3) RETURNING *`,
+            [`todo ${i}`, created, opts.withPosition ? (i + 1) * 1000 : null]
+        );
+        rows.push(r[0]);
+    }
+    return rows;
+}
+
+async function seedNotes(specs) {
+    // specs: [{ title, folderId|null, createdAt? }]
+    const rows = [];
+    for (let i = 0; i < specs.length; i++) {
+        const s = specs[i];
+        const created = s.createdAt || new Date(Date.UTC(2026, 0, 1, 0, 0, i));
+        const { rows: r } = await pool.query(
+            `INSERT INTO notes (title, content, folder_id, created_at, updated_at)
+             VALUES ($1, '', $2, $3, $3) RETURNING *`,
+            [s.title, s.folderId ?? null, created]
+        );
+        rows.push(r[0]);
+    }
+    return rows;
+}
+
+async function seedFolders(names) {
+    const rows = [];
+    for (let i = 0; i < names.length; i++) {
+        const created = new Date(Date.UTC(2026, 0, 1, 0, 0, i));
+        const { rows: r } = await pool.query(
+            'INSERT INTO note_folders (name, created_at) VALUES ($1, $2) RETURNING *',
+            [names[i], created]
+        );
+        rows.push(r[0]);
+    }
+    return rows;
+}
+
+async function seedLists(titles) {
+    const rows = [];
+    for (let i = 0; i < titles.length; i++) {
+        const created = new Date(Date.UTC(2026, 0, 1, 0, 0, i));
+        const { rows: r } = await pool.query(
+            `INSERT INTO lists (title, items, created_at) VALUES ($1, '[]', $2) RETURNING *`,
+            [titles[i], created]
+        );
+        rows.push(r[0]);
+    }
+    return rows;
+}
+
+async function getOrderedPositions(table, scopeWhere = '', scopeParams = []) {
+    const sql = `SELECT id, position FROM ${table} ${scopeWhere ? 'WHERE ' + scopeWhere : ''} ORDER BY position ASC NULLS LAST, id ASC`;
+    const { rows } = await pool.query(sql, scopeParams);
+    return rows;
+}
+
+module.exports = {
+    pool,
+    applySchema,
+    applyMigration,
+    resetDb,
+    seedTodos,
+    seedNotes,
+    seedFolders,
+    seedLists,
+    getOrderedPositions,
+    close,
+    TEST_DATABASE_URL,
+};

--- a/server/tests/migration.test.js
+++ b/server/tests/migration.test.js
@@ -1,0 +1,181 @@
+/**
+ * Migration backfill tests.
+ *
+ * Drops the test DB to a clean state, applies schema (without position
+ * columns) by raw DDL, seeds rows with NULL positions, runs migration.sql,
+ * and asserts:
+ *   - every row has a position
+ *   - positions are gap-1000 sequential per scope (global for todos/lists/folders,
+ *     per-folder for notes)
+ *   - re-running the migration is idempotent (no double-positioning)
+ */
+
+const { test, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const { pool, close } = require('./helpers');
+
+const MIGRATION_PATH = path.join(__dirname, '..', 'migration.sql');
+
+async function dropEverything() {
+    await pool.query(`
+        DROP TABLE IF EXISTS todo_history, note_history, list_history,
+            todos, notes, lists, note_folders,
+            draft_actions, ai_messages, dashboard_config CASCADE
+    `);
+}
+
+async function legacySchema() {
+    // Recreate the pre-migration shape WITHOUT position columns. We only
+    // need the columns the migration's backfill reads from.
+    await pool.query(`
+        CREATE TABLE todos (
+            id SERIAL PRIMARY KEY,
+            title TEXT NOT NULL,
+            description TEXT,
+            completed BOOLEAN DEFAULT FALSE,
+            due_date TIMESTAMPTZ,
+            tag TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            deleted_at TIMESTAMP
+        );
+        CREATE TABLE note_folders (
+            id SERIAL PRIMARY KEY,
+            name TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE notes (
+            id SERIAL PRIMARY KEY,
+            folder_id INTEGER REFERENCES note_folders(id) ON DELETE CASCADE,
+            title TEXT,
+            content TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE lists (
+            id SERIAL PRIMARY KEY,
+            title TEXT NOT NULL,
+            items JSONB DEFAULT '[]',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+    `);
+}
+
+async function applyMigration() {
+    const sql = fs.readFileSync(MIGRATION_PATH, 'utf8');
+    await pool.query(sql);
+}
+
+before(async () => {
+    await dropEverything();
+    await legacySchema();
+});
+
+after(async () => {
+    await close();
+});
+
+test('backfills positions for todos with gap-1000 sequential values', async () => {
+    // Seed 4 todos with strictly increasing created_at; expect positions
+    // 1000, 2000, 3000, 4000 in created_at order.
+    for (let i = 0; i < 4; i++) {
+        const created = new Date(Date.UTC(2026, 0, 1, 0, 0, i));
+        await pool.query(
+            `INSERT INTO todos (title, created_at, updated_at) VALUES ($1, $2, $2)`,
+            [`todo ${i}`, created]
+        );
+    }
+    await applyMigration();
+    const { rows } = await pool.query('SELECT id, title, position FROM todos ORDER BY created_at ASC');
+    assert.strictEqual(rows.length, 4);
+    rows.forEach((r, i) => {
+        assert.strictEqual(r.position, (i + 1) * 1000, `row ${r.id} should be position ${(i + 1) * 1000}`);
+    });
+});
+
+test('backfills lists with gap-1000 globally', async () => {
+    for (let i = 0; i < 3; i++) {
+        const created = new Date(Date.UTC(2026, 1, 1, 0, 0, i));
+        await pool.query(
+            `INSERT INTO lists (title, created_at) VALUES ($1, $2)`,
+            [`list ${i}`, created]
+        );
+    }
+    await applyMigration();
+    const { rows } = await pool.query('SELECT position FROM lists ORDER BY created_at ASC');
+    assert.deepStrictEqual(rows.map(r => r.position), [1000, 2000, 3000]);
+});
+
+test('backfills note_folders globally with gap-1000', async () => {
+    for (let i = 0; i < 3; i++) {
+        const created = new Date(Date.UTC(2026, 2, 1, 0, 0, i));
+        await pool.query(
+            `INSERT INTO note_folders (name, created_at) VALUES ($1, $2)`,
+            [`folder ${i}`, created]
+        );
+    }
+    await applyMigration();
+    const { rows } = await pool.query('SELECT position FROM note_folders ORDER BY created_at ASC');
+    assert.deepStrictEqual(rows.map(r => r.position), [1000, 2000, 3000]);
+});
+
+test('backfills notes per-folder (NULL folder is its own scope)', async () => {
+    // First flush prior data so partitioning is clean. Notes already have
+    // positions from earlier tests' migration runs; null them out so the
+    // backfill has work to do.
+    await pool.query('TRUNCATE notes RESTART IDENTITY');
+
+    const { rows: folders } = await pool.query('SELECT id FROM note_folders ORDER BY id LIMIT 2');
+    const [f1, f2] = folders;
+
+    // 2 notes in folder1, 3 notes in folder2, 2 unfiled. Each scope should
+    // start at 1000 and step 1000.
+    let t = 0;
+    const insert = async (folderId) => {
+        const created = new Date(Date.UTC(2026, 3, 1, 0, 0, t++));
+        await pool.query(
+            `INSERT INTO notes (title, folder_id, created_at, updated_at) VALUES ($1, $2, $3, $3)`,
+            [`n${t}`, folderId, created]
+        );
+    };
+    await insert(f1.id); await insert(f1.id);
+    await insert(f2.id); await insert(f2.id); await insert(f2.id);
+    await insert(null);  await insert(null);
+
+    await applyMigration();
+
+    const { rows: r1 } = await pool.query('SELECT position FROM notes WHERE folder_id = $1 ORDER BY created_at', [f1.id]);
+    const { rows: r2 } = await pool.query('SELECT position FROM notes WHERE folder_id = $1 ORDER BY created_at', [f2.id]);
+    const { rows: r0 } = await pool.query('SELECT position FROM notes WHERE folder_id IS NULL ORDER BY created_at');
+
+    assert.deepStrictEqual(r1.map(r => r.position), [1000, 2000]);
+    assert.deepStrictEqual(r2.map(r => r.position), [1000, 2000, 3000]);
+    assert.deepStrictEqual(r0.map(r => r.position), [1000, 2000]);
+});
+
+test('migration is idempotent - re-running does NOT double-position rows', async () => {
+    // Snapshot positions, re-apply the migration, assert nothing changed.
+    const { rows: before } = await pool.query('SELECT id, position FROM todos ORDER BY id');
+
+    await applyMigration();
+    await applyMigration();
+
+    const { rows: after } = await pool.query('SELECT id, position FROM todos ORDER BY id');
+    assert.deepStrictEqual(after, before, 'positions must be stable across reruns');
+});
+
+test('inserting a new row with NULL position then re-migrating fills only that row', async () => {
+    await pool.query(
+        `INSERT INTO todos (title, created_at, updated_at) VALUES ('fresh', NOW(), NOW())`
+    );
+    const { rows: before } = await pool.query('SELECT position FROM todos WHERE title = $1', ['fresh']);
+    assert.strictEqual(before[0].position, null);
+
+    await applyMigration();
+
+    const { rows: after } = await pool.query('SELECT position FROM todos WHERE title = $1', ['fresh']);
+    assert.notStrictEqual(after[0].position, null, 'new NULL row should get a position on re-run');
+});

--- a/server/tests/preferences.test.js
+++ b/server/tests/preferences.test.js
@@ -1,0 +1,161 @@
+/**
+ * Preferences tests.
+ *
+ *  - deepMerge unit tests
+ *  - hydrateLayoutPreference unit tests
+ *  - GET /api/dashboard/config returns full defaults when stored is empty
+ *  - PATCH /api/dashboard/config/preferences deep-merges partial updates
+ *  - PATCH preserves widgets array
+ *  - PATCH validates types via Zod (rejects bad enum)
+ */
+
+const { test, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+
+const helpers = require('./helpers');
+const { pool, resetDb, applySchema, applyMigration, close } = helpers;
+
+const { app } = require('..');
+const { deepMerge, hydrateLayoutPreference, DEFAULT_PREFERENCES } = require('../preferences');
+
+let server;
+let baseUrl;
+
+before(async () => {
+    await applySchema();
+    await applyMigration();
+    server = http.createServer(app);
+    await new Promise(resolve => server.listen(0, resolve));
+    baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(async () => {
+    await new Promise(resolve => server.close(resolve));
+    await close();
+});
+
+beforeEach(async () => {
+    await resetDb();
+    // Re-seed the dashboard_config row that schema.sql normally inserts; the
+    // truncate above wipes it.
+    await pool.query(`INSERT INTO dashboard_config (id, layout_preference) VALUES (1, '{"widgets": ["todos","notes","lists"]}')`);
+});
+
+async function api(method, path, body) {
+    const res = await fetch(`${baseUrl}${path}`, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: body == null ? undefined : JSON.stringify(body),
+    });
+    let data = null;
+    const text = await res.text();
+    if (text) { try { data = JSON.parse(text); } catch (_) { data = text; } }
+    return { status: res.status, body: data };
+}
+
+// --- deepMerge ---------------------------------------------------------------
+
+test('deepMerge merges plain objects key-wise', () => {
+    const out = deepMerge({ a: 1, b: { x: 1, y: 2 } }, { b: { y: 99, z: 3 }, c: 4 });
+    assert.deepStrictEqual(out, { a: 1, b: { x: 1, y: 99, z: 3 }, c: 4 });
+});
+
+test('deepMerge replaces arrays wholesale (does NOT concat)', () => {
+    const out = deepMerge({ tags: ['a', 'b'] }, { tags: ['c'] });
+    assert.deepStrictEqual(out.tags, ['c']);
+});
+
+test('deepMerge does not mutate the inputs', () => {
+    const base = { a: { b: 1 } };
+    const patch = { a: { c: 2 } };
+    deepMerge(base, patch);
+    assert.deepStrictEqual(base, { a: { b: 1 } });
+    assert.deepStrictEqual(patch, { a: { c: 2 } });
+});
+
+// --- hydrateLayoutPreference -------------------------------------------------
+
+test('hydrateLayoutPreference fills full preferences when stored is empty', () => {
+    const out = hydrateLayoutPreference(null);
+    assert.deepStrictEqual(out.preferences, DEFAULT_PREFERENCES);
+    assert.deepStrictEqual(out.widgets, ['todos', 'notes', 'lists']);
+});
+
+test('hydrateLayoutPreference preserves stored widgets', () => {
+    const out = hydrateLayoutPreference({ widgets: ['notes'], preferences: { theme: 'dark' } });
+    assert.deepStrictEqual(out.widgets, ['notes']);
+    assert.strictEqual(out.preferences.theme, 'dark');
+    // Defaults still fill in for unset keys.
+    assert.strictEqual(out.preferences.density, 'comfortable');
+});
+
+// --- HTTP ---------------------------------------------------------------------
+
+test('GET /api/dashboard/config returns full defaults', async () => {
+    const { status, body } = await api('GET', '/api/dashboard/config');
+    assert.strictEqual(status, 200);
+    assert.deepStrictEqual(body.layout_preference.widgets, ['todos', 'notes', 'lists']);
+    assert.strictEqual(body.layout_preference.preferences.theme, 'system');
+    assert.strictEqual(body.layout_preference.preferences.default_view, 'today');
+    assert.strictEqual(body.layout_preference.preferences.ai.stream, true);
+});
+
+test('PATCH /api/dashboard/config/preferences deep-merges partial update', async () => {
+    const { status, body } = await api('PATCH', '/api/dashboard/config/preferences', {
+        theme: 'dark',
+        ai: { model: 'gpt-4o-mini' },
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.layout_preference.preferences.theme, 'dark');
+    // ai.stream default preserved by deep-merge:
+    assert.strictEqual(body.layout_preference.preferences.ai.stream, true);
+    assert.strictEqual(body.layout_preference.preferences.ai.model, 'gpt-4o-mini');
+});
+
+test('PATCH /api/dashboard/config/preferences does NOT clobber widgets', async () => {
+    // Set a custom widgets array first.
+    await pool.query(
+        `UPDATE dashboard_config SET layout_preference = $1 WHERE id = 1`,
+        [JSON.stringify({ widgets: ['notes', 'todos'], preferences: { theme: 'light' } })]
+    );
+
+    const { body } = await api('PATCH', '/api/dashboard/config/preferences', { density: 'compact' });
+    assert.deepStrictEqual(body.layout_preference.widgets, ['notes', 'todos']);
+    assert.strictEqual(body.layout_preference.preferences.theme, 'light');
+    assert.strictEqual(body.layout_preference.preferences.density, 'compact');
+});
+
+test('PATCH /api/dashboard/config/preferences rejects invalid enum', async () => {
+    const { status, body } = await api('PATCH', '/api/dashboard/config/preferences', {
+        theme: 'neon-pink',
+    });
+    assert.strictEqual(status, 400);
+    assert.ok(body.error);
+});
+
+test('PATCH /api/dashboard/config/preferences rejects unknown keys (strict schema)', async () => {
+    const { status } = await api('PATCH', '/api/dashboard/config/preferences', {
+        not_a_key: true,
+    });
+    assert.strictEqual(status, 400);
+});
+
+test('PATCH then GET round-trips merged preferences', async () => {
+    await api('PATCH', '/api/dashboard/config/preferences', {
+        theme: 'dark',
+        density: 'compact',
+        dashboard_widget_order: ['notes', 'todos', 'lists'],
+    });
+    const { body } = await api('GET', '/api/dashboard/config');
+    assert.strictEqual(body.layout_preference.preferences.theme, 'dark');
+    assert.strictEqual(body.layout_preference.preferences.density, 'compact');
+    assert.deepStrictEqual(body.layout_preference.preferences.dashboard_widget_order, ['notes', 'todos', 'lists']);
+});
+
+test('GET /api/config (legacy alias) returns the same hydrated shape', async () => {
+    const { status, body } = await api('GET', '/api/config');
+    assert.strictEqual(status, 200);
+    assert.ok(body.layout_preference.preferences);
+    assert.strictEqual(body.layout_preference.preferences.theme, 'system');
+});

--- a/server/tests/reorder.test.js
+++ b/server/tests/reorder.test.js
@@ -1,0 +1,285 @@
+/**
+ * Reorder helper + endpoint tests.
+ *
+ * Covers:
+ *  - reorder mid-list (interpolation between two neighbours)
+ *  - reorder to top (afterId only)
+ *  - reorder to bottom (beforeId only or both null)
+ *  - reorder when neighbours are adjacent (forces renumber)
+ *  - reorder a note across folders (notes endpoint specific)
+ *  - HTTP layer: 404 on unknown id, 400 on bad body, history row written
+ */
+
+const { test, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+
+const helpers = require('./helpers');
+const { pool, resetDb, applySchema, applyMigration, seedTodos, seedNotes, seedFolders, seedLists, close } = helpers;
+
+// Require the app AFTER helpers (which set DATABASE_URL).
+const { app } = require('..');
+const { computeNewPosition } = require('../reorderHelpers');
+
+let server;
+let baseUrl;
+
+before(async () => {
+    // Reset to a known schema. applySchema is idempotent (CREATE TABLE IF NOT EXISTS).
+    await applySchema();
+    await applyMigration();
+
+    server = http.createServer(app);
+    await new Promise(resolve => server.listen(0, resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+    await new Promise(resolve => server.close(resolve));
+    await close();
+});
+
+beforeEach(async () => {
+    await resetDb();
+});
+
+/**
+ * Tiny http client. node:fetch is fine; using it keeps tests dep-free.
+ */
+async function api(method, path, body) {
+    const res = await fetch(`${baseUrl}${path}`, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: body == null ? undefined : JSON.stringify(body),
+    });
+    let data = null;
+    const text = await res.text();
+    if (text) { try { data = JSON.parse(text); } catch (_) { data = text; } }
+    return { status: res.status, body: data };
+}
+
+// --- computeNewPosition (helper-level) ---------------------------------------
+
+test('computeNewPosition: interpolates between two neighbours', async () => {
+    const todos = await seedTodos(4, { withPosition: true });
+    // Move the 4th todo (position 4000) between the 1st (1000) and 2nd (2000).
+    const client = await pool.connect();
+    try {
+        await client.query('BEGIN');
+        const newPos = await computeNewPosition(
+            client, 'todos', { deleted_at: null },
+            todos[3].id, todos[0].id, todos[1].id
+        );
+        await client.query('COMMIT');
+        assert.strictEqual(newPos, 1500, 'midpoint of 1000 and 2000');
+    } finally {
+        client.release();
+    }
+});
+
+test('computeNewPosition: places at top when beforeId is null', async () => {
+    const todos = await seedTodos(3, { withPosition: true });
+    const client = await pool.connect();
+    try {
+        await client.query('BEGIN');
+        const newPos = await computeNewPosition(
+            client, 'todos', { deleted_at: null },
+            todos[2].id, null, todos[0].id
+        );
+        await client.query('COMMIT');
+        assert.strictEqual(newPos, 500, 'half of the smallest existing position');
+    } finally {
+        client.release();
+    }
+});
+
+test('computeNewPosition: places at bottom when afterId is null', async () => {
+    const todos = await seedTodos(3, { withPosition: true });
+    const client = await pool.connect();
+    try {
+        await client.query('BEGIN');
+        const newPos = await computeNewPosition(
+            client, 'todos', { deleted_at: null },
+            todos[0].id, todos[2].id, null
+        );
+        await client.query('COMMIT');
+        assert.strictEqual(newPos, 4000, 'max existing (3000) + 1000');
+    } finally {
+        client.release();
+    }
+});
+
+test('computeNewPosition: renumbers when neighbours are adjacent', async () => {
+    // Seed 3 todos at positions 100, 101, 200. Moving the 3rd between 1st and 2nd
+    // forces renumber because the gap between 100 and 101 is 1.
+    const created1 = new Date(Date.UTC(2026, 0, 1, 0, 0, 0));
+    const created2 = new Date(Date.UTC(2026, 0, 1, 0, 0, 1));
+    const created3 = new Date(Date.UTC(2026, 0, 1, 0, 0, 2));
+    const ins = (title, created, pos) => pool.query(
+        `INSERT INTO todos (title, created_at, updated_at, position) VALUES ($1, $2, $2, $3) RETURNING *`,
+        [title, created, pos]
+    );
+    const a = (await ins('a', created1, 100)).rows[0];
+    const b = (await ins('b', created2, 101)).rows[0];
+    const c = (await ins('c', created3, 200)).rows[0];
+
+    const client = await pool.connect();
+    try {
+        await client.query('BEGIN');
+        const newPos = await computeNewPosition(
+            client, 'todos', { deleted_at: null },
+            c.id, a.id, b.id
+        );
+        await client.query('COMMIT');
+
+        const { rows } = await pool.query('SELECT id, position FROM todos ORDER BY position ASC');
+        // Renumbering should produce 1000, 2000, 3000 with c sandwiched between a and b.
+        assert.deepStrictEqual(rows.map(r => r.position), [1000, 2000, 3000]);
+        // c lands at the slot between a and b => position 2000 in the renumbered scope.
+        const cAfter = rows.find(r => r.id === c.id);
+        assert.strictEqual(cAfter.position, newPos);
+        assert.strictEqual(cAfter.position, 2000);
+    } finally {
+        client.release();
+    }
+});
+
+// --- HTTP endpoints ----------------------------------------------------------
+
+test('PATCH /api/todos/:id/reorder moves to bottom and writes history', async () => {
+    const todos = await seedTodos(3, { withPosition: true });
+    const targetId = todos[0].id; // currently first
+
+    const { status, body } = await api('PATCH', `/api/todos/${targetId}/reorder`, {
+        before_id: todos[2].id,
+        after_id: null,
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.id, targetId);
+    assert.strictEqual(body.position, 4000);
+
+    const { rows: history } = await pool.query(
+        `SELECT action, field_changed, new_value FROM todo_history WHERE todo_id = $1`,
+        [targetId]
+    );
+    assert.strictEqual(history.length, 1);
+    assert.strictEqual(history[0].action, 'reorder');
+    assert.strictEqual(history[0].field_changed, 'position');
+    assert.strictEqual(history[0].new_value, '4000');
+});
+
+test('PATCH /api/lists/:id/reorder interpolates between two neighbours', async () => {
+    const lists = await seedLists(['a', 'b', 'c']);
+    // Apply backfill first to give them positions 1000, 2000, 3000.
+    await applyMigration();
+    const refreshed = (await pool.query('SELECT * FROM lists ORDER BY position')).rows;
+
+    // Move list c (position 3000) between a (1000) and b (2000).
+    const { status, body } = await api('PATCH', `/api/lists/${refreshed[2].id}/reorder`, {
+        before_id: refreshed[0].id,
+        after_id: refreshed[1].id,
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.position, 1500);
+});
+
+test('PATCH /api/note_folders/:id/reorder', async () => {
+    const folders = await seedFolders(['x', 'y', 'z']);
+    await applyMigration();
+    const fresh = (await pool.query('SELECT * FROM note_folders ORDER BY position')).rows;
+
+    const { status, body } = await api('PATCH', `/api/note_folders/${fresh[2].id}/reorder`, {
+        before_id: null,
+        after_id: fresh[0].id,
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.position, 500);
+});
+
+test('PATCH /api/notes/:id/reorder within same folder', async () => {
+    const [f1] = await seedFolders(['F1']);
+    const notes = await seedNotes([
+        { title: 'n1', folderId: f1.id },
+        { title: 'n2', folderId: f1.id },
+        { title: 'n3', folderId: f1.id },
+    ]);
+    await applyMigration();
+    const fresh = (await pool.query('SELECT * FROM notes ORDER BY position')).rows;
+
+    // Move n3 to the very top.
+    const { status, body } = await api('PATCH', `/api/notes/${fresh[2].id}/reorder`, {
+        before_id: null,
+        after_id: fresh[0].id,
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.position, 500);
+    assert.strictEqual(body.folder_id, f1.id);
+});
+
+test('PATCH /api/notes/:id/reorder across folders writes both moved + reorder history', async () => {
+    const [f1, f2] = await seedFolders(['F1', 'F2']);
+    const notes = await seedNotes([
+        { title: 'a', folderId: f1.id },
+        { title: 'b', folderId: f1.id },
+        { title: 'c', folderId: f2.id },
+    ]);
+    await applyMigration();
+
+    // Move note 'a' to folder f2 at the top.
+    const noteA = notes[0];
+    const cInF2 = (await pool.query('SELECT id FROM notes WHERE folder_id = $1 ORDER BY position', [f2.id])).rows[0];
+
+    const { status, body } = await api('PATCH', `/api/notes/${noteA.id}/reorder`, {
+        before_id: null,
+        after_id: cInF2.id,
+        folder_id: f2.id,
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.folder_id, f2.id);
+    assert.ok(body.position < 1000, 'should land above the existing F2 note');
+
+    const { rows: history } = await pool.query(
+        `SELECT action, field_changed, old_value, new_value FROM note_history
+         WHERE note_id = $1 ORDER BY id`,
+        [noteA.id]
+    );
+    const actions = history.map(h => h.action);
+    assert.ok(actions.includes('moved'), 'cross-folder move should log a moved entry');
+    assert.ok(actions.includes('reorder'), 'reorder should also be logged');
+});
+
+test('PATCH /api/notes/:id/reorder to unfiled (folder_id: null)', async () => {
+    const [f1] = await seedFolders(['F1']);
+    const notes = await seedNotes([
+        { title: 'a', folderId: f1.id },
+        { title: 'unfiled1', folderId: null },
+    ]);
+    await applyMigration();
+
+    const noteA = notes[0];
+    const { status, body } = await api('PATCH', `/api/notes/${noteA.id}/reorder`, {
+        before_id: null,
+        after_id: null,
+        folder_id: null,
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.folder_id, null);
+});
+
+test('PATCH /api/todos/:id/reorder rejects bad body', async () => {
+    const todos = await seedTodos(2, { withPosition: true });
+    const { status } = await api('PATCH', `/api/todos/${todos[0].id}/reorder`, {
+        before_id: 'not-a-number',
+    });
+    assert.strictEqual(status, 400);
+});
+
+test('PATCH /api/todos/:id/reorder on missing id falls through (no row updated)', async () => {
+    // computeNewPosition still produces a value, but the UPDATE matches no
+    // rows so the route returns 404 via the rows[0] guard.
+    const { status } = await api('PATCH', `/api/todos/999999/reorder`, {
+        before_id: null, after_id: null,
+    });
+    assert.strictEqual(status, 404);
+});


### PR DESCRIPTION
## Summary

Brings the v2-backend deliverables (`docs/design/refactor-v2.md` §7, §12) forward onto the post-v2-frontend `main`. Unblocks two features whose frontends already shipped:

- iOS list reorder (`ListsView.swift` calls `viewModel.reorderItems(...)`) had no server endpoint to persist to.
- Web `PreferencesContext.jsx` had a `// TODO: wire when backend lands /api/dashboard/config/preferences` waiting on this.

## What's in

- **Schema migration**: nullable `position INTEGER` on todos, notes, lists, note_folders. Backfilled with gap-1000 sequential values per scope (notes partition by `folder_id`; everything else global). Idempotent.
- **Reorder endpoints**: `PATCH /api/{todos,notes,lists,note_folders}/:id/reorder` share a `computeNewPosition` helper. Midpoint between neighbours, renumber when gap collapses to <= 1, `SELECT ... FOR UPDATE` inside transactions for serializable concurrent reorders.
- **Preferences API**: `GET /api/dashboard/config` (and legacy `/api/config`) hydrate full preferences with defaults; `PATCH /api/dashboard/config/preferences` validates with Zod and deep-merges so `widgets` is preserved on partial updates.
- **Tests**: helpers + migration + reorder + preferences specs run under `node --test`.

## What was deliberately dropped

The original v2-backend commit also rewrote `/api/ai/parse/stream` to use `streamText` with a `{type:"delta"/"draft"/"done"}` wire format. Main already has a typewriter SSE implementation (`event: text` / `data: {chunk}`) that both the iOS and web clients consume; the v2 wire format would have required coordinated client rewrites and is not needed today. `chatStream.js` and `stream.test.js` removed accordingly. The work is preserved in the original commit (`0b03cba` pre-rebase) if anyone wants to revive it later.

## Test plan

- [ ] `cd server && createdb personal_dashboard_test && npm test` (runs migration + reorder + preferences specs)
- [ ] iOS list reorder persists across relaunch (drag, kill app, reopen — order kept)
- [ ] Web: changing a preference (theme, density) survives a page refresh
- [ ] Existing chat / drafts flow still works (regression check on the typewriter SSE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)