### PR TITLE
feat(mobile): switch iOS OTA install transport to Tailscale Serve

### DIFF
--- a/mobile/PersonalDashboard/App/AppConfig.swift
+++ b/mobile/PersonalDashboard/App/AppConfig.swift
@@ -5,17 +5,29 @@ import Foundation
 /// Resolution order:
 ///   1. The `API_URL` environment variable (set in the Xcode scheme's
 ///      Run > Arguments > Environment Variables for local development,
-///      or injected at archive time for OTA builds).
-///   2. The default below: `http://localhost:3000/api`. This works for the
-///      iOS simulator running on the same Mac as the dev server; physical
-///      devices cannot reach Mac localhost and need either the env var
-///      override or a public tunnel URL substituted here.
+///      or injected at archive time for OTA builds via xcodebuild).
+///   2. The `OTA_API_URL` Info.plist key, injected by `mobile/ota/ship.sh`
+///      at archive time via `xcodebuild OTA_API_URL=https://<host>/api`.
+///      This makes OTA-installed builds reach the Mac over Tailscale
+///      automatically, without any manual configuration on the device.
+///   3. The default `http://localhost:3000/api`. This works for the iOS
+///      simulator on the same Mac as the dev server; physical devices on a
+///      different host need option 1 or 2.
 enum AppConfig {
     static let apiBaseURL: URL = {
+        // 1. Runtime env var override (Xcode scheme or xcodebuild injection).
         if let override = ProcessInfo.processInfo.environment["API_URL"],
            let url = URL(string: override) {
             return url
         }
+        // 2. Build-time OTA URL embedded in Info.plist by ship.sh.
+        if let otaURL = Bundle.main.object(forInfoDictionaryKey: "OTA_API_URL") as? String,
+           !otaURL.isEmpty,
+           !otaURL.hasPrefix("$("),   // guard against unexpanded xcconfig variables
+           let url = URL(string: otaURL) {
+            return url
+        }
+        // 3. Local simulator default.
         return URL(string: "http://localhost:3000/api")!
     }()
 }

--- a/mobile/PersonalDashboard/Info.plist
+++ b/mobile/PersonalDashboard/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>OTA_API_URL</key>
+	<string>$(OTA_API_URL)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Calistoga-Regular.ttf</string>

--- a/mobile/ota/README.md
+++ b/mobile/ota/README.md
@@ -1,0 +1,78 @@
+# OTA Install — Tailscale transport
+
+`ship.sh` archives the app, serves the `.ipa` and `manifest.plist` over HTTPS,
+and prints an `itms-services://` URL you open in Safari on your iPhone.
+
+The default transport is **Tailscale Serve**, which uses the stable MagicDNS
+hostname your Mac already has. The iPhone reaches the Mac over Tailscale — works
+on any network, no same-LAN requirement.
+
+---
+
+## One-time setup
+
+Do these steps once. They take about five minutes.
+
+1. **Install Tailscale on Mac**: `brew install --cask tailscale`. Start it and log
+   in with your Tailscale account.
+
+2. **Install Tailscale on iPhone**: download from the App Store, log in with the
+   same account.
+
+3. **Enable MagicDNS**: in the Tailscale admin console
+   (`login.tailscale.com/admin/dns`), turn on MagicDNS. This gives your Mac a
+   stable hostname like `my-mac.tail1234.ts.net`.
+
+4. **Enable HTTPS Certificates**: on the same DNS settings page, turn on HTTPS
+   Certificates. This lets Tailscale issue a browser-trusted TLS cert for your
+   hostname so iOS accepts it without any trust prompt. `tailscale serve`
+   provisions and renews the cert automatically the first time it runs.
+
+5. **Enable Tailscale Serve**: this is a separate per-tailnet toggle from HTTPS
+   Certificates. The first time you run `ship.sh` the script will print a
+   one-click admin URL like `https://login.tailscale.com/f/serve?node=...` if
+   Serve is disabled. Open it, click enable, and re-run the script.
+
+No auth keys or tokens are needed. `tailscale serve` uses the daemon that is
+already authenticated, and the cert is fetched automatically.
+
+---
+
+## Daily use
+
+```bash
+bash mobile/ota/ship.sh
+```
+
+The script prints an install URL and copies it to your clipboard. Open it in
+Safari on your iPhone (Tailscale must be active on the phone) and tap **Install**.
+
+The archived build is pre-configured to call the API at
+`https://<your-mac-hostname>.ts.net/api` — no manual URL setup on the device.
+
+After the download starts on your phone, press Ctrl-C in the terminal to stop
+Tailscale Serve and the local HTTP server.
+
+The free personal-team provisioning profile expires every 7 days. Re-run
+`ship.sh` to install a fresh build.
+
+---
+
+## Troubleshooting / fallback
+
+**Tailscale is unavailable on this network**: fall back to a Cloudflare quick
+tunnel. The URL changes every run, so you will need to set `API_URL` manually
+on the device (or via scheme env var before archiving).
+
+```bash
+OTA_TRANSPORT=cloudflare bash mobile/ota/ship.sh
+```
+
+**`tailscale serve` fails with a TLS or cert error**: enable HTTPS Certificates
+in the Tailscale admin console (DNS settings) and re-run `ship.sh`.
+
+**`tailscale status` is empty**: make sure `tailscaled` is running
+(`open -a Tailscale`).
+
+**Install URL does not load on iPhone**: confirm Tailscale is enabled on the
+iPhone (the VPN icon in the status bar).

--- a/mobile/ota/ship.sh
+++ b/mobile/ota/ship.sh
@@ -1,27 +1,34 @@
 #!/usr/bin/env bash
 # Ship a development-signed build of personal-dashboard to your iPhone over the
-# internet via a Cloudflare quick tunnel + itms-services OTA install.
+# internet via Tailscale Serve + itms-services OTA install.
 #
 # No App Store Connect, no paid Apple Developer Program required. Works with the
 # free "personal team" provisioning profile — but it expires every 7 days, so
 # you'll re-run this weekly.
 #
 # Usage:
-#   bash mobile/ota/ship.sh
+#   bash mobile/ota/ship.sh                          # default: Tailscale transport
+#   OTA_TRANSPORT=cloudflare bash mobile/ota/ship.sh  # use Cloudflare quick tunnel
 #
 # What this does:
 #   1. Regenerates the Xcode project (xcodegen).
 #   2. Archives + exports a development-signed .ipa to /tmp/ota/.
 #   3. Generates manifest.plist + index.html for OTA install.
 #   4. Starts a local HTTP server on :8081.
-#   5. Starts a Cloudflare quick tunnel; captures the public HTTPS URL.
+#   5. Tailscale path: runs `tailscale serve` to expose the server over HTTPS;
+#      uses the stable MagicDNS hostname. Cloudflare path: starts a quick tunnel.
 #   6. Writes the public URL into manifest.plist + index.html.
 #   7. Prints (and copies to clipboard) the install URL.
 #
 # Open the install URL on your iPhone in Safari and tap "Install".
 # Ctrl-C in this terminal cleans up the tunnel and HTTP server.
+#
+# See mobile/ota/README.md for one-time Tailscale setup instructions.
 
 set -euo pipefail
+
+# ---- Transport ----
+TRANSPORT="${OTA_TRANSPORT:-tailscale}"
 
 # ---- Paths ----
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -34,14 +41,28 @@ OTA_DIR="/tmp/ota"
 PORT=8081
 
 # ---- Pre-flight ----
-command -v xcodegen >/dev/null  || { echo "❌ xcodegen not found (brew install xcodegen)"; exit 1; }
-command -v cloudflared >/dev/null || { echo "❌ cloudflared not found (brew install cloudflared)"; exit 1; }
-command -v xcodebuild >/dev/null || { echo "❌ xcodebuild not found"; exit 1; }
-command -v python3 >/dev/null    || { echo "❌ python3 not found"; exit 1; }
+command -v xcodegen  >/dev/null || { echo "xcodegen not found (brew install xcodegen)"; exit 1; }
+command -v xcodebuild >/dev/null || { echo "xcodebuild not found"; exit 1; }
+command -v python3   >/dev/null || { echo "python3 not found"; exit 1; }
+
+if [ "${TRANSPORT}" = "tailscale" ]; then
+  # If the resolved `tailscale` shim is broken (e.g. orphaned shim from an
+  # uninstalled Tailscale.app pointing into /Applications), prefer the brew CLI.
+  if ! tailscale version >/dev/null 2>&1; then
+    if [ -x /opt/homebrew/bin/tailscale ]; then
+      export PATH="/opt/homebrew/bin:${PATH}"
+    elif [ -x /usr/local/Cellar/tailscale/*/bin/tailscale ] 2>/dev/null; then
+      export PATH="/usr/local/bin:${PATH}"
+    fi
+  fi
+  tailscale version >/dev/null 2>&1 || { echo "tailscale not working (brew install tailscale) — or set OTA_TRANSPORT=cloudflare"; exit 1; }
+else
+  command -v cloudflared >/dev/null || { echo "cloudflared not found (brew install cloudflared)"; exit 1; }
+fi
 
 cd "${MOBILE_DIR}"
 
-echo "→ regenerating Xcode project"
+echo "-> regenerating Xcode project"
 xcodegen generate >/dev/null
 
 # ---- Clean OTA staging ----
@@ -52,11 +73,44 @@ mkdir -p "${OTA_DIR}"
 BUNDLE_VERSION="$(date +%s)"
 SHORT_VERSION="$(awk -F'"' '/CFBundleShortVersionString/{print $2; exit}' "${MOBILE_DIR}/project.yml" 2>/dev/null)"
 SHORT_VERSION="${SHORT_VERSION:-0.1.0}"
-echo "→ bundle ${SHORT_VERSION} (${BUNDLE_VERSION})"
+echo "-> bundle ${SHORT_VERSION} (${BUNDLE_VERSION})"
+
+# ---- Resolve transport URL before archiving ----
+# We need the URL at archive time so the IPA knows where to reach the API.
+if [ "${TRANSPORT}" = "tailscale" ]; then
+  echo "-> resolving Tailscale hostname"
+  TS_HOSTNAME="$(tailscale status --json 2>/dev/null \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["Self"]["DNSName"].rstrip("."))' 2>/dev/null || true)"
+  if [ -z "${TS_HOSTNAME}" ]; then
+    echo "Could not resolve Tailscale hostname. Is Tailscale running and logged in?"
+    echo "Run: tailscale status"
+    exit 1
+  fi
+  echo "-> Tailscale hostname: ${TS_HOSTNAME}"
+
+  # `tailscale serve --https` provisions and renews a Let's Encrypt cert via
+  # tailscaled automatically. The only prerequisite is that HTTPS Certificates
+  # is enabled for this tailnet (admin console -> DNS). If it is not, the serve
+  # command below will fail with a clear error message.
+
+  TUNNEL_URL="https://${TS_HOSTNAME}"
+  OTA_API_URL="https://${TS_HOSTNAME}/api"
+else
+  # Cloudflare path: URL is not known until the tunnel is up; leave blank for archive.
+  # The app will need an API_URL env var override or manual configuration.
+  OTA_API_URL=""
+fi
 
 # ---- Archive ----
 ARCHIVE_PATH="${OTA_DIR}/PersonalDashboard.xcarchive"
-echo "→ archiving (this takes ~1-2 minutes the first time)"
+echo "-> archiving (this takes ~1-2 minutes the first time)"
+
+# Build xcodebuild args array so OTA_API_URL is only appended when non-empty.
+XCODE_EXTRA_SETTINGS=()
+if [ -n "${OTA_API_URL}" ]; then
+  XCODE_EXTRA_SETTINGS+=("OTA_API_URL=${OTA_API_URL}")
+fi
+
 xcodebuild \
   -project "${PROJECT}" \
   -scheme "${SCHEME}" \
@@ -65,13 +119,14 @@ xcodebuild \
   -archivePath "${ARCHIVE_PATH}" \
   CURRENT_PROJECT_VERSION="${BUNDLE_VERSION}" \
   MARKETING_VERSION="${SHORT_VERSION}" \
+  "${XCODE_EXTRA_SETTINGS[@]+"${XCODE_EXTRA_SETTINGS[@]}"}" \
   archive \
   2>&1 | grep -E "(error:|warning:|\*\* )" || true
 
-[ -d "${ARCHIVE_PATH}" ] || { echo "❌ archive failed"; exit 1; }
+[ -d "${ARCHIVE_PATH}" ] || { echo "archive failed"; exit 1; }
 
 # ---- Export .ipa ----
-echo "→ exporting development .ipa"
+echo "-> exporting development .ipa"
 xcodebuild \
   -exportArchive \
   -archivePath "${ARCHIVE_PATH}" \
@@ -81,7 +136,7 @@ xcodebuild \
   2>&1 | grep -E "(error:|warning:|\*\* )" || true
 
 EXPORTED_IPA="$(find "${OTA_DIR}" -maxdepth 1 -name "*.ipa" | head -1)"
-[ -f "${EXPORTED_IPA}" ] || { echo "❌ export failed: no .ipa produced"; exit 1; }
+[ -f "${EXPORTED_IPA}" ] || { echo "export failed: no .ipa produced"; exit 1; }
 mv "${EXPORTED_IPA}" "${OTA_DIR}/app.ipa"
 
 # ---- Profile expiry (informational) ----
@@ -89,34 +144,59 @@ PROFILE_EXPIRY="$(security cms -D -i "${ARCHIVE_PATH}/Products/Applications/Pers
   | plutil -extract ExpirationDate raw - 2>/dev/null | cut -d'T' -f1 || echo "unknown")"
 
 # ---- Start HTTP server ----
-echo "→ starting HTTP server on :${PORT}"
+echo "-> starting HTTP server on :${PORT}"
 cd "${OTA_DIR}"
 python3 -m http.server "${PORT}" --bind 127.0.0.1 >"${OTA_DIR}/http.log" 2>&1 &
 HTTP_PID=$!
 
-# ---- Start cloudflared quick tunnel ----
-echo "→ starting cloudflared quick tunnel"
-cloudflared tunnel --url "http://127.0.0.1:${PORT}" >"${OTA_DIR}/cloudflared.log" 2>&1 &
-TUNNEL_PID=$!
+# ---- Start transport ----
+if [ "${TRANSPORT}" = "tailscale" ]; then
+  echo "-> starting Tailscale Serve (https=443 -> localhost:${PORT})"
+  if ! tailscale serve --bg "http://127.0.0.1:${PORT}" >/tmp/ts-serve.log 2>&1; then
+    echo "tailscale serve failed:"
+    cat /tmp/ts-serve.log
+    exit 1
+  fi
 
-cleanup() {
-  echo ""
-  echo "→ cleaning up (tunnel + http server)"
-  kill "${TUNNEL_PID}" 2>/dev/null || true
-  kill "${HTTP_PID}" 2>/dev/null || true
-  wait 2>/dev/null || true
-}
-trap cleanup EXIT INT TERM
+  cleanup() {
+    echo ""
+    echo "-> cleaning up (tailscale serve + http server)"
+    tailscale serve reset 2>/dev/null || true
+    kill "${HTTP_PID}" 2>/dev/null || true
+    wait 2>/dev/null || true
+  }
+  trap cleanup EXIT INT TERM
 
-# ---- Wait for tunnel URL ----
-TUNNEL_URL=""
-for i in {1..40}; do
-  TUNNEL_URL="$(grep -Eo 'https://[a-z0-9-]+\.trycloudflare\.com' "${OTA_DIR}/cloudflared.log" | head -1 || true)"
-  [ -n "${TUNNEL_URL}" ] && break
-  sleep 0.5
-done
-[ -n "${TUNNEL_URL}" ] || { echo "❌ tunnel did not come up in 20s — see ${OTA_DIR}/cloudflared.log"; exit 1; }
-echo "→ tunnel: ${TUNNEL_URL}"
+  # With Tailscale Serve the URL is already known (hostname resolved above).
+  # Give the serve a moment to register, then proceed immediately.
+  sleep 1
+  echo "-> tunnel: ${TUNNEL_URL}"
+
+else
+  # ---- Cloudflare path (unchanged) ----
+  echo "-> starting cloudflared quick tunnel"
+  cloudflared tunnel --url "http://127.0.0.1:${PORT}" >"${OTA_DIR}/cloudflared.log" 2>&1 &
+  TUNNEL_PID=$!
+
+  cleanup() {
+    echo ""
+    echo "-> cleaning up (tunnel + http server)"
+    kill "${TUNNEL_PID}" 2>/dev/null || true
+    kill "${HTTP_PID}" 2>/dev/null || true
+    wait 2>/dev/null || true
+  }
+  trap cleanup EXIT INT TERM
+
+  # ---- Wait for tunnel URL ----
+  TUNNEL_URL=""
+  for i in {1..40}; do
+    TUNNEL_URL="$(grep -Eo 'https://[a-z0-9-]+\.trycloudflare\.com' "${OTA_DIR}/cloudflared.log" | head -1 || true)"
+    [ -n "${TUNNEL_URL}" ] && break
+    sleep 0.5
+  done
+  [ -n "${TUNNEL_URL}" ] || { echo "tunnel did not come up in 20s — see ${OTA_DIR}/cloudflared.log"; exit 1; }
+  echo "-> tunnel: ${TUNNEL_URL}"
+fi
 
 # ---- Render manifest.plist + index.html ----
 IPA_URL="${TUNNEL_URL}/app.ipa"
@@ -136,21 +216,34 @@ INSTALL_URL="${TUNNEL_URL}/"
 ITMS_URL="itms-services://?action=download-manifest&url=${MANIFEST_URL}"
 
 echo ""
-echo "════════════════════════════════════════════════════════════════"
+echo "================================================================"
 echo "  Open this URL in Safari on your iPhone, then tap Install:"
 echo ""
 echo "  ${INSTALL_URL}"
 echo ""
 echo "  Profile expires: ${PROFILE_EXPIRY}  (re-run this script after that)"
-echo "════════════════════════════════════════════════════════════════"
+echo "================================================================"
 echo ""
 echo "  Tip: this URL has been copied to your clipboard."
 echo "  AirDrop or text it to yourself, or type it into Safari."
 echo ""
-echo "  Press Ctrl-C here once the install starts on your phone"
-echo "  (the IPA download streams from this Mac through the tunnel)."
+
+if [ "${TRANSPORT}" = "tailscale" ]; then
+  echo "  Tailscale must be active on your iPhone to reach this URL."
+  echo "  After install the app will call the API at: ${OTA_API_URL}"
+  echo "  Keep this terminal open while the IPA downloads on your phone."
+  echo "  Ctrl-C here when done to stop Tailscale Serve."
+else
+  echo "  Press Ctrl-C here once the install starts on your phone"
+  echo "  (the IPA download streams from this Mac through the tunnel)."
+fi
 
 printf "%s" "${INSTALL_URL}" | pbcopy 2>/dev/null || true
 
 # ---- Block until user kills it ----
-wait "${TUNNEL_PID}"
+if [ "${TRANSPORT}" = "tailscale" ]; then
+  # No background process to wait on; just block until Ctrl-C.
+  while true; do sleep 60; done
+else
+  wait "${TUNNEL_PID}"
+fi

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -34,6 +34,7 @@ targets:
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait
         ITSAppUsesNonExemptEncryption: false
+        OTA_API_URL: $(OTA_API_URL)
         UIAppFonts:
           - Calistoga-Regular.ttf
           - Inter-Regular.ttf


### PR DESCRIPTION
## Summary
- Switch iOS OTA install transport from Cloudflare quick tunnel to Tailscale Serve (default)
- Inject stable API URL into the IPA via `OTA_API_URL` Info.plist key, read at runtime in `AppConfig`
- Add `mobile/ota/README.md` documenting one-time tailnet setup (MagicDNS, HTTPS Certificates, Serve enable)
- Cloudflare path preserved as opt-in via `OTA_TRANSPORT=cloudflare`

Closes #6

## Test plan
- [x] `bash -n mobile/ota/ship.sh` passes
- [x] `xcodegen generate` succeeds; `OTA_API_URL` key appears in generated `Info.plist`
- [x] `bash mobile/ota/ship.sh` archives + exports + serves at `https://macbook-air.tail604d5b.ts.net/` with `tailscale serve` proxying `/` -> `:8081`
- [ ] OTA install on iPhone via Safari (manual; profile expires 2026-05-09)
- [ ] App reaches the Mac at `https://<host>/api` after install (requires API also exposed via Tailscale Serve - tracked separately)
- [ ] Install from a network the Mac is NOT on (cellular)
- [ ] `OTA_TRANSPORT=cloudflare bash mobile/ota/ship.sh` still works (regression fallback)

## Notes
- Tailscale 1.96 dropped the `--https=443 --set-path=/` flags; script now uses the simpler `tailscale serve --bg <target>` form
- Pre-flight gracefully recovers when `/usr/local/bin/tailscale` is an orphan shim from an uninstalled `Tailscale.app` (the Mac in question had this state)
- Follow-up needed: Tailscale Serve currently only proxies the OTA static files. After install, calls to `/api` go nowhere because port 3000 isn't exposed. Will be a separate ticket to either path-mount `/api` -> `:3000` or document a `tailscale serve set-config` workflow.
