### PR TITLE
feat(mobile): expose dev API at /api over Tailscale Serve

### DIFF
--- a/mobile/ota/README.md
+++ b/mobile/ota/README.md
@@ -58,6 +58,34 @@ The free personal-team provisioning profile expires every 7 days. Re-run
 
 ---
 
+## Daily dev loop (use the installed build with live backend)
+
+After the app is installed on your phone, you do not need to re-archive every
+time you change the backend. Run two terminals:
+
+```bash
+# Terminal 1: Express dev server with hot reload
+npm start
+```
+
+```bash
+# Terminal 2: Tailscale tunnel for the API only
+bash mobile/ota/dev-tunnel.sh
+```
+
+Your phone (with Tailscale on) now hits the dev server at
+`https://<your-mac-hostname>.ts.net/api` over Tailscale. Edit `server/`,
+nodemon restarts, the phone sees the change immediately. Works on any network.
+
+Press Ctrl-C in the tunnel terminal to tear down. Re-running `dev-tunnel.sh`
+is safe; it resets and re-applies the Serve config.
+
+If you run `ship.sh` while `npm start` is already up, `ship.sh` configures the
+`/api` route automatically alongside the OTA route, so the freshly installed
+app can talk to the backend right away.
+
+---
+
 ## Troubleshooting / fallback
 
 **Tailscale is unavailable on this network**: fall back to a Cloudflare quick

--- a/mobile/ota/dev-tunnel.sh
+++ b/mobile/ota/dev-tunnel.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Expose the local Express dev server (port 3000) at /api over Tailscale Serve.
+#
+# Use this after `bash mobile/ota/ship.sh` has installed the app on your phone.
+# While this script is running, the installed app can reach your live dev server
+# at https://<host>.ts.net/api from anywhere on the Tailnet.
+#
+# Usage:
+#   npm start &            # or in a separate terminal
+#   bash mobile/ota/dev-tunnel.sh
+#
+# Override the API port:
+#   API_PORT=4000 bash mobile/ota/dev-tunnel.sh
+#
+# Ctrl-C resets the /api Tailscale Serve config.
+
+set -euo pipefail
+
+# ---- PATH fallback for orphan Tailscale shim ----
+# An uninstalled Tailscale.app can leave behind a broken shim in /usr/local/bin
+# or wherever the PATH resolves `tailscale`. Detect and prefer the brew CLI.
+if ! tailscale version >/dev/null 2>&1; then
+  if [ -x /opt/homebrew/bin/tailscale ]; then
+    export PATH="/opt/homebrew/bin:${PATH}"
+  fi
+fi
+
+API_PORT="${API_PORT:-3000}"
+
+# ---- Pre-flight: tooling ----
+command -v tailscale >/dev/null 2>&1 || { echo "tailscale not found (brew install tailscale)"; exit 1; }
+tailscale version >/dev/null 2>&1 || { echo "tailscale not working — is tailscaled running?"; exit 1; }
+
+# ---- Pre-flight: dev server ----
+if ! lsof -nP -iTCP:"${API_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "(error) Nothing listening on :${API_PORT}. Run 'npm start' first (Express dev server expected on :${API_PORT})." >&2
+  exit 1
+fi
+
+# ---- Resolve Tailscale hostname ----
+TS_HOSTNAME="$(tailscale status --json 2>/dev/null \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["Self"]["DNSName"].rstrip("."))' 2>/dev/null \
+  || true)"
+if [ -z "${TS_HOSTNAME}" ]; then
+  echo "(error) Could not resolve Tailscale hostname. Is Tailscale running and logged in?" >&2
+  echo "        Run: tailscale status" >&2
+  exit 1
+fi
+
+# ---- Expose /api via Tailscale Serve ----
+echo "-> exposing /api -> http://127.0.0.1:${API_PORT} via Tailscale Serve"
+if ! tailscale serve --bg --set-path=/api "http://127.0.0.1:${API_PORT}" >/tmp/ts-dev-tunnel.log 2>&1; then
+  echo "(error) tailscale serve failed:" >&2
+  cat /tmp/ts-dev-tunnel.log >&2
+  exit 1
+fi
+
+# ---- Cleanup on exit ----
+cleanup() {
+  echo ""
+  echo "-> resetting Tailscale Serve config"
+  tailscale serve reset 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# ---- Status block ----
+cat <<INFO
+================================================================
+  Dev API exposed at:
+  https://${TS_HOSTNAME}/api
+
+  Test from another Tailnet device:
+    curl https://${TS_HOSTNAME}/api/health
+
+  Edit server/, nodemon restarts, the phone sees it immediately.
+
+  Press Ctrl-C to stop and reset the Tailscale Serve config.
+================================================================
+INFO
+
+# ---- Block until Ctrl-C ----
+while true; do sleep 60; done

--- a/mobile/ota/ship.sh
+++ b/mobile/ota/ship.sh
@@ -158,6 +158,15 @@ if [ "${TRANSPORT}" = "tailscale" ]; then
     exit 1
   fi
 
+  # Optionally also expose the dev API at /api when npm start is already running.
+  if lsof -nP -iTCP:3000 -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "-> also exposing /api -> http://127.0.0.1:3000 (dev server detected on :3000)"
+    tailscale serve --bg --set-path=/api "http://127.0.0.1:3000" >/tmp/ts-serve-api.log 2>&1 \
+      || echo "(warning) /api route failed — install will work but the installed app cannot reach the backend. See /tmp/ts-serve-api.log"
+  else
+    echo "(warning) port 3000 not listening; /api route skipped. Run 'npm start' before ship.sh if you want the installed app to reach the backend."
+  fi
+
   cleanup() {
     echo ""
     echo "-> cleaning up (tailscale serve + http server)"


### PR DESCRIPTION
## Summary
- New `mobile/ota/dev-tunnel.sh` exposes the local Express dev server (`:3000`) at `https://<host>.ts.net/api` via Tailscale Serve for the daily phone+live-backend loop
- `mobile/ota/ship.sh` now also adds the `/api` route automatically when `npm start` is already running, so a fresh OTA install reaches the backend without a second script
- README adds a "Daily dev loop" section walking through `npm start` then `bash mobile/ota/dev-tunnel.sh`

Closes #8

## Test plan
- [x] `bash -n mobile/ota/dev-tunnel.sh` passes
- [x] `bash -n mobile/ota/ship.sh` passes
- [x] `tailscale serve --help` confirms `--set-path` is supported on 1.96.4 (the version on the dev Mac)
- [ ] `dev-tunnel.sh` while `npm start` is up: status line confirms `/api` -> `:3000`, blocks until Ctrl-C (manual)
- [ ] `dev-tunnel.sh` without `npm start`: warns and exits non-zero (manual)
- [ ] `curl https://<host>.ts.net/api/health` from another tailnet device matches `localhost:3000/api/health` (manual)
- [ ] `ship.sh` with `npm start` running configures both `/` and `/api` routes (manual via `tailscale serve status`)
- [ ] `ship.sh` without `npm start` still works install-only and prints a warning (manual)
- [ ] Ctrl-C resets Tailscale Serve in both scripts (manual)

## Notes
- Builds on PR #7 (Tailscale OTA transport)
- Cleanup uses `tailscale serve reset` (clears all config) — fine since both scripts manage their own lifecycle and shouldn't be running simultaneously
- TestFlight remains the proper long-term answer for zero-friction install + live backend (separate ticket whenever you're ready for $99/yr Apple Developer Program)
