### PR TITLE
feat(client): show app version above sidebar profile

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -15,7 +15,7 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, __APP_VERSION__: 'readonly' },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -134,6 +134,16 @@ function SidebarBody({ expanded, onNavigate, wordmark }) {
 
       {/* Footer: theme toggle + profile pip placeholder */}
       <div className="px-2 py-3 border-t border-divider">
+        <div
+          className={
+            'px-2 mb-1.5 ' +
+            (expanded ? 'opacity-100' : 'opacity-0 pointer-events-none')
+          }
+        >
+          <span className="text-[10px] font-mono tracking-wider text-muted">
+            v{__APP_VERSION__}
+          </span>
+        </div>
         <div className="flex items-center gap-2">
           <ThemeToggle />
           <div

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,9 +1,18 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const { version } = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, 'package.json'), 'utf-8')
+)
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary
- Inject `__APP_VERSION__` at build time via Vite `define`, sourced from `client/package.json` so it stays in lockstep with the package version.
- Render `v<version>` in muted mono type immediately above the profile avatar row in the sidebar footer. Reuses the existing `expanded ? opacity-100 : opacity-0 pointer-events-none` guard so the 64px collapsed rail stays clean (no width shift).
- Whitelist `__APP_VERSION__` in `client/eslint.config.js` so the lint pass recognises the injected global.

Closes #10

## Test plan
- [x] Verified visually at three sidebar states. Screenshots + ticked acceptance criteria are on the ticket: https://github.com/akshaydotsharma/personal-dashboard/issues/10#issuecomment-4364600569
- [x] `vite build` succeeds; bundle confirms `__APP_VERSION__` is fully substituted to `"1.0.0"` (no leftover token).