### PR TITLE
feat: iOS local-first data layer (todos, notes, lists, folders)

### DIFF
--- a/.claude/progress/ios-local-first-data.md
+++ b/.claude/progress/ios-local-first-data.md
@@ -52,10 +52,20 @@ Make iOS todos, notes, and lists fully usable when the Mac is off. Local-first s
 - [ ] Device QA evidence in ticket comment
 
 ## Completed Steps
-(none yet)
+- [x] Phase 1: schema additions + sync triggers + tests (5 new tests, 2026-05-03)
+- [x] Phase 2: sync endpoints + soft-delete switch for notes/lists/folders + tests (7 new tests, 2026-05-03)
+- [x] Phase 3: iOS SwiftData scaffold — LocalTodo @Model, SwiftDataStore container, SyncEngine pull+push, SyncWatermark, SyncWireFormat DTOs, app-launch sync wiring (2026-05-03). Build succeeds.
 
 ## Current Step
-Phase 1: schema additions.
+Phase 4: migrate Todos widget to read from SwiftData.
+- Rewrite `TodoService` so create/update/delete operate on `LocalTodo` first, then enqueue (set `needsSync = true`) for the next sync push. Read paths fetch LocalTodo and project to `Todo` DTOs.
+- Rewrite `TodosViewModel` to source `[Todo]` from `SwiftDataStore.shared.context.fetch(LocalTodo)` instead of the API. `load()` becomes "trigger sync, then refetch from local store".
+- Validate on a real device per `dev-workflow.md`: airplane-mode add/edit/delete, reconnect, watch the sync settle.
+- Note: `ChatViewModel` and the AI capture flow also call `TodoService.create` etc — confirm those paths still work after the rewrite (they should, as the API surface stays the same shape).
+
+## Phase 4 callsite map (compiled before starting)
+- `TodoService` is consumed by: `TodosViewModel`, `ChatViewModel` (chat-to-drafts confirmation), the App Intent capture flow.
+- All three should keep working because the public method signatures don't change — only the implementation moves from "POST/PUT/DELETE API call" to "write to SwiftData + queue for sync".
 
 ## Blockers
 None.

--- a/.claude/progress/ios-local-first-data.md
+++ b/.claude/progress/ios-local-first-data.md
@@ -1,0 +1,74 @@
+# iOS local-first data layer
+
+**Status**: in-progress
+**Started**: 2026-05-03
+**Last Updated**: 2026-05-03 SGT
+**Ticket**: #14
+**Branch**: `feat/ios-local-first-data`
+
+## Objective
+Make iOS todos, notes, and lists fully usable when the Mac is off. Local-first store on iPhone (SwiftData) with background sync to the Express + Postgres backend on the Mac. Conflict resolution is last-write-wins by `updated_at`, with `version` for delta sync.
+
+## Phases
+
+### Phase 1: Server schema + sync primitives (this session)
+- [ ] Add `version BIGINT NOT NULL DEFAULT 1` to todos, notes, lists, note_folders
+- [ ] Add `client_uuid UUID UNIQUE` to todos, notes, lists, note_folders
+- [ ] Add `deleted_at TIMESTAMP` to notes, lists, note_folders (todos already has)
+- [ ] Ensure `updated_at` exists everywhere (lists, note_folders need it)
+- [ ] Trigger that bumps `version` and `updated_at` on every UPDATE
+- [ ] All write paths in `server/index.js` return `version` and `client_uuid` in their JSON
+- [ ] Server tests pass
+
+### Phase 2: Server sync endpoints (this session or next)
+- [ ] `GET /api/sync/changes?since_version=N` returns delta across todos, notes, lists, note_folders since the version watermark, including soft-deletes
+- [ ] `POST /api/sync/upsert` accepts a batch of client changes keyed by `client_uuid`, with conflict resolution: server wins if its `updated_at` is newer; otherwise apply client change
+- [ ] Server tests cover: insert by client_uuid, update by client_uuid, delete, conflict resolution
+
+### Phase 3: iOS SwiftData scaffold
+- [ ] `Models/Local/LocalTodo.swift` (and Note, List, NoteFolder later)
+- [ ] `Cache/SwiftDataStore.swift` boot + container
+- [ ] `Cache/Outbox.swift` for queued mutations (create/update/delete)
+- [ ] `Sync/SyncEngine.swift` with `pullChanges()` + `pushOutbox()`
+- [ ] Hook into app lifecycle: drain outbox + pull on foreground, on push-notification (later), on connectivity restored
+
+### Phase 4: Migrate Todos widget end-to-end
+- [ ] `TodoService` reads from SwiftData first, falls back to API on miss
+- [ ] All writes go to SwiftData + enqueue outbox
+- [ ] `TodosViewModel` switches to SwiftData `@Query`
+- [ ] Retire `CacheStore.Key.todos` once green
+- [ ] Device QA: airplane mode add/edit/delete, reconnect, verify convergence
+
+### Phase 5: Migrate Notes
+- [ ] Same pattern as Todos. Folders included.
+
+### Phase 6: Migrate Lists / Checklists
+- [ ] Same pattern. Note: `lists.items` is JSONB; the items array is part of the row, not separate rows.
+
+### Phase 7: Cleanup + ship
+- [ ] Retire `CacheStore` entirely
+- [ ] Document conflict semantics in CLAUDE.md
+- [ ] Open PR linked to #14
+- [ ] Device QA evidence in ticket comment
+
+## Completed Steps
+(none yet)
+
+## Current Step
+Phase 1: schema additions.
+
+## Blockers
+None.
+
+## Key Decisions Made
+- 2026-05-03: SwiftData over Core Data / SQLite. iOS 17+ minimum is fine.
+- 2026-05-03: Last-write-wins by `updated_at`. No CRDTs.
+- 2026-05-03: `client_uuid` UUID column lets iOS create rows offline with a stable identity. Server still keeps integer PK for backward compat.
+- 2026-05-03: `version BIGINT` per row, monotonic across the whole DB (or per table; deciding in Phase 1).
+- 2026-05-03: Soft-delete everywhere (notes, lists, folders) so deletes can sync.
+
+## Files Modified
+(filled in as we go)
+
+## Context for Next Session
+Read this file. Then check `git log feat/ios-local-first-data` for what's already shipped. Then resume from "Current Step".

--- a/mobile/PersonalDashboard/App/PersonalDashboardApp.swift
+++ b/mobile/PersonalDashboard/App/PersonalDashboardApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftData
 
 @main
 struct PersonalDashboardApp: App {
@@ -14,7 +15,14 @@ struct PersonalDashboardApp: App {
                     // Also make one real API call so the app shows up in
                     // iOS Settings with a Local Network toggle on first run.
                     let _: EmptyResponse? = try? await APIClient.shared.get("dashboard/config")
+
+                    // Kick off a sync round-trip on launch so the SwiftData
+                    // store hydrates from the server (or pushes pending
+                    // local changes) before the user navigates anywhere.
+                    // Failures are silent — the next refresh retries.
+                    try? await SyncEngine.shared.sync()
                 }
         }
+        .modelContainer(SwiftDataStore.shared.container)
     }
 }

--- a/mobile/PersonalDashboard/Cache/CacheStore.swift
+++ b/mobile/PersonalDashboard/Cache/CacheStore.swift
@@ -1,27 +1,18 @@
 import Foundation
 
-/// Read-only on-disk JSON cache for API responses.
+/// Read-only on-disk JSON cache for derived API responses.
 ///
-/// Each view model reads from the cache during `init` so the surface paints
-/// stale data on the very first frame, then refreshes from the API in the
-/// background. The cache is never authoritative — it's a snapshot of the most
-/// recent successful fetch. Writes go straight to the API; the cache is updated
-/// after a successful refresh.
+/// Scope shrank with #14: todos, notes, lists, and folders moved to the
+/// SwiftData store (`SwiftDataStore`) which is the authoritative on-device
+/// source. CacheStore now exists only for derived/aggregated payloads
+/// (currently just the dashboard stats), where the iOS app simply mirrors
+/// what the server computes and a cache eviction is recoverable on the
+/// next fetch.
 ///
-/// Files live in `Caches/api-cache/<key>.json`. The system may evict caches
-/// under storage pressure, which is fine — next fetch repopulates.
-///
-/// We use plain JSON files instead of SwiftData @Model classes because the
-/// data is read-only, the volumes are small (a single user's todos/notes/
-/// lists/stats), and JSON keeps the interop with the API codecs zero-friction.
-/// If we ever need live queries, on-device search, or schema migrations, this
-/// can be swapped to SwiftData without touching the call sites.
+/// Files live in `Caches/api-cache/<key>.json`. The system may evict
+/// caches under storage pressure, which is fine — next fetch repopulates.
 enum CacheStore {
     enum Key: String {
-        case todos
-        case notes
-        case noteFolders = "note_folders"
-        case lists
         case dashboardStats = "dashboard_stats"
     }
 

--- a/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
+++ b/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
@@ -21,9 +21,21 @@ final class SwiftDataStore {
     private init() {
         do {
             let schema = Schema([LocalTodo.self])
+            // SwiftData defaults the store URL to Application Support, but
+            // on a fresh simulator that directory doesn't exist yet and
+            // CoreData logs a noisy stat failure on first run. Pre-creating
+            // the directory and pointing the configuration at an explicit
+            // URL avoids both problems.
+            let supportDir = try FileManager.default.url(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+            let storeURL = supportDir.appendingPathComponent("PersonalDashboard.sqlite")
             let configuration = ModelConfiguration(
                 schema: schema,
-                isStoredInMemoryOnly: false
+                url: storeURL
             )
             self.container = try ModelContainer(for: schema, configurations: [configuration])
         } catch {

--- a/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
+++ b/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
@@ -20,7 +20,12 @@ final class SwiftDataStore {
 
     private init() {
         do {
-            let schema = Schema([LocalTodo.self])
+            let schema = Schema([
+                LocalTodo.self,
+                LocalNoteFolder.self,
+                LocalNote.self,
+                LocalList.self,
+            ])
             // SwiftData defaults the store URL to Application Support, but
             // on a fresh simulator that directory doesn't exist yet and
             // CoreData logs a noisy stat failure on first run. Pre-creating
@@ -46,7 +51,12 @@ final class SwiftDataStore {
     /// Build an in-memory container for tests or previews.
     static func makeInMemory() -> ModelContainer {
         do {
-            let schema = Schema([LocalTodo.self])
+            let schema = Schema([
+                LocalTodo.self,
+                LocalNoteFolder.self,
+                LocalNote.self,
+                LocalList.self,
+            ])
             let configuration = ModelConfiguration(
                 schema: schema,
                 isStoredInMemoryOnly: true

--- a/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
+++ b/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
@@ -1,0 +1,47 @@
+import Foundation
+import SwiftData
+
+/// SwiftData container singleton.
+///
+/// The store backs the iOS local-first data layer (#14). It holds
+/// `LocalTodo` (and later `LocalNote`, `LocalList`, `LocalNoteFolder`).
+/// SwiftData persists to the app's Application Support directory by default,
+/// which survives cache eviction unlike the legacy JSON cache.
+///
+/// Access the shared `ModelContext` via `SwiftDataStore.shared.context`.
+/// Services and view models inject this context; tests can substitute an
+/// in-memory container via `SwiftDataStore.makeInMemory()`.
+@MainActor
+final class SwiftDataStore {
+    static let shared = SwiftDataStore()
+
+    let container: ModelContainer
+    var context: ModelContext { container.mainContext }
+
+    private init() {
+        do {
+            let schema = Schema([LocalTodo.self])
+            let configuration = ModelConfiguration(
+                schema: schema,
+                isStoredInMemoryOnly: false
+            )
+            self.container = try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Failed to bootstrap SwiftData container: \(error)")
+        }
+    }
+
+    /// Build an in-memory container for tests or previews.
+    static func makeInMemory() -> ModelContainer {
+        do {
+            let schema = Schema([LocalTodo.self])
+            let configuration = ModelConfiguration(
+                schema: schema,
+                isStoredInMemoryOnly: true
+            )
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Failed to bootstrap in-memory SwiftData container: \(error)")
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Models/Checklist.swift
+++ b/mobile/PersonalDashboard/Models/Checklist.swift
@@ -35,19 +35,35 @@ struct ChecklistItem: Codable, Hashable, Sendable {
     }
 }
 
+/// View-facing DTO for a checklist. Identity is the clientUUID.
 struct Checklist: Codable, Identifiable, Hashable, Sendable {
-    let id: Int
+    let id: UUID
     var title: String
     var items: [ChecklistItem]
+    var position: Int?
+    let version: Int64
     let createdAt: Date
+    let updatedAt: Date
+    let deletedAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "clientUuid"
+        case title
+        case items
+        case position
+        case version
+        case createdAt
+        case updatedAt
+        case deletedAt
+    }
 }
 
-struct ChecklistCreateRequest: Encodable {
+struct ChecklistCreateRequest {
     let title: String
     let items: [ChecklistItem]
 }
 
-struct ChecklistUpdateRequest: Encodable {
+struct ChecklistUpdateRequest {
     let title: String
     let items: [ChecklistItem]
 }

--- a/mobile/PersonalDashboard/Models/Local/LocalList.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalList.swift
@@ -1,0 +1,80 @@
+import Foundation
+import SwiftData
+
+@Model
+final class LocalList {
+    @Attribute(.unique) var clientUUID: UUID
+    var title: String
+    /// Items are stored as JSON-encoded data so SwiftData (iOS 17.0)
+    /// can persist them without a custom transformer. The view-facing
+    /// `[ChecklistItem]` array is reconstructed on demand via toDTO().
+    var itemsData: Data
+    var position: Int?
+    var version: Int64
+    var createdAt: Date
+    var updatedAt: Date
+    var deletedAt: Date?
+    var needsSync: Bool
+
+    init(
+        clientUUID: UUID = UUID(),
+        title: String,
+        items: [ChecklistItem] = [],
+        position: Int? = nil,
+        version: Int64 = 0,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        deletedAt: Date? = nil,
+        needsSync: Bool = true
+    ) {
+        self.clientUUID = clientUUID
+        self.title = title
+        self.itemsData = LocalList.encode(items)
+        self.position = position
+        self.version = version
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.deletedAt = deletedAt
+        self.needsSync = needsSync
+    }
+
+    /// Read/write the items as a structured array. Decoding failures
+    /// fall back to an empty list rather than crashing — better to show
+    /// a recoverable empty state than a fatal error in production.
+    var items: [ChecklistItem] {
+        get { LocalList.decode(itemsData) }
+        set { itemsData = LocalList.encode(newValue) }
+    }
+
+    func applyServerState(_ dto: Checklist) {
+        self.title = dto.title
+        self.items = dto.items
+        self.position = dto.position
+        self.version = dto.version
+        self.createdAt = dto.createdAt
+        self.updatedAt = dto.updatedAt
+        self.deletedAt = dto.deletedAt
+        self.needsSync = false
+    }
+
+    func toDTO() -> Checklist {
+        Checklist(
+            id: clientUUID,
+            title: title,
+            items: items,
+            position: position,
+            version: version,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt
+        )
+    }
+
+    private static func encode(_ items: [ChecklistItem]) -> Data {
+        (try? JSONEncoder().encode(items)) ?? Data("[]".utf8)
+    }
+
+    private static func decode(_ data: Data) -> [ChecklistItem] {
+        (try? JSONDecoder().decode([ChecklistItem].self, from: data)) ?? []
+    }
+}

--- a/mobile/PersonalDashboard/Models/Local/LocalNote.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalNote.swift
@@ -1,0 +1,68 @@
+import Foundation
+import SwiftData
+
+@Model
+final class LocalNote {
+    @Attribute(.unique) var clientUUID: UUID
+    /// Folder link by UUID, mapping to the server's folder_client_uuid
+    /// column. Nil for notes outside any folder ("unfiled").
+    var folderClientUUID: UUID?
+    var title: String?
+    var content: String?
+    var position: Int?
+    var version: Int64
+    var createdAt: Date
+    var updatedAt: Date
+    var deletedAt: Date?
+    var needsSync: Bool
+
+    init(
+        clientUUID: UUID = UUID(),
+        folderClientUUID: UUID? = nil,
+        title: String? = nil,
+        content: String? = nil,
+        position: Int? = nil,
+        version: Int64 = 0,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        deletedAt: Date? = nil,
+        needsSync: Bool = true
+    ) {
+        self.clientUUID = clientUUID
+        self.folderClientUUID = folderClientUUID
+        self.title = title
+        self.content = content
+        self.position = position
+        self.version = version
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.deletedAt = deletedAt
+        self.needsSync = needsSync
+    }
+
+    func applyServerState(_ dto: Note) {
+        self.folderClientUUID = dto.folderId
+        self.title = dto.title
+        self.content = dto.content
+        self.position = dto.position
+        self.version = dto.version
+        self.createdAt = dto.createdAt
+        self.updatedAt = dto.updatedAt
+        self.deletedAt = dto.deletedAt
+        self.needsSync = false
+    }
+
+    func toDTO() -> Note {
+        Note(
+            id: clientUUID,
+            folderId: folderClientUUID,
+            title: title,
+            content: content,
+            position: position,
+            version: version,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt
+        )
+    }
+}

--- a/mobile/PersonalDashboard/Models/Local/LocalNoteFolder.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalNoteFolder.swift
@@ -1,0 +1,56 @@
+import Foundation
+import SwiftData
+
+@Model
+final class LocalNoteFolder {
+    @Attribute(.unique) var clientUUID: UUID
+    var name: String
+    var position: Int?
+    var version: Int64
+    var createdAt: Date
+    var updatedAt: Date
+    var deletedAt: Date?
+    var needsSync: Bool
+
+    init(
+        clientUUID: UUID = UUID(),
+        name: String,
+        position: Int? = nil,
+        version: Int64 = 0,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        deletedAt: Date? = nil,
+        needsSync: Bool = true
+    ) {
+        self.clientUUID = clientUUID
+        self.name = name
+        self.position = position
+        self.version = version
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.deletedAt = deletedAt
+        self.needsSync = needsSync
+    }
+
+    func applyServerState(_ dto: NoteFolder) {
+        self.name = dto.name
+        self.position = dto.position
+        self.version = dto.version
+        self.createdAt = dto.createdAt
+        self.updatedAt = dto.updatedAt
+        self.deletedAt = dto.deletedAt
+        self.needsSync = false
+    }
+
+    func toDTO() -> NoteFolder {
+        NoteFolder(
+            id: clientUUID,
+            name: name,
+            position: position,
+            version: version,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt
+        )
+    }
+}

--- a/mobile/PersonalDashboard/Models/Local/LocalTodo.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalTodo.swift
@@ -4,17 +4,13 @@ import SwiftData
 /// Local-first SwiftData model for a todo. The phone treats this as the
 /// source of truth: every create/update/delete writes here first, then the
 /// `SyncEngine` pushes pending changes to the server and pulls remote
-/// changes back. `clientUUID` is the stable identity across the network —
-/// the server keeps an integer `id` but the iOS layer only ever keys on UUID.
+/// changes back. `clientUUID` is the stable identity across the network;
+/// the server's integer primary key is irrelevant on the iOS side.
 @Model
 final class LocalTodo {
     /// Stable identity. Generated locally on creation; the server adopts it
     /// on first sync. Unique within the SwiftData store.
     @Attribute(.unique) var clientUUID: UUID
-
-    /// Server-assigned integer id, populated after the first successful sync.
-    /// nil for rows that exist locally but have not yet been pushed.
-    var serverID: Int?
 
     var title: String
     var todoDescription: String?
@@ -36,7 +32,6 @@ final class LocalTodo {
 
     init(
         clientUUID: UUID = UUID(),
-        serverID: Int? = nil,
         title: String,
         todoDescription: String? = nil,
         completed: Bool = false,
@@ -50,7 +45,6 @@ final class LocalTodo {
         needsSync: Bool = true
     ) {
         self.clientUUID = clientUUID
-        self.serverID = serverID
         self.title = title
         self.todoDescription = todoDescription
         self.completed = completed
@@ -68,7 +62,6 @@ final class LocalTodo {
     /// applying delta from `/api/sync/changes`. Clears `needsSync` because
     /// the row now matches the server.
     func applyServerState(_ dto: Todo) {
-        self.serverID = dto.id
         self.title = dto.title
         self.todoDescription = dto.description
         self.completed = dto.completed
@@ -82,12 +75,12 @@ final class LocalTodo {
         self.needsSync = false
     }
 
-    /// Project to the API-wire DTO for legacy view-model consumption while
-    /// the migration is in flight. ViewModels that read `[Todo]` keep working.
+    /// Project to the view-facing DTO. ViewModels and views consume `Todo`
+    /// (struct, value semantics) rather than the `LocalTodo` model directly,
+    /// so SwiftUI updates are predictable and equality is per-snapshot.
     func toDTO() -> Todo {
         Todo(
-            id: serverID ?? 0,
-            clientUuid: clientUUID,
+            id: clientUUID,
             title: title,
             description: todoDescription,
             completed: completed,

--- a/mobile/PersonalDashboard/Models/Local/LocalTodo.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalTodo.swift
@@ -1,0 +1,103 @@
+import Foundation
+import SwiftData
+
+/// Local-first SwiftData model for a todo. The phone treats this as the
+/// source of truth: every create/update/delete writes here first, then the
+/// `SyncEngine` pushes pending changes to the server and pulls remote
+/// changes back. `clientUUID` is the stable identity across the network —
+/// the server keeps an integer `id` but the iOS layer only ever keys on UUID.
+@Model
+final class LocalTodo {
+    /// Stable identity. Generated locally on creation; the server adopts it
+    /// on first sync. Unique within the SwiftData store.
+    @Attribute(.unique) var clientUUID: UUID
+
+    /// Server-assigned integer id, populated after the first successful sync.
+    /// nil for rows that exist locally but have not yet been pushed.
+    var serverID: Int?
+
+    var title: String
+    var todoDescription: String?
+    var completed: Bool
+    var dueDate: Date?
+    var tag: String?
+    var position: Int?
+
+    /// Server-assigned monotonic version. 0 if never synced.
+    var version: Int64
+
+    var createdAt: Date
+    var updatedAt: Date
+    var deletedAt: Date?
+
+    /// True when this row has unpushed local changes. The sync engine drains
+    /// the set of `needsSync == true` rows on every push cycle.
+    var needsSync: Bool
+
+    init(
+        clientUUID: UUID = UUID(),
+        serverID: Int? = nil,
+        title: String,
+        todoDescription: String? = nil,
+        completed: Bool = false,
+        dueDate: Date? = nil,
+        tag: String? = nil,
+        position: Int? = nil,
+        version: Int64 = 0,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        deletedAt: Date? = nil,
+        needsSync: Bool = true
+    ) {
+        self.clientUUID = clientUUID
+        self.serverID = serverID
+        self.title = title
+        self.todoDescription = todoDescription
+        self.completed = completed
+        self.dueDate = dueDate
+        self.tag = tag
+        self.position = position
+        self.version = version
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.deletedAt = deletedAt
+        self.needsSync = needsSync
+    }
+
+    /// Adopt server state into the local row. Used by SyncEngine when
+    /// applying delta from `/api/sync/changes`. Clears `needsSync` because
+    /// the row now matches the server.
+    func applyServerState(_ dto: Todo) {
+        self.serverID = dto.id
+        self.title = dto.title
+        self.todoDescription = dto.description
+        self.completed = dto.completed
+        self.dueDate = dto.dueDate
+        self.tag = dto.tag
+        self.position = dto.position
+        self.version = dto.version
+        self.createdAt = dto.createdAt
+        self.updatedAt = dto.updatedAt
+        self.deletedAt = dto.deletedAt
+        self.needsSync = false
+    }
+
+    /// Project to the API-wire DTO for legacy view-model consumption while
+    /// the migration is in flight. ViewModels that read `[Todo]` keep working.
+    func toDTO() -> Todo {
+        Todo(
+            id: serverID ?? 0,
+            clientUuid: clientUUID,
+            title: title,
+            description: todoDescription,
+            completed: completed,
+            dueDate: dueDate,
+            tag: tag,
+            position: position,
+            version: version,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            deletedAt: deletedAt
+        )
+    }
+}

--- a/mobile/PersonalDashboard/Models/Note.swift
+++ b/mobile/PersonalDashboard/Models/Note.swift
@@ -1,32 +1,66 @@
 import Foundation
 
+/// View-facing DTO for a folder. Identity is the clientUUID.
 struct NoteFolder: Codable, Identifiable, Hashable, Sendable {
-    let id: Int
+    let id: UUID
     var name: String
-    let createdAt: Date
-}
-
-struct Note: Codable, Identifiable, Hashable, Sendable {
-    let id: Int
-    var folderId: Int?
-    var title: String?
-    var content: String?
+    var position: Int?
+    let version: Int64
     let createdAt: Date
     let updatedAt: Date
+    let deletedAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "clientUuid"
+        case name
+        case position
+        case version
+        case createdAt
+        case updatedAt
+        case deletedAt
+    }
 }
 
-struct NoteFolderCreateRequest: Encodable {
+/// View-facing DTO for a note. Identity is the clientUUID. The folder
+/// link travels by UUID (folderId here = folder_client_uuid on the
+/// server) so an offline-created note can reference an offline-created
+/// folder before either has touched the server.
+struct Note: Codable, Identifiable, Hashable, Sendable {
+    let id: UUID
+    var folderId: UUID?
+    var title: String?
+    var content: String?
+    var position: Int?
+    let version: Int64
+    let createdAt: Date
+    let updatedAt: Date
+    let deletedAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "clientUuid"
+        case folderId = "folderClientUuid"
+        case title
+        case content
+        case position
+        case version
+        case createdAt
+        case updatedAt
+        case deletedAt
+    }
+}
+
+struct NoteFolderCreateRequest {
     let name: String
 }
 
-struct NoteCreateRequest: Encodable {
+struct NoteCreateRequest {
     let title: String?
     let content: String?
-    let folderId: Int?
+    let folderId: UUID?
 }
 
-struct NoteUpdateRequest: Encodable {
+struct NoteUpdateRequest {
     let title: String?
     let content: String?
-    let folderId: Int?
+    let folderId: UUID?
 }

--- a/mobile/PersonalDashboard/Models/Todo.swift
+++ b/mobile/PersonalDashboard/Models/Todo.swift
@@ -1,11 +1,14 @@
 import Foundation
 
-/// API-wire DTO for a todo. Maps directly to the server's `todos` row.
-/// View code consumes `Todo` (or `LocalTodo` when the SwiftData store is the
-/// source of truth — see `Models/Local/LocalTodo.swift`).
+/// View-facing DTO for a todo. Identity is the `clientUUID` (here exposed
+/// as `id` for Identifiable conformance), which is the sync key shared with
+/// the server. The server's integer primary key is kept inside `LocalTodo`
+/// for sync internals and never bubbles up to views — this lets locally
+/// created todos render correctly before they have ever reached the server.
 struct Todo: Codable, Identifiable, Hashable, Sendable {
-    let id: Int
-    let clientUuid: UUID
+    /// Stable identity, matches `LocalTodo.clientUUID` and the server's
+    /// `client_uuid` column.
+    let id: UUID
     var title: String
     var description: String?
     var completed: Bool
@@ -16,6 +19,24 @@ struct Todo: Codable, Identifiable, Hashable, Sendable {
     let createdAt: Date
     let updatedAt: Date
     let deletedAt: Date?
+
+    /// Server JSON has both `id` (int) and `client_uuid`; we map our `id`
+    /// to `client_uuid` and ignore the server's int. The decoder's
+    /// `.convertFromSnakeCase` strategy turns `client_uuid` into
+    /// `clientUuid`, which is what the explicit raw value below matches.
+    private enum CodingKeys: String, CodingKey {
+        case id = "clientUuid"
+        case title
+        case description
+        case completed
+        case dueDate
+        case tag
+        case position
+        case version
+        case createdAt
+        case updatedAt
+        case deletedAt
+    }
 }
 
 struct TodoCreateRequest: Encodable {

--- a/mobile/PersonalDashboard/Models/Todo.swift
+++ b/mobile/PersonalDashboard/Models/Todo.swift
@@ -1,12 +1,18 @@
 import Foundation
 
+/// API-wire DTO for a todo. Maps directly to the server's `todos` row.
+/// View code consumes `Todo` (or `LocalTodo` when the SwiftData store is the
+/// source of truth — see `Models/Local/LocalTodo.swift`).
 struct Todo: Codable, Identifiable, Hashable, Sendable {
     let id: Int
+    let clientUuid: UUID
     var title: String
     var description: String?
     var completed: Bool
     var dueDate: Date?
     var tag: String?
+    var position: Int?
+    let version: Int64
     let createdAt: Date
     let updatedAt: Date
     let deletedAt: Date?

--- a/mobile/PersonalDashboard/Services/APIClient.swift
+++ b/mobile/PersonalDashboard/Services/APIClient.swift
@@ -82,6 +82,9 @@ struct APIClient: Sendable {
             do {
                 return try Self.decoder.decode(T.self, from: data)
             } catch {
+                let bodyPreview = String(data: data.prefix(800), encoding: .utf8) ?? "<non-utf8 bytes>"
+                NSLog("[APIClient] Decoding failed for %@ — error=%@ body=%@",
+                      String(describing: T.self), String(describing: error), bodyPreview)
                 throw APIError.decoding(error)
             }
         } catch let error as APIError {

--- a/mobile/PersonalDashboard/Services/APIError.swift
+++ b/mobile/PersonalDashboard/Services/APIError.swift
@@ -5,6 +5,7 @@ enum APIError: LocalizedError {
     case http(status: Int, message: String?)
     case decoding(Error)
     case transport(Error)
+    case notFound
 
     var errorDescription: String? {
         switch self {
@@ -16,6 +17,8 @@ enum APIError: LocalizedError {
             return "Could not parse server response. \(err.localizedDescription)"
         case .transport(let err):
             return err.localizedDescription
+        case .notFound:
+            return "Item not found."
         }
     }
 }

--- a/mobile/PersonalDashboard/Services/ChecklistService.swift
+++ b/mobile/PersonalDashboard/Services/ChecklistService.swift
@@ -1,25 +1,74 @@
 import Foundation
+import SwiftData
 
-struct ChecklistService: Sendable {
-    let api: APIClient
+/// Local-first checklist service. Items are part of the row (JSONB on
+/// the server, JSON-encoded Data on the device) so updating an item is
+/// a row-level update.
+@MainActor
+struct ChecklistService {
+    let store: SwiftDataStore
+    let syncEngine: SyncEngine
 
-    init(api: APIClient = .shared) {
-        self.api = api
+    init(store: SwiftDataStore = .shared, syncEngine: SyncEngine = .shared) {
+        self.store = store
+        self.syncEngine = syncEngine
     }
 
     func list() async throws -> [Checklist] {
-        try await api.get("lists")
+        let descriptor = FetchDescriptor<LocalList>(
+            predicate: #Predicate { $0.deletedAt == nil },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        let rows = try store.context.fetch(descriptor)
+        return rows.map { $0.toDTO() }
     }
 
     func create(_ request: ChecklistCreateRequest) async throws -> Checklist {
-        try await api.post("lists", body: request)
+        let now = Date()
+        let row = LocalList(
+            title: request.title,
+            items: request.items,
+            createdAt: now,
+            updatedAt: now,
+            needsSync: true
+        )
+        store.context.insert(row)
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
     }
 
-    func update(id: Int, _ request: ChecklistUpdateRequest) async throws -> Checklist {
-        try await api.put("lists/\(id)", body: request)
+    func update(_ list: Checklist, _ request: ChecklistUpdateRequest) async throws -> Checklist {
+        let row = try fetchLocal(uuid: list.id)
+        row.title = request.title
+        row.items = request.items
+        row.updatedAt = Date()
+        row.needsSync = true
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
     }
 
-    func delete(id: Int) async throws {
-        try await api.delete("lists/\(id)")
+    func delete(_ list: Checklist) async throws {
+        let row = try fetchLocal(uuid: list.id)
+        row.deletedAt = Date()
+        row.updatedAt = Date()
+        row.needsSync = true
+        try store.context.save()
+        kickSync()
+    }
+
+    private func fetchLocal(uuid: UUID) throws -> LocalList {
+        let descriptor = FetchDescriptor<LocalList>(
+            predicate: #Predicate { $0.clientUUID == uuid }
+        )
+        guard let row = try store.context.fetch(descriptor).first else {
+            throw APIError.notFound
+        }
+        return row
+    }
+
+    private func kickSync() {
+        Task { @MainActor in try? await syncEngine.sync() }
     }
 }

--- a/mobile/PersonalDashboard/Services/NoteService.swift
+++ b/mobile/PersonalDashboard/Services/NoteService.swift
@@ -1,44 +1,149 @@
 import Foundation
+import SwiftData
 
-struct NoteService: Sendable {
-    let api: APIClient
+/// Local-first note service. Mirrors `TodoService` pattern: every
+/// mutation lands in SwiftData first, gets flagged needsSync, and the
+/// SyncEngine pushes to the server in the background.
+@MainActor
+struct NoteService {
+    let store: SwiftDataStore
+    let syncEngine: SyncEngine
 
-    init(api: APIClient = .shared) {
-        self.api = api
+    init(store: SwiftDataStore = .shared, syncEngine: SyncEngine = .shared) {
+        self.store = store
+        self.syncEngine = syncEngine
     }
 
-    // Folders
+    // MARK: - Folders
+
     func listFolders() async throws -> [NoteFolder] {
-        try await api.get("note-folders")
+        let descriptor = FetchDescriptor<LocalNoteFolder>(
+            predicate: #Predicate { $0.deletedAt == nil },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        let rows = try store.context.fetch(descriptor)
+        return rows.map { $0.toDTO() }
     }
 
     func createFolder(name: String) async throws -> NoteFolder {
-        try await api.post("note-folders", body: NoteFolderCreateRequest(name: name))
+        let row = LocalNoteFolder(name: name, needsSync: true)
+        store.context.insert(row)
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
     }
 
-    func renameFolder(id: Int, name: String) async throws -> NoteFolder {
-        try await api.put("note-folders/\(id)", body: NoteFolderCreateRequest(name: name))
+    func renameFolder(_ folder: NoteFolder, to name: String) async throws -> NoteFolder {
+        let row = try fetchLocalFolder(uuid: folder.id)
+        row.name = name
+        row.updatedAt = Date()
+        row.needsSync = true
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
     }
 
-    func deleteFolder(id: Int) async throws {
-        try await api.delete("note-folders/\(id)")
+    func deleteFolder(_ folder: NoteFolder) async throws {
+        let row = try fetchLocalFolder(uuid: folder.id)
+        row.deletedAt = Date()
+        row.updatedAt = Date()
+        row.needsSync = true
+        // Soft-cascade to child notes so the iOS view immediately stops
+        // showing them. The server's folder delete also cascades, so
+        // post-sync state matches.
+        let folderUUID = folder.id
+        let childDescriptor = FetchDescriptor<LocalNote>(
+            predicate: #Predicate { $0.folderClientUUID == folderUUID && $0.deletedAt == nil }
+        )
+        let children = try store.context.fetch(childDescriptor)
+        for child in children {
+            child.deletedAt = Date()
+            child.updatedAt = Date()
+            child.needsSync = true
+        }
+        try store.context.save()
+        kickSync()
     }
 
-    // Notes
-    func list(folderId: Int? = nil) async throws -> [Note] {
-        let query = folderId.map { [URLQueryItem(name: "folder_id", value: String($0))] } ?? []
-        return try await api.get("notes", query: query)
+    // MARK: - Notes
+
+    func list(folderId: UUID? = nil) async throws -> [Note] {
+        let descriptor: FetchDescriptor<LocalNote>
+        if let folderId {
+            descriptor = FetchDescriptor<LocalNote>(
+                predicate: #Predicate { $0.deletedAt == nil && $0.folderClientUUID == folderId },
+                sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
+            )
+        } else {
+            descriptor = FetchDescriptor<LocalNote>(
+                predicate: #Predicate { $0.deletedAt == nil },
+                sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
+            )
+        }
+        let rows = try store.context.fetch(descriptor)
+        return rows.map { $0.toDTO() }
     }
 
     func create(_ request: NoteCreateRequest) async throws -> Note {
-        try await api.post("notes", body: request)
+        let now = Date()
+        let row = LocalNote(
+            folderClientUUID: request.folderId,
+            title: request.title,
+            content: request.content,
+            createdAt: now,
+            updatedAt: now,
+            needsSync: true
+        )
+        store.context.insert(row)
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
     }
 
-    func update(id: Int, _ request: NoteUpdateRequest) async throws -> Note {
-        try await api.put("notes/\(id)", body: request)
+    func update(_ note: Note, _ request: NoteUpdateRequest) async throws -> Note {
+        let row = try fetchLocalNote(uuid: note.id)
+        if let title = request.title { row.title = title }
+        if let content = request.content { row.content = content }
+        if let folderId = request.folderId { row.folderClientUUID = folderId }
+        row.updatedAt = Date()
+        row.needsSync = true
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
     }
 
-    func delete(id: Int) async throws {
-        try await api.delete("notes/\(id)")
+    func delete(_ note: Note) async throws {
+        let row = try fetchLocalNote(uuid: note.id)
+        row.deletedAt = Date()
+        row.updatedAt = Date()
+        row.needsSync = true
+        try store.context.save()
+        kickSync()
+    }
+
+    // MARK: - Internals
+
+    private func fetchLocalFolder(uuid: UUID) throws -> LocalNoteFolder {
+        let descriptor = FetchDescriptor<LocalNoteFolder>(
+            predicate: #Predicate { $0.clientUUID == uuid }
+        )
+        guard let row = try store.context.fetch(descriptor).first else {
+            throw APIError.notFound
+        }
+        return row
+    }
+
+    private func fetchLocalNote(uuid: UUID) throws -> LocalNote {
+        let descriptor = FetchDescriptor<LocalNote>(
+            predicate: #Predicate { $0.clientUUID == uuid }
+        )
+        guard let row = try store.context.fetch(descriptor).first else {
+            throw APIError.notFound
+        }
+        return row
+    }
+
+    private func kickSync() {
+        Task { @MainActor in try? await syncEngine.sync() }
     }
 }

--- a/mobile/PersonalDashboard/Services/TodoService.swift
+++ b/mobile/PersonalDashboard/Services/TodoService.swift
@@ -1,41 +1,134 @@
 import Foundation
+import SwiftData
 
-struct TodoService: Sendable {
-    let api: APIClient
+/// Local-first todo service. All mutations land in SwiftData first, get
+/// flagged with `needsSync = true`, and are pushed to the server in the
+/// background by `SyncEngine`. Reads always come from the local store, so
+/// the UI stays responsive even when the Mac is off.
+///
+/// Identity is the row's `clientUUID` (exposed as `Todo.id`), which is
+/// stable across the network — the iOS layer never depends on the
+/// server's integer primary key.
+@MainActor
+struct TodoService {
+    let store: SwiftDataStore
+    let syncEngine: SyncEngine
 
-    init(api: APIClient = .shared) {
-        self.api = api
+    init(store: SwiftDataStore = .shared, syncEngine: SyncEngine = .shared) {
+        self.store = store
+        self.syncEngine = syncEngine
     }
 
+    // MARK: - Reads
+
+    /// Return the live, undeleted todos sorted by the server's preferred
+    /// position (or createdAt as a fallback).
     func list() async throws -> [Todo] {
-        try await api.get("todos")
-    }
-
-    func create(_ request: TodoCreateRequest) async throws -> Todo {
-        try await api.post("todos", body: request)
-    }
-
-    func update(id: Int, _ request: TodoUpdateRequest) async throws -> Todo {
-        try await api.put("todos/\(id)", body: request)
-    }
-
-    func toggleCompleted(_ todo: Todo) async throws -> Todo {
-        let request = TodoUpdateRequest(
-            title: nil,
-            description: nil,
-            completed: !todo.completed,
-            dueDate: nil,
-            tag: nil
+        let context = store.context
+        let descriptor = FetchDescriptor<LocalTodo>(
+            predicate: #Predicate { $0.deletedAt == nil },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
         )
-        return try await api.put("todos/\(todo.id)", body: request)
+        let rows = try context.fetch(descriptor)
+        return rows.map { $0.toDTO() }
     }
 
-    func delete(id: Int, permanent: Bool = false) async throws {
-        let query = permanent ? [URLQueryItem(name: "permanent", value: "true")] : []
-        try await api.delete("todos/\(id)", query: query)
+    // MARK: - Writes
+
+    /// Create a new todo locally with a fresh UUID. The row is queued for
+    /// sync; it appears in `list()` immediately and shows up on the Mac on
+    /// the next successful push.
+    func create(_ request: TodoCreateRequest) async throws -> Todo {
+        let now = Date()
+        let row = LocalTodo(
+            title: request.title,
+            todoDescription: request.description,
+            completed: false,
+            dueDate: request.dueDate,
+            tag: request.tag,
+            createdAt: now,
+            updatedAt: now,
+            needsSync: true
+        )
+        store.context.insert(row)
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
     }
 
-    func restore(id: Int) async throws -> Todo {
-        try await api.postNoBody("todos/\(id)/restore")
+    /// Update a todo identified by its UUID (= `Todo.id`). Only fields
+    /// present on `request` are changed; nil values leave the existing
+    /// value alone.
+    func update(_ todo: Todo, _ request: TodoUpdateRequest) async throws -> Todo {
+        let row = try fetchLocal(uuid: todo.id)
+        if let title = request.title { row.title = title }
+        if let description = request.description { row.todoDescription = description }
+        if let completed = request.completed { row.completed = completed }
+        if let dueDate = request.dueDate { row.dueDate = dueDate }
+        if let tag = request.tag { row.tag = tag }
+        row.updatedAt = Date()
+        row.needsSync = true
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
+    }
+
+    /// Flip the `completed` flag. Identity is the UUID on `todo`.
+    func toggleCompleted(_ todo: Todo) async throws -> Todo {
+        let row = try fetchLocal(uuid: todo.id)
+        row.completed.toggle()
+        row.updatedAt = Date()
+        row.needsSync = true
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
+    }
+
+    /// Soft-delete the todo. The row stays in SwiftData with `deletedAt`
+    /// stamped so the next sync can push the tombstone. `permanent: true`
+    /// removes the row from the local store too — used when the server has
+    /// confirmed the delete and we no longer need the tombstone locally.
+    func delete(_ todo: Todo, permanent: Bool = false) async throws {
+        let row = try fetchLocal(uuid: todo.id)
+        if permanent {
+            store.context.delete(row)
+        } else {
+            row.deletedAt = Date()
+            row.updatedAt = Date()
+            row.needsSync = true
+        }
+        try store.context.save()
+        kickSync()
+    }
+
+    /// Restore a soft-deleted todo. Clears `deletedAt` and queues for sync.
+    func restore(_ todo: Todo) async throws -> Todo {
+        let row = try fetchLocal(uuid: todo.id)
+        row.deletedAt = nil
+        row.updatedAt = Date()
+        row.needsSync = true
+        try store.context.save()
+        kickSync()
+        return row.toDTO()
+    }
+
+    // MARK: - Internals
+
+    private func fetchLocal(uuid: UUID) throws -> LocalTodo {
+        let descriptor = FetchDescriptor<LocalTodo>(
+            predicate: #Predicate { $0.clientUUID == uuid }
+        )
+        guard let row = try store.context.fetch(descriptor).first else {
+            throw APIError.notFound
+        }
+        return row
+    }
+
+    /// Best-effort background sync. Failures are silent — the row stays
+    /// `needsSync = true` and the next attempt retries.
+    private func kickSync() {
+        Task { @MainActor in
+            try? await syncEngine.sync()
+        }
     }
 }

--- a/mobile/PersonalDashboard/Sync/SyncEngine.swift
+++ b/mobile/PersonalDashboard/Sync/SyncEngine.swift
@@ -32,8 +32,16 @@ final class SyncEngine {
     /// surfaced for the caller to display; the local store is unaffected
     /// by transport failures so the next sync retries.
     func sync() async throws {
-        try await pushOutbox()
-        try await pullChanges()
+        NSLog("[SyncEngine] sync() begin")
+        do {
+            try await pushOutbox()
+            NSLog("[SyncEngine] pushOutbox done")
+            try await pullChanges()
+            NSLog("[SyncEngine] pullChanges done")
+        } catch {
+            NSLog("[SyncEngine] sync failed: %@", String(describing: error))
+            throw error
+        }
     }
 
     // MARK: - Push

--- a/mobile/PersonalDashboard/Sync/SyncEngine.swift
+++ b/mobile/PersonalDashboard/Sync/SyncEngine.swift
@@ -70,7 +70,7 @@ final class SyncEngine {
         for row in pending { byUUID[row.clientUUID] = row }
 
         for serverDTO in response.applied.todos {
-            byUUID[serverDTO.clientUuid]?.applyServerState(serverDTO)
+            byUUID[serverDTO.id]?.applyServerState(serverDTO)
         }
         for rejection in response.rejected.todos {
             if let serverRow = rejection.serverRow {
@@ -104,7 +104,7 @@ final class SyncEngine {
     }
 
     private func applyIncomingTodo(_ dto: Todo, in context: ModelContext) throws {
-        let uuid = dto.clientUuid
+        let uuid = dto.id
         let descriptor = FetchDescriptor<LocalTodo>(
             predicate: #Predicate { $0.clientUUID == uuid }
         )
@@ -132,8 +132,7 @@ final class SyncEngine {
             }
             // New row from server.
             let row = LocalTodo(
-                clientUUID: dto.clientUuid,
-                serverID: dto.id,
+                clientUUID: dto.id,
                 title: dto.title,
                 todoDescription: dto.description,
                 completed: dto.completed,

--- a/mobile/PersonalDashboard/Sync/SyncEngine.swift
+++ b/mobile/PersonalDashboard/Sync/SyncEngine.swift
@@ -4,15 +4,16 @@ import SwiftData
 /// Sync engine for the iOS local-first data layer (#14).
 ///
 /// Two responsibilities:
-///   1. **Push**: drains LocalTodo rows where `needsSync == true`, posts
-///      them to `/api/sync/upsert`, and applies the server's response back
-///      into the store (so server-assigned id + version are stamped on).
-///   2. **Pull**: asks `/api/sync/changes?since_version=<watermark>` for any
+///   1. **Push**: drains rows where `needsSync == true` across todos,
+///      notes, lists, and note_folders, posts them to `/api/sync/upsert`,
+///      and applies the server's response back into the store (so
+///      server-assigned version is stamped on).
+///   2. **Pull**: asks `/api/sync/changes?since_version=<watermark>` for
 ///      remote changes since last sync and applies them — including
-///      tombstones, which delete the matching LocalTodo locally.
+///      tombstones, which delete the matching local row.
 ///
-/// `sync()` runs push then pull, which is the natural order: push local
-/// edits first so the pull doesn't fetch and overwrite them in flight.
+/// `sync()` runs push then pull, so push results don't get clobbered by
+/// the pull window.
 ///
 /// All entry points are async + actor-isolated to MainActor because the
 /// SwiftData ModelContext is main-actor-only on iOS 17.
@@ -28,9 +29,6 @@ final class SyncEngine {
         self.store = store
     }
 
-    /// Push pending local changes, then pull remote changes. Errors are
-    /// surfaced for the caller to display; the local store is unaffected
-    /// by transport failures so the next sync retries.
     func sync() async throws {
         NSLog("[SyncEngine] sync() begin")
         do {
@@ -46,57 +44,114 @@ final class SyncEngine {
 
     // MARK: - Push
 
-    /// Drain LocalTodo rows where needsSync == true. Build an upsert batch,
-    /// post it, then apply the response: applied rows adopt server state;
-    /// rejected rows (server_newer) adopt the server's row.
     func pushOutbox() async throws {
         let context = store.context
-        let descriptor = FetchDescriptor<LocalTodo>(
-            predicate: #Predicate { $0.needsSync == true }
-        )
-        let pending = try context.fetch(descriptor)
-        guard !pending.isEmpty else { return }
 
-        let rows = pending.map { todo in
-            TodoUpsertRow(
-                clientUuid: todo.clientUUID,
-                title: todo.title,
-                description: todo.todoDescription,
-                completed: todo.completed,
-                dueDate: todo.dueDate,
-                tag: todo.tag,
-                position: todo.position,
-                deletedAt: todo.deletedAt,
-                updatedAt: todo.updatedAt
-            )
-        }
-        let body = SyncUpsertRequest(todos: rows)
+        // Folders go first inside the same batch so notes referencing
+        // a freshly-created folder by UUID can resolve on the server.
+        let pendingFolders = try context.fetch(FetchDescriptor<LocalNoteFolder>(
+            predicate: #Predicate { $0.needsSync == true }
+        ))
+        let pendingTodos = try context.fetch(FetchDescriptor<LocalTodo>(
+            predicate: #Predicate { $0.needsSync == true }
+        ))
+        let pendingNotes = try context.fetch(FetchDescriptor<LocalNote>(
+            predicate: #Predicate { $0.needsSync == true }
+        ))
+        let pendingLists = try context.fetch(FetchDescriptor<LocalList>(
+            predicate: #Predicate { $0.needsSync == true }
+        ))
+
+        var body = SyncUpsertRequest()
+        body.noteFolders = pendingFolders.map(folderToRow)
+        body.todos = pendingTodos.map(todoToRow)
+        body.notes = pendingNotes.map(noteToRow)
+        body.lists = pendingLists.map(listToRow)
+
+        guard !body.isEmpty else { return }
+
         let response: SyncUpsertResponse = try await api.post("sync/upsert", body: body)
 
-        // Index local rows by clientUUID for fast lookup during apply.
-        var byUUID: [UUID: LocalTodo] = [:]
-        for row in pending { byUUID[row.clientUUID] = row }
+        var todosByUUID: [UUID: LocalTodo] = [:]
+        for r in pendingTodos { todosByUUID[r.clientUUID] = r }
+        var foldersByUUID: [UUID: LocalNoteFolder] = [:]
+        for r in pendingFolders { foldersByUUID[r.clientUUID] = r }
+        var notesByUUID: [UUID: LocalNote] = [:]
+        for r in pendingNotes { notesByUUID[r.clientUUID] = r }
+        var listsByUUID: [UUID: LocalList] = [:]
+        for r in pendingLists { listsByUUID[r.clientUUID] = r }
 
-        for serverDTO in response.applied.todos {
-            byUUID[serverDTO.id]?.applyServerState(serverDTO)
+        for dto in response.applied.todos { todosByUUID[dto.id]?.applyServerState(dto) }
+        for dto in response.applied.noteFolders { foldersByUUID[dto.id]?.applyServerState(dto) }
+        for dto in response.applied.notes { notesByUUID[dto.id]?.applyServerState(dto) }
+        for dto in response.applied.lists { listsByUUID[dto.id]?.applyServerState(dto) }
+
+        for r in response.rejected.todos {
+            if let server = r.serverRow { todosByUUID[r.clientUuid]?.applyServerState(server) }
         }
-        for rejection in response.rejected.todos {
-            if let serverRow = rejection.serverRow {
-                byUUID[rejection.clientUuid]?.applyServerState(serverRow)
-            }
-            // For non-server_newer rejections (missing fields, etc.), the
-            // local row keeps needsSync = true so the next push retries.
+        for r in response.rejected.noteFolders {
+            if let server = r.serverRow { foldersByUUID[r.clientUuid]?.applyServerState(server) }
+        }
+        for r in response.rejected.notes {
+            if let server = r.serverRow { notesByUUID[r.clientUuid]?.applyServerState(server) }
+        }
+        for r in response.rejected.lists {
+            if let server = r.serverRow { listsByUUID[r.clientUuid]?.applyServerState(server) }
         }
 
         try context.save()
         SyncWatermark.advance(to: response.maxVersion)
     }
 
+    private func todoToRow(_ row: LocalTodo) -> TodoUpsertRow {
+        TodoUpsertRow(
+            clientUuid: row.clientUUID,
+            title: row.title,
+            description: row.todoDescription,
+            completed: row.completed,
+            dueDate: row.dueDate,
+            tag: row.tag,
+            position: row.position,
+            deletedAt: row.deletedAt,
+            updatedAt: row.updatedAt
+        )
+    }
+
+    private func folderToRow(_ row: LocalNoteFolder) -> NoteFolderUpsertRow {
+        NoteFolderUpsertRow(
+            clientUuid: row.clientUUID,
+            name: row.name,
+            position: row.position,
+            deletedAt: row.deletedAt,
+            updatedAt: row.updatedAt
+        )
+    }
+
+    private func noteToRow(_ row: LocalNote) -> NoteUpsertRow {
+        NoteUpsertRow(
+            clientUuid: row.clientUUID,
+            folderClientUuid: row.folderClientUUID,
+            title: row.title,
+            content: row.content,
+            position: row.position,
+            deletedAt: row.deletedAt,
+            updatedAt: row.updatedAt
+        )
+    }
+
+    private func listToRow(_ row: LocalList) -> ListUpsertRow {
+        ListUpsertRow(
+            clientUuid: row.clientUUID,
+            title: row.title,
+            items: row.items,
+            position: row.position,
+            deletedAt: row.deletedAt,
+            updatedAt: row.updatedAt
+        )
+    }
+
     // MARK: - Pull
 
-    /// Fetch every server change with `version > watermark` and apply.
-    /// Inserts rows we don't have. Updates rows we do. Rows whose
-    /// `deleted_at` is not null are tombstones — the local row is deleted.
     func pullChanges() async throws {
         let watermark = SyncWatermark.current
         let path = "sync/changes"
@@ -104,9 +159,10 @@ final class SyncEngine {
         let response: SyncChangesResponse = try await api.get(path, query: query)
 
         let context = store.context
-        for incoming in response.todos {
-            try applyIncomingTodo(incoming, in: context)
-        }
+        for dto in response.noteFolders { try applyIncomingFolder(dto, in: context) }
+        for dto in response.todos { try applyIncomingTodo(dto, in: context) }
+        for dto in response.notes { try applyIncomingNote(dto, in: context) }
+        for dto in response.lists { try applyIncomingList(dto, in: context) }
         try context.save()
         SyncWatermark.advance(to: response.maxVersion)
     }
@@ -119,26 +175,10 @@ final class SyncEngine {
         let existing = try context.fetch(descriptor).first
 
         if let row = existing {
-            // Tombstone? Delete locally (only if local has no unsynced edits;
-            // otherwise the next push will conflict and the server response
-            // will overwrite us).
-            if dto.deletedAt != nil {
-                context.delete(row)
-                return
-            }
-            // Last-write-wins by updated_at: only adopt server state when
-            // the server's updated_at is newer than ours. If the local row
-            // has unpushed edits with a later updated_at, leave it alone —
-            // the next pushOutbox() will resolve the conflict.
-            if dto.updatedAt > row.updatedAt {
-                row.applyServerState(dto)
-            }
+            if dto.deletedAt != nil { context.delete(row); return }
+            if dto.updatedAt > row.updatedAt { row.applyServerState(dto) }
         } else {
-            if dto.deletedAt != nil {
-                // Tombstone for a row we never had locally. Skip.
-                return
-            }
-            // New row from server.
+            if dto.deletedAt != nil { return }
             let row = LocalTodo(
                 clientUUID: dto.id,
                 title: dto.title,
@@ -146,6 +186,87 @@ final class SyncEngine {
                 completed: dto.completed,
                 dueDate: dto.dueDate,
                 tag: dto.tag,
+                position: dto.position,
+                version: dto.version,
+                createdAt: dto.createdAt,
+                updatedAt: dto.updatedAt,
+                deletedAt: dto.deletedAt,
+                needsSync: false
+            )
+            context.insert(row)
+        }
+    }
+
+    private func applyIncomingFolder(_ dto: NoteFolder, in context: ModelContext) throws {
+        let uuid = dto.id
+        let descriptor = FetchDescriptor<LocalNoteFolder>(
+            predicate: #Predicate { $0.clientUUID == uuid }
+        )
+        let existing = try context.fetch(descriptor).first
+
+        if let row = existing {
+            if dto.deletedAt != nil { context.delete(row); return }
+            if dto.updatedAt > row.updatedAt { row.applyServerState(dto) }
+        } else {
+            if dto.deletedAt != nil { return }
+            let row = LocalNoteFolder(
+                clientUUID: dto.id,
+                name: dto.name,
+                position: dto.position,
+                version: dto.version,
+                createdAt: dto.createdAt,
+                updatedAt: dto.updatedAt,
+                deletedAt: dto.deletedAt,
+                needsSync: false
+            )
+            context.insert(row)
+        }
+    }
+
+    private func applyIncomingNote(_ dto: Note, in context: ModelContext) throws {
+        let uuid = dto.id
+        let descriptor = FetchDescriptor<LocalNote>(
+            predicate: #Predicate { $0.clientUUID == uuid }
+        )
+        let existing = try context.fetch(descriptor).first
+
+        if let row = existing {
+            if dto.deletedAt != nil { context.delete(row); return }
+            if dto.updatedAt > row.updatedAt { row.applyServerState(dto) }
+        } else {
+            if dto.deletedAt != nil { return }
+            let row = LocalNote(
+                clientUUID: dto.id,
+                folderClientUUID: dto.folderId,
+                title: dto.title,
+                content: dto.content,
+                position: dto.position,
+                version: dto.version,
+                createdAt: dto.createdAt,
+                updatedAt: dto.updatedAt,
+                deletedAt: dto.deletedAt,
+                needsSync: false
+            )
+            context.insert(row)
+        }
+    }
+
+    private func applyIncomingList(_ dto: Checklist, in context: ModelContext) throws {
+        let uuid = dto.id
+        let descriptor = FetchDescriptor<LocalList>(
+            predicate: #Predicate { $0.clientUUID == uuid }
+        )
+        let existing = try context.fetch(descriptor).first
+
+        if let row = existing {
+            if dto.deletedAt != nil { context.delete(row); return }
+            if dto.updatedAt > row.updatedAt { row.applyServerState(dto) }
+        } else {
+            if dto.deletedAt != nil { return }
+            let row = LocalList(
+                clientUUID: dto.id,
+                title: dto.title,
+                items: dto.items,
                 position: dto.position,
                 version: dto.version,
                 createdAt: dto.createdAt,

--- a/mobile/PersonalDashboard/Sync/SyncEngine.swift
+++ b/mobile/PersonalDashboard/Sync/SyncEngine.swift
@@ -1,0 +1,152 @@
+import Foundation
+import SwiftData
+
+/// Sync engine for the iOS local-first data layer (#14).
+///
+/// Two responsibilities:
+///   1. **Push**: drains LocalTodo rows where `needsSync == true`, posts
+///      them to `/api/sync/upsert`, and applies the server's response back
+///      into the store (so server-assigned id + version are stamped on).
+///   2. **Pull**: asks `/api/sync/changes?since_version=<watermark>` for any
+///      remote changes since last sync and applies them — including
+///      tombstones, which delete the matching LocalTodo locally.
+///
+/// `sync()` runs push then pull, which is the natural order: push local
+/// edits first so the pull doesn't fetch and overwrite them in flight.
+///
+/// All entry points are async + actor-isolated to MainActor because the
+/// SwiftData ModelContext is main-actor-only on iOS 17.
+@MainActor
+final class SyncEngine {
+    static let shared = SyncEngine(api: .shared, store: SwiftDataStore.shared)
+
+    let api: APIClient
+    let store: SwiftDataStore
+
+    init(api: APIClient, store: SwiftDataStore) {
+        self.api = api
+        self.store = store
+    }
+
+    /// Push pending local changes, then pull remote changes. Errors are
+    /// surfaced for the caller to display; the local store is unaffected
+    /// by transport failures so the next sync retries.
+    func sync() async throws {
+        try await pushOutbox()
+        try await pullChanges()
+    }
+
+    // MARK: - Push
+
+    /// Drain LocalTodo rows where needsSync == true. Build an upsert batch,
+    /// post it, then apply the response: applied rows adopt server state;
+    /// rejected rows (server_newer) adopt the server's row.
+    func pushOutbox() async throws {
+        let context = store.context
+        let descriptor = FetchDescriptor<LocalTodo>(
+            predicate: #Predicate { $0.needsSync == true }
+        )
+        let pending = try context.fetch(descriptor)
+        guard !pending.isEmpty else { return }
+
+        let rows = pending.map { todo in
+            TodoUpsertRow(
+                clientUuid: todo.clientUUID,
+                title: todo.title,
+                description: todo.todoDescription,
+                completed: todo.completed,
+                dueDate: todo.dueDate,
+                tag: todo.tag,
+                position: todo.position,
+                deletedAt: todo.deletedAt,
+                updatedAt: todo.updatedAt
+            )
+        }
+        let body = SyncUpsertRequest(todos: rows)
+        let response: SyncUpsertResponse = try await api.post("sync/upsert", body: body)
+
+        // Index local rows by clientUUID for fast lookup during apply.
+        var byUUID: [UUID: LocalTodo] = [:]
+        for row in pending { byUUID[row.clientUUID] = row }
+
+        for serverDTO in response.applied.todos {
+            byUUID[serverDTO.clientUuid]?.applyServerState(serverDTO)
+        }
+        for rejection in response.rejected.todos {
+            if let serverRow = rejection.serverRow {
+                byUUID[rejection.clientUuid]?.applyServerState(serverRow)
+            }
+            // For non-server_newer rejections (missing fields, etc.), the
+            // local row keeps needsSync = true so the next push retries.
+        }
+
+        try context.save()
+        SyncWatermark.advance(to: response.maxVersion)
+    }
+
+    // MARK: - Pull
+
+    /// Fetch every server change with `version > watermark` and apply.
+    /// Inserts rows we don't have. Updates rows we do. Rows whose
+    /// `deleted_at` is not null are tombstones — the local row is deleted.
+    func pullChanges() async throws {
+        let watermark = SyncWatermark.current
+        let path = "sync/changes"
+        let query = [URLQueryItem(name: "since_version", value: String(watermark))]
+        let response: SyncChangesResponse = try await api.get(path, query: query)
+
+        let context = store.context
+        for incoming in response.todos {
+            try applyIncomingTodo(incoming, in: context)
+        }
+        try context.save()
+        SyncWatermark.advance(to: response.maxVersion)
+    }
+
+    private func applyIncomingTodo(_ dto: Todo, in context: ModelContext) throws {
+        let uuid = dto.clientUuid
+        let descriptor = FetchDescriptor<LocalTodo>(
+            predicate: #Predicate { $0.clientUUID == uuid }
+        )
+        let existing = try context.fetch(descriptor).first
+
+        if let row = existing {
+            // Tombstone? Delete locally (only if local has no unsynced edits;
+            // otherwise the next push will conflict and the server response
+            // will overwrite us).
+            if dto.deletedAt != nil {
+                context.delete(row)
+                return
+            }
+            // Last-write-wins by updated_at: only adopt server state when
+            // the server's updated_at is newer than ours. If the local row
+            // has unpushed edits with a later updated_at, leave it alone —
+            // the next pushOutbox() will resolve the conflict.
+            if dto.updatedAt > row.updatedAt {
+                row.applyServerState(dto)
+            }
+        } else {
+            if dto.deletedAt != nil {
+                // Tombstone for a row we never had locally. Skip.
+                return
+            }
+            // New row from server.
+            let row = LocalTodo(
+                clientUUID: dto.clientUuid,
+                serverID: dto.id,
+                title: dto.title,
+                todoDescription: dto.description,
+                completed: dto.completed,
+                dueDate: dto.dueDate,
+                tag: dto.tag,
+                position: dto.position,
+                version: dto.version,
+                createdAt: dto.createdAt,
+                updatedAt: dto.updatedAt,
+                deletedAt: dto.deletedAt,
+                needsSync: false
+            )
+            context.insert(row)
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Sync/SyncWatermark.swift
+++ b/mobile/PersonalDashboard/Sync/SyncWatermark.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// UserDefaults-backed watermark for the sync engine. Stores the highest
+/// `version` the iOS client has seen from the server. The next pull asks
+/// `/api/sync/changes?since_version=<watermark>`.
+enum SyncWatermark {
+    private static let key = "sync.lastVersion.v1"
+
+    static var current: Int64 {
+        get { Int64(UserDefaults.standard.integer(forKey: key)) }
+        set { UserDefaults.standard.set(Int(newValue), forKey: key) }
+    }
+
+    /// Bump only if the new value is strictly greater. Safe to call from
+    /// concurrent push/pull paths.
+    static func advance(to candidate: Int64) {
+        if candidate > current {
+            current = candidate
+        }
+    }
+
+    /// Reset for tests or "log out + clear" flows.
+    static func reset() {
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+}

--- a/mobile/PersonalDashboard/Sync/SyncWireFormat.swift
+++ b/mobile/PersonalDashboard/Sync/SyncWireFormat.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Wire DTOs for the sync endpoints (`/api/sync/changes`, `/api/sync/upsert`).
+/// Names mirror the server JSON, so APIClient.decoder/encoder snake-case
+/// conversion does the rest.
+
+struct SyncChangesResponse: Decodable {
+    let todos: [Todo]
+    // Notes / lists / note_folders fields are present on the wire but iOS
+    // does not consume them yet (Phase 5/6). Decoded as a passthrough so
+    // the response still parses.
+    let maxVersion: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case todos
+        case maxVersion = "max_version"
+    }
+}
+
+/// Body for `POST /api/sync/upsert`. Each table is a separate array so the
+/// server can route per-table without inferring entity type.
+struct SyncUpsertRequest: Encodable {
+    var todos: [TodoUpsertRow]
+
+    enum CodingKeys: String, CodingKey {
+        case todos
+    }
+}
+
+/// One row in a sync upsert batch. Carries client_uuid + updated_at + the
+/// fields the client wants to write. nil-valued fields are omitted via the
+/// optional encoding so the server's schema-driven upsert leaves them alone.
+struct TodoUpsertRow: Encodable {
+    let clientUuid: UUID
+    let title: String?
+    let description: String?
+    let completed: Bool?
+    let dueDate: Date?
+    let tag: String?
+    let position: Int?
+    let deletedAt: Date?
+    let updatedAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case clientUuid = "client_uuid"
+        case title
+        case description
+        case completed
+        case dueDate = "due_date"
+        case tag
+        case position
+        case deletedAt = "deleted_at"
+        case updatedAt = "updated_at"
+    }
+}
+
+struct SyncUpsertResponse: Decodable {
+    let applied: AppliedRows
+    let rejected: RejectedRows
+    let maxVersion: Int64
+
+    struct AppliedRows: Decodable {
+        let todos: [Todo]
+    }
+
+    struct RejectedRows: Decodable {
+        let todos: [RejectedRow]
+    }
+
+    struct RejectedRow: Decodable {
+        let clientUuid: UUID
+        let reason: String
+        /// When the server wins, it returns the current row so the client
+        /// can adopt it without a separate GET.
+        let serverRow: Todo?
+
+        enum CodingKeys: String, CodingKey {
+            case clientUuid = "client_uuid"
+            case reason
+            case serverRow = "server_row"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case applied
+        case rejected
+        case maxVersion = "max_version"
+    }
+}

--- a/mobile/PersonalDashboard/Sync/SyncWireFormat.swift
+++ b/mobile/PersonalDashboard/Sync/SyncWireFormat.swift
@@ -13,13 +13,23 @@ import Foundation
 
 struct SyncChangesResponse: Decodable {
     let todos: [Todo]
+    let notes: [Note]
+    let lists: [Checklist]
+    let noteFolders: [NoteFolder]
     let maxVersion: Int64
 }
 
 /// Body for `POST /api/sync/upsert`. Each table is a separate array so the
 /// server can route per-table without inferring entity type.
 struct SyncUpsertRequest: Encodable {
-    var todos: [TodoUpsertRow]
+    var todos: [TodoUpsertRow] = []
+    var notes: [NoteUpsertRow] = []
+    var lists: [ListUpsertRow] = []
+    var noteFolders: [NoteFolderUpsertRow] = []
+
+    var isEmpty: Bool {
+        todos.isEmpty && notes.isEmpty && lists.isEmpty && noteFolders.isEmpty
+    }
 }
 
 /// One row in a sync upsert batch. Carries clientUuid + updatedAt + the
@@ -38,6 +48,35 @@ struct TodoUpsertRow: Encodable {
     let updatedAt: Date
 }
 
+struct NoteFolderUpsertRow: Encodable {
+    let clientUuid: UUID
+    let name: String?
+    let position: Int?
+    let deletedAt: Date?
+    let updatedAt: Date
+}
+
+struct NoteUpsertRow: Encodable {
+    let clientUuid: UUID
+    /// Maps to server's `folder_client_uuid`. Nil clears the folder
+    /// assignment (note becomes unfiled).
+    let folderClientUuid: UUID?
+    let title: String?
+    let content: String?
+    let position: Int?
+    let deletedAt: Date?
+    let updatedAt: Date
+}
+
+struct ListUpsertRow: Encodable {
+    let clientUuid: UUID
+    let title: String?
+    let items: [ChecklistItem]?
+    let position: Int?
+    let deletedAt: Date?
+    let updatedAt: Date
+}
+
 struct SyncUpsertResponse: Decodable {
     let applied: AppliedRows
     let rejected: RejectedRows
@@ -45,17 +84,23 @@ struct SyncUpsertResponse: Decodable {
 
     struct AppliedRows: Decodable {
         let todos: [Todo]
+        let notes: [Note]
+        let lists: [Checklist]
+        let noteFolders: [NoteFolder]
     }
 
     struct RejectedRows: Decodable {
-        let todos: [RejectedRow]
+        let todos: [RejectedRow<Todo>]
+        let notes: [RejectedRow<Note>]
+        let lists: [RejectedRow<Checklist>]
+        let noteFolders: [RejectedRow<NoteFolder>]
     }
 
-    struct RejectedRow: Decodable {
+    struct RejectedRow<Row: Decodable>: Decodable {
         let clientUuid: UUID
         let reason: String
         /// When the server wins, it returns the current row so the client
         /// can adopt it without a separate GET.
-        let serverRow: Todo?
+        let serverRow: Row?
     }
 }

--- a/mobile/PersonalDashboard/Sync/SyncWireFormat.swift
+++ b/mobile/PersonalDashboard/Sync/SyncWireFormat.swift
@@ -1,35 +1,31 @@
 import Foundation
 
 /// Wire DTOs for the sync endpoints (`/api/sync/changes`, `/api/sync/upsert`).
-/// Names mirror the server JSON, so APIClient.decoder/encoder snake-case
-/// conversion does the rest.
+///
+/// `APIClient.decoder` uses `.convertFromSnakeCase` and `APIClient.encoder`
+/// uses `.convertToSnakeCase`. With those strategies in place, snake_case
+/// keys on the server map automatically to camelCase property names — so
+/// these DTOs DELIBERATELY do not declare CodingKeys with explicit
+/// snake_case raw values. The strategy converts the JSON key first; the
+/// CodingKey lookup runs against the converted (camelCase) form, which
+/// means raw values like `"max_version"` would fail to match. Default
+/// CodingKeys are correct here.
 
 struct SyncChangesResponse: Decodable {
     let todos: [Todo]
-    // Notes / lists / note_folders fields are present on the wire but iOS
-    // does not consume them yet (Phase 5/6). Decoded as a passthrough so
-    // the response still parses.
     let maxVersion: Int64
-
-    enum CodingKeys: String, CodingKey {
-        case todos
-        case maxVersion = "max_version"
-    }
 }
 
 /// Body for `POST /api/sync/upsert`. Each table is a separate array so the
 /// server can route per-table without inferring entity type.
 struct SyncUpsertRequest: Encodable {
     var todos: [TodoUpsertRow]
-
-    enum CodingKeys: String, CodingKey {
-        case todos
-    }
 }
 
-/// One row in a sync upsert batch. Carries client_uuid + updated_at + the
-/// fields the client wants to write. nil-valued fields are omitted via the
-/// optional encoding so the server's schema-driven upsert leaves them alone.
+/// One row in a sync upsert batch. Carries clientUuid + updatedAt + the
+/// fields the client wants to write. nil-valued fields are omitted by
+/// default Encodable behaviour, which lets the server's schema-driven
+/// upsert leave them alone.
 struct TodoUpsertRow: Encodable {
     let clientUuid: UUID
     let title: String?
@@ -40,18 +36,6 @@ struct TodoUpsertRow: Encodable {
     let position: Int?
     let deletedAt: Date?
     let updatedAt: Date
-
-    enum CodingKeys: String, CodingKey {
-        case clientUuid = "client_uuid"
-        case title
-        case description
-        case completed
-        case dueDate = "due_date"
-        case tag
-        case position
-        case deletedAt = "deleted_at"
-        case updatedAt = "updated_at"
-    }
 }
 
 struct SyncUpsertResponse: Decodable {
@@ -73,17 +57,5 @@ struct SyncUpsertResponse: Decodable {
         /// When the server wins, it returns the current row so the client
         /// can adopt it without a separate GET.
         let serverRow: Todo?
-
-        enum CodingKeys: String, CodingKey {
-            case clientUuid = "client_uuid"
-            case reason
-            case serverRow = "server_row"
-        }
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case applied
-        case rejected
-        case maxVersion = "max_version"
     }
 }

--- a/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import SwiftData
 
 @Observable
 @MainActor
@@ -10,20 +11,30 @@ final class ListsViewModel {
 
     private let service: ChecklistService
 
-    init(service: ChecklistService = ChecklistService()) {
-        self.service = service
-        if let cached = CacheStore.load([Checklist].self, from: .lists) {
-            self.lists = cached
-        }
+    init(service: ChecklistService? = nil) {
+        let resolved = service ?? ChecklistService()
+        self.service = resolved
+
+        let descriptor = FetchDescriptor<LocalList>(
+            predicate: #Predicate { $0.deletedAt == nil },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        let rows = (try? resolved.store.context.fetch(descriptor)) ?? []
+        self.lists = rows.map { $0.toDTO() }
     }
 
-    func load() async {
+    func load(syncFirst: Bool = true) async {
         isLoading = true
         errorMessage = nil
+        if syncFirst {
+            do {
+                try await SyncEngine.shared.sync()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
         do {
-            let fresh = try await service.list()
-            lists = fresh
-            CacheStore.save(fresh, to: .lists)
+            lists = try await service.list()
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -43,7 +54,7 @@ final class ListsViewModel {
     func update(_ list: Checklist) async {
         do {
             let request = ChecklistUpdateRequest(title: list.title, items: list.items)
-            let updated = try await service.update(id: list.id, request)
+            let updated = try await service.update(list, request)
             if let index = lists.firstIndex(where: { $0.id == list.id }) {
                 lists[index] = updated
             }
@@ -89,7 +100,7 @@ final class ListsViewModel {
 
     func delete(_ list: Checklist) async {
         do {
-            try await service.delete(id: list.id)
+            try await service.delete(list)
             lists.removeAll { $0.id == list.id }
         } catch {
             errorMessage = error.localizedDescription

--- a/mobile/PersonalDashboard/ViewModels/NotesViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/NotesViewModel.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Observation
+import SwiftData
 
+/// View model for the Notes surface. Reads from SwiftData via NoteService;
+/// mutations land locally and trigger a background sync push.
 @Observable
 @MainActor
 final class NotesViewModel {
@@ -11,28 +14,39 @@ final class NotesViewModel {
 
     private let service: NoteService
 
-    init(service: NoteService = NoteService()) {
-        self.service = service
-        if let cachedFolders = CacheStore.load([NoteFolder].self, from: .noteFolders) {
-            self.folders = cachedFolders
-        }
-        if let cachedNotes = CacheStore.load([Note].self, from: .notes) {
-            self.notes = cachedNotes
-        }
+    init(service: NoteService? = nil) {
+        let resolved = service ?? NoteService()
+        self.service = resolved
+
+        let folderDescriptor = FetchDescriptor<LocalNoteFolder>(
+            predicate: #Predicate { $0.deletedAt == nil },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        let noteDescriptor = FetchDescriptor<LocalNote>(
+            predicate: #Predicate { $0.deletedAt == nil },
+            sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
+        )
+        let folderRows = (try? resolved.store.context.fetch(folderDescriptor)) ?? []
+        let noteRows = (try? resolved.store.context.fetch(noteDescriptor)) ?? []
+        self.folders = folderRows.map { $0.toDTO() }
+        self.notes = noteRows.map { $0.toDTO() }
     }
 
-    func load() async {
+    func load(syncFirst: Bool = true) async {
         isLoading = true
         errorMessage = nil
+        if syncFirst {
+            do {
+                try await SyncEngine.shared.sync()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
         do {
-            async let folders = service.listFolders()
-            async let notes = service.list()
-            let f = try await folders
-            let n = try await notes
-            self.folders = f
-            self.notes = n
-            CacheStore.save(f, to: .noteFolders)
-            CacheStore.save(n, to: .notes)
+            async let f = service.listFolders()
+            async let n = service.list()
+            self.folders = try await f
+            self.notes = try await n
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -57,7 +71,7 @@ final class NotesViewModel {
 
     func renameFolder(_ folder: NoteFolder, to name: String) async {
         do {
-            let updated = try await service.renameFolder(id: folder.id, name: name)
+            let updated = try await service.renameFolder(folder, to: name)
             if let index = folders.firstIndex(where: { $0.id == folder.id }) {
                 folders[index] = updated
             }
@@ -68,7 +82,7 @@ final class NotesViewModel {
 
     func deleteFolder(_ folder: NoteFolder) async {
         do {
-            try await service.deleteFolder(id: folder.id)
+            try await service.deleteFolder(folder)
             folders.removeAll { $0.id == folder.id }
             notes.removeAll { $0.folderId == folder.id }
         } catch {
@@ -76,7 +90,7 @@ final class NotesViewModel {
         }
     }
 
-    func createNote(title: String?, content: String?, folderId: Int? = nil) async -> Note? {
+    func createNote(title: String?, content: String?, folderId: UUID? = nil) async -> Note? {
         do {
             let request = NoteCreateRequest(title: title, content: content, folderId: folderId)
             let note = try await service.create(request)
@@ -88,10 +102,10 @@ final class NotesViewModel {
         }
     }
 
-    func updateNote(_ note: Note, title: String?, content: String?, folderId: Int?) async {
+    func updateNote(_ note: Note, title: String?, content: String?, folderId: UUID?) async {
         do {
             let request = NoteUpdateRequest(title: title, content: content, folderId: folderId)
-            let updated = try await service.update(id: note.id, request)
+            let updated = try await service.update(note, request)
             if let index = notes.firstIndex(where: { $0.id == note.id }) {
                 notes[index] = updated
             }
@@ -102,7 +116,7 @@ final class NotesViewModel {
 
     func deleteNote(_ note: Note) async {
         do {
-            try await service.delete(id: note.id)
+            try await service.delete(note)
             notes.removeAll { $0.id == note.id }
         } catch {
             errorMessage = error.localizedDescription

--- a/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Observation
+import SwiftData
 
+/// View model for the Tasks surface. Reads from the local SwiftData store
+/// (via `TodoService`) so the UI works whether or not the Mac is reachable.
+/// Mutations go to the local store immediately and trigger a background
+/// sync; the next refresh pulls back the canonical server state.
 @Observable
 @MainActor
 final class TodosViewModel {
@@ -10,20 +15,35 @@ final class TodosViewModel {
 
     private let service: TodoService
 
-    init(service: TodoService = TodoService()) {
-        self.service = service
-        if let cached = CacheStore.load([Todo].self, from: .todos) {
-            self.todos = cached
-        }
+    init(service: TodoService? = nil) {
+        let resolvedService = service ?? TodoService()
+        self.service = resolvedService
+        // First paint: read the local store synchronously so the surface
+        // never flashes empty. SwiftData's main-context fetch is synchronous.
+        let descriptor = FetchDescriptor<LocalTodo>(
+            predicate: #Predicate { $0.deletedAt == nil },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        let rows = (try? resolvedService.store.context.fetch(descriptor)) ?? []
+        self.todos = rows.map { $0.toDTO() }
     }
 
-    func load() async {
+    /// Refresh from the local store. Optionally triggers a sync first so
+    /// the local store catches up with the server before we re-render.
+    func load(syncFirst: Bool = true) async {
         isLoading = true
         errorMessage = nil
+        if syncFirst {
+            do {
+                try await SyncEngine.shared.sync()
+            } catch {
+                // Sync failure is non-fatal — the local store still has the
+                // last-known state. Surface the error but keep going.
+                errorMessage = error.localizedDescription
+            }
+        }
         do {
-            let fresh = try await service.list()
-            todos = fresh
-            CacheStore.save(fresh, to: .todos)
+            todos = try await service.list()
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -31,7 +51,7 @@ final class TodosViewModel {
     }
 
     func refresh() async {
-        await load()
+        await load(syncFirst: true)
     }
 
     func create(title: String, description: String? = nil, dueDate: Date? = nil, tag: String? = nil) async {
@@ -45,29 +65,15 @@ final class TodosViewModel {
     }
 
     func toggleCompleted(_ todo: Todo) async {
-        guard let index = todos.firstIndex(of: todo) else { return }
-        let optimistic = Todo(
-            id: todo.id,
-            clientUuid: todo.clientUuid,
-            title: todo.title,
-            description: todo.description,
-            completed: !todo.completed,
-            dueDate: todo.dueDate,
-            tag: todo.tag,
-            position: todo.position,
-            version: todo.version,
-            createdAt: todo.createdAt,
-            updatedAt: Date(),
-            deletedAt: todo.deletedAt
-        )
-        todos[index] = optimistic
+        guard let index = todos.firstIndex(where: { $0.id == todo.id }) else { return }
+        // Optimistic flip so the row animates immediately.
+        todos[index].completed.toggle()
         do {
             let updated = try await service.toggleCompleted(todo)
-            if let idx = todos.firstIndex(where: { $0.id == updated.id }) {
-                todos[idx] = updated
-            }
+            todos[index] = updated
         } catch {
-            todos[index] = todo
+            // Revert on failure.
+            todos[index].completed.toggle()
             errorMessage = error.localizedDescription
         }
     }
@@ -81,7 +87,7 @@ final class TodosViewModel {
                 dueDate: dueDate,
                 tag: tag
             )
-            let updated = try await service.update(id: todo.id, request)
+            let updated = try await service.update(todo, request)
             if let index = todos.firstIndex(where: { $0.id == todo.id }) {
                 todos[index] = updated
             }
@@ -91,10 +97,10 @@ final class TodosViewModel {
     }
 
     func delete(_ todo: Todo) async {
-        let originalIndex = todos.firstIndex(of: todo)
+        let originalIndex = todos.firstIndex(where: { $0.id == todo.id })
         todos.removeAll { $0.id == todo.id }
         do {
-            try await service.delete(id: todo.id)
+            try await service.delete(todo)
         } catch {
             errorMessage = error.localizedDescription
             if let idx = originalIndex {
@@ -103,3 +109,4 @@ final class TodosViewModel {
         }
     }
 }
+

--- a/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
@@ -48,11 +48,14 @@ final class TodosViewModel {
         guard let index = todos.firstIndex(of: todo) else { return }
         let optimistic = Todo(
             id: todo.id,
+            clientUuid: todo.clientUuid,
             title: todo.title,
             description: todo.description,
             completed: !todo.completed,
             dueDate: todo.dueDate,
             tag: todo.tag,
+            position: todo.position,
+            version: todo.version,
             createdAt: todo.createdAt,
             updatedAt: Date(),
             deletedAt: todo.deletedAt

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 struct ListsView: View {
     @State private var viewModel = ListsViewModel()
     @State private var showingNewList = false
-    @State private var selectedListId: Int? = {
-        if let raw = ProcessInfo.processInfo.environment["LAUNCH_LIST_ID"], let id = Int(raw) { return id }
+    @State private var selectedListId: UUID? = {
+        if let raw = ProcessInfo.processInfo.environment["LAUNCH_LIST_ID"], let id = UUID(uuidString: raw) { return id }
         return nil
     }()
 
@@ -190,7 +190,7 @@ private struct ListSummaryRow: View {
 
 private struct ListDetailContent: View {
     @Bindable var viewModel: ListsViewModel
-    let listId: Int
+    let listId: UUID
     @State private var newItemText: String = ""
 
     var body: some View {

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -3,10 +3,10 @@ import SwiftUI
 struct NotesView: View {
     @State private var viewModel = NotesViewModel()
     @State private var showingNewFolder = false
-    @State private var selectedNoteId: Int?
+    @State private var selectedNoteId: UUID?
     @State private var selectedFolder: NoteFolder?
-    @State private var pendingFolderLaunchId: Int? = {
-        if let raw = ProcessInfo.processInfo.environment["LAUNCH_FOLDER_ID"], let id = Int(raw) { return id }
+    @State private var pendingFolderLaunchId: UUID? = {
+        if let raw = ProcessInfo.processInfo.environment["LAUNCH_FOLDER_ID"], let id = UUID(uuidString: raw) { return id }
         return nil
     }()
 
@@ -204,7 +204,7 @@ struct NotesView: View {
         withAnimation(.easeOut(duration: 0.2)) { selectedNoteId = note.id }
     }
 
-    private func createBlankNote(folderId: Int?) async {
+    private func createBlankNote(folderId: UUID?) async {
         guard let new = await viewModel.createNote(title: nil, content: nil, folderId: folderId) else { return }
         withAnimation(.easeOut(duration: 0.2)) { selectedNoteId = new.id }
     }
@@ -327,7 +327,7 @@ private struct NoteDetailContent: View {
 
     @State private var title: String = ""
     @State private var content: String = ""
-    @State private var folderId: Int?
+    @State private var folderId: UUID?
     @State private var hasLoaded = false
     @FocusState private var contentFocused: Bool
 

--- a/server/db.js
+++ b/server/db.js
@@ -1,5 +1,13 @@
 require('dotenv').config();
-const { Pool } = require('pg');
+const { Pool, types } = require('pg');
+
+// Postgres BIGINT (OID 20) defaults to a string in JS to avoid precision
+// loss above Number.MAX_SAFE_INTEGER. Our use case for BIGINT is the
+// monotonic `sync_version_seq` which produces row versions — these stay
+// well within Int53 range, so parsing as Number keeps the wire format
+// consistent with the iOS Int64 expectation. If we ever introduce other
+// BIGINT columns at scale, revisit this per-column.
+types.setTypeParser(20, (val) => parseInt(val, 10));
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL,

--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,7 @@ const draftStore = require('./ai/draftStore');
 // v2 refactor helpers
 const { z } = require('zod');
 const { computeNewPosition } = require('./reorderHelpers');
+const { mountSyncRoutes } = require('./sync');
 const {
     DEFAULT_PREFERENCES,
     DEFAULT_WIDGETS,
@@ -148,6 +149,10 @@ const initDb = async () => {
         console.error('Error initializing database:', err);
     }
 };
+
+// Mount sync routes (iOS local-first data layer, #14). These live in their
+// own module to keep the wire format isolated from the legacy CRUD endpoints.
+mountSyncRoutes(app, db);
 
 // API Routes
 
@@ -383,7 +388,9 @@ app.post('/api/todos/:id/restore', async (req, res) => {
 // NOTE FOLDERS
 app.get('/api/note-folders', async (req, res) => {
     try {
-        const { rows } = await db.query('SELECT * FROM note_folders ORDER BY created_at DESC');
+        const { rows } = await db.query(
+            'SELECT * FROM note_folders WHERE deleted_at IS NULL ORDER BY created_at DESC'
+        );
         res.json(rows);
     } catch (err) {
         sendErrorResponse(res, err);
@@ -395,7 +402,7 @@ app.post('/api/note-folders', async (req, res) => {
         const { name } = req.body;
         const { rows } = await db.query(
             `INSERT INTO note_folders (name, position)
-             VALUES ($1, (SELECT COALESCE(MAX(position), 0) + 1000 FROM note_folders))
+             VALUES ($1, (SELECT COALESCE(MAX(position), 0) + 1000 FROM note_folders WHERE deleted_at IS NULL))
              RETURNING *`,
             [name]
         );
@@ -440,7 +447,22 @@ app.delete('/api/note-folders/:id', async (req, res) => {
         const { rows: folderRows } = await db.query('SELECT name FROM note_folders WHERE id = $1', [id]);
         const folderName = folderRows.length > 0 ? folderRows[0].name : null;
 
-        await db.query('DELETE FROM note_folders WHERE id = $1', [id]);
+        // Soft-delete the folder AND any notes inside it. Cascading the
+        // soft-delete to children means the iOS sync engine receives a
+        // tombstone per note, so local state correctly removes the whole
+        // subtree without orphaned references.
+        await db.withTransaction(async (client) => {
+            await client.query(
+                `UPDATE notes SET deleted_at = CURRENT_TIMESTAMP
+                 WHERE folder_id = $1 AND deleted_at IS NULL`,
+                [id]
+            );
+            await client.query(
+                `UPDATE note_folders SET deleted_at = CURRENT_TIMESTAMP
+                 WHERE id = $1 AND deleted_at IS NULL`,
+                [id]
+            );
+        });
 
         // Log folder deletion
         await logNoteHistory(parseInt(id), 'deleted', null, folderName, null, 'folder');
@@ -455,11 +477,11 @@ app.delete('/api/note-folders/:id', async (req, res) => {
 app.get('/api/notes', async (req, res) => {
     try {
         const { folder_id } = req.query;
-        let query = 'SELECT * FROM notes';
+        let query = 'SELECT * FROM notes WHERE deleted_at IS NULL';
         let params = [];
 
         if (folder_id) {
-            query += ' WHERE folder_id = $1';
+            query += ' AND folder_id = $1';
             params.push(folder_id);
         }
         query += ' ORDER BY updated_at DESC';
@@ -522,7 +544,7 @@ app.post('/api/notes', async (req, res) => {
             `INSERT INTO notes (title, content, folder_id, position, updated_at)
              VALUES ($1, $2, $3,
                      (SELECT COALESCE(MAX(position), 0) + 1000 FROM notes
-                      WHERE folder_id IS NOT DISTINCT FROM $3),
+                      WHERE folder_id IS NOT DISTINCT FROM $3 AND deleted_at IS NULL),
                      CURRENT_TIMESTAMP)
              RETURNING *`,
             [title, content, folderId]
@@ -600,7 +622,11 @@ app.delete('/api/notes/:id', async (req, res) => {
         const { rows: noteRows } = await db.query('SELECT title FROM notes WHERE id = $1', [id]);
         const noteTitle = noteRows.length > 0 ? noteRows[0].title : null;
 
-        await db.query('DELETE FROM notes WHERE id = $1', [id]);
+        await db.query(
+            `UPDATE notes SET deleted_at = CURRENT_TIMESTAMP
+             WHERE id = $1 AND deleted_at IS NULL`,
+            [id]
+        );
 
         // Log deletion
         await logNoteHistory(parseInt(id), 'deleted', null, noteTitle, null);
@@ -614,7 +640,9 @@ app.delete('/api/notes/:id', async (req, res) => {
 // LISTS
 app.get('/api/lists', async (req, res) => {
     try {
-        const { rows } = await db.query('SELECT * FROM lists ORDER BY created_at DESC');
+        const { rows } = await db.query(
+            'SELECT * FROM lists WHERE deleted_at IS NULL ORDER BY created_at DESC'
+        );
         res.json(rows);
     } catch (err) {
         sendErrorResponse(res, err);
@@ -662,7 +690,7 @@ app.post('/api/lists', async (req, res) => {
         const { title, items } = req.body;
         const { rows } = await db.query(
             `INSERT INTO lists (title, items, position)
-             VALUES ($1, $2, (SELECT COALESCE(MAX(position), 0) + 1000 FROM lists))
+             VALUES ($1, $2, (SELECT COALESCE(MAX(position), 0) + 1000 FROM lists WHERE deleted_at IS NULL))
              RETURNING *`,
             [title, JSON.stringify(items)]
         );
@@ -774,7 +802,11 @@ app.delete('/api/lists/:id', async (req, res) => {
         const { rows: listRows } = await db.query('SELECT title FROM lists WHERE id = $1', [id]);
         const listTitle = listRows.length > 0 ? listRows[0].title : null;
 
-        await db.query('DELETE FROM lists WHERE id = $1', [id]);
+        await db.query(
+            `UPDATE lists SET deleted_at = CURRENT_TIMESTAMP
+             WHERE id = $1 AND deleted_at IS NULL`,
+            [id]
+        );
 
         // Log deletion
         await logListHistory(parseInt(id), 'deleted', null, listTitle, null);

--- a/server/index.js
+++ b/server/index.js
@@ -134,10 +134,15 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 // Initialize Database Schema
+// schema.sql is the canonical fresh install; migration.sql is the cumulative
+// idempotent diff applied on top so existing DBs pick up new columns/triggers
+// without manual intervention. Both files must be safe to re-run on every boot.
 const initDb = async () => {
     try {
         const schema = fs.readFileSync(path.join(__dirname, 'schema.sql'), 'utf8');
         await db.query(schema);
+        const migration = fs.readFileSync(path.join(__dirname, 'migration.sql'), 'utf8');
+        await db.query(migration);
         console.log('Database initialized successfully');
     } catch (err) {
         console.error('Error initializing database:', err);

--- a/server/migration.sql
+++ b/server/migration.sql
@@ -188,3 +188,38 @@ CREATE INDEX IF NOT EXISTS todos_version_idx        ON todos (version);
 CREATE INDEX IF NOT EXISTS notes_version_idx        ON notes (version);
 CREATE INDEX IF NOT EXISTS lists_version_idx        ON lists (version);
 CREATE INDEX IF NOT EXISTS note_folders_version_idx ON note_folders (version);
+
+-- =============================================================================
+-- 2026-05-03: folder_client_uuid for note->folder linking by UUID (#14)
+-- =============================================================================
+-- iOS can create a folder offline AND a note inside that folder offline.
+-- Both rows arrive at the server in a single sync upsert batch. The note
+-- needs to reference the folder by something stable across the network,
+-- and the folder's integer id only exists after the server has persisted
+-- the folder. folder_client_uuid is the canonical link going forward;
+-- folder_id is kept in sync via the sync.js upsert handler so legacy
+-- callers that read folder_id keep working.
+
+ALTER TABLE notes ADD COLUMN IF NOT EXISTS folder_client_uuid UUID;
+
+-- Backfill from existing folder_id by joining note_folders.client_uuid.
+UPDATE notes n
+SET folder_client_uuid = f.client_uuid
+FROM note_folders f
+WHERE n.folder_id = f.id AND n.folder_client_uuid IS NULL;
+
+CREATE INDEX IF NOT EXISTS notes_folder_client_uuid_idx ON notes (folder_client_uuid);
+
+-- FK only after backfill is safe to add. Wrap in DO so re-runs are idempotent.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'notes_folder_client_uuid_fkey'
+    ) THEN
+        ALTER TABLE notes
+        ADD CONSTRAINT notes_folder_client_uuid_fkey
+        FOREIGN KEY (folder_client_uuid)
+        REFERENCES note_folders(client_uuid) ON DELETE CASCADE;
+    END IF;
+END $$;

--- a/server/migration.sql
+++ b/server/migration.sql
@@ -92,3 +92,99 @@ CREATE INDEX IF NOT EXISTS todos_position_idx        ON todos (position);
 CREATE INDEX IF NOT EXISTS lists_position_idx        ON lists (position);
 CREATE INDEX IF NOT EXISTS note_folders_position_idx ON note_folders (position);
 CREATE INDEX IF NOT EXISTS notes_folder_position_idx ON notes (folder_id, position);
+
+-- =============================================================================
+-- 2026-05-03: Sync metadata for iOS local-first data layer (#14)
+-- =============================================================================
+-- Adds a global monotonic sync-version sequence, plus per-row `version`,
+-- `client_uuid`, `updated_at`, and `deleted_at` columns to todos, notes, lists,
+-- and note_folders so the iOS SwiftData store can do delta sync. A BEFORE
+-- UPDATE trigger on each table bumps version + updated_at on every UPDATE so
+-- application code does not have to remember to set them. client_uuid lets the
+-- phone create rows offline with a stable identity that the server adopts on
+-- first sync.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, conditional UNIQUE constraint, ALTER
+-- COLUMN SET NOT NULL only after backfill, DROP TRIGGER IF EXISTS before
+-- recreating. Re-running the script is a no-op once applied.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE SEQUENCE IF NOT EXISTS sync_version_seq;
+
+ALTER TABLE todos        ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT nextval('sync_version_seq');
+ALTER TABLE notes        ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT nextval('sync_version_seq');
+ALTER TABLE lists        ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT nextval('sync_version_seq');
+ALTER TABLE note_folders ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT nextval('sync_version_seq');
+
+ALTER TABLE todos        ADD COLUMN IF NOT EXISTS client_uuid UUID;
+ALTER TABLE notes        ADD COLUMN IF NOT EXISTS client_uuid UUID;
+ALTER TABLE lists        ADD COLUMN IF NOT EXISTS client_uuid UUID;
+ALTER TABLE note_folders ADD COLUMN IF NOT EXISTS client_uuid UUID;
+
+UPDATE todos        SET client_uuid = gen_random_uuid() WHERE client_uuid IS NULL;
+UPDATE notes        SET client_uuid = gen_random_uuid() WHERE client_uuid IS NULL;
+UPDATE lists        SET client_uuid = gen_random_uuid() WHERE client_uuid IS NULL;
+UPDATE note_folders SET client_uuid = gen_random_uuid() WHERE client_uuid IS NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'todos_client_uuid_key') THEN
+        ALTER TABLE todos ADD CONSTRAINT todos_client_uuid_key UNIQUE (client_uuid);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'notes_client_uuid_key') THEN
+        ALTER TABLE notes ADD CONSTRAINT notes_client_uuid_key UNIQUE (client_uuid);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lists_client_uuid_key') THEN
+        ALTER TABLE lists ADD CONSTRAINT lists_client_uuid_key UNIQUE (client_uuid);
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'note_folders_client_uuid_key') THEN
+        ALTER TABLE note_folders ADD CONSTRAINT note_folders_client_uuid_key UNIQUE (client_uuid);
+    END IF;
+END $$;
+
+ALTER TABLE todos        ALTER COLUMN client_uuid SET NOT NULL;
+ALTER TABLE notes        ALTER COLUMN client_uuid SET NOT NULL;
+ALTER TABLE lists        ALTER COLUMN client_uuid SET NOT NULL;
+ALTER TABLE note_folders ALTER COLUMN client_uuid SET NOT NULL;
+
+ALTER TABLE todos        ALTER COLUMN client_uuid SET DEFAULT gen_random_uuid();
+ALTER TABLE notes        ALTER COLUMN client_uuid SET DEFAULT gen_random_uuid();
+ALTER TABLE lists        ALTER COLUMN client_uuid SET DEFAULT gen_random_uuid();
+ALTER TABLE note_folders ALTER COLUMN client_uuid SET DEFAULT gen_random_uuid();
+
+ALTER TABLE notes        ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP DEFAULT NULL;
+ALTER TABLE lists        ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP DEFAULT NULL;
+ALTER TABLE note_folders ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP DEFAULT NULL;
+
+ALTER TABLE lists        ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE note_folders ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+CREATE OR REPLACE FUNCTION bump_sync_metadata() RETURNS trigger AS $$
+BEGIN
+    NEW.version := nextval('sync_version_seq');
+    NEW.updated_at := CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS todos_bump_sync ON todos;
+CREATE TRIGGER todos_bump_sync BEFORE UPDATE ON todos
+    FOR EACH ROW EXECUTE FUNCTION bump_sync_metadata();
+
+DROP TRIGGER IF EXISTS notes_bump_sync ON notes;
+CREATE TRIGGER notes_bump_sync BEFORE UPDATE ON notes
+    FOR EACH ROW EXECUTE FUNCTION bump_sync_metadata();
+
+DROP TRIGGER IF EXISTS lists_bump_sync ON lists;
+CREATE TRIGGER lists_bump_sync BEFORE UPDATE ON lists
+    FOR EACH ROW EXECUTE FUNCTION bump_sync_metadata();
+
+DROP TRIGGER IF EXISTS note_folders_bump_sync ON note_folders;
+CREATE TRIGGER note_folders_bump_sync BEFORE UPDATE ON note_folders
+    FOR EACH ROW EXECUTE FUNCTION bump_sync_metadata();
+
+CREATE INDEX IF NOT EXISTS todos_version_idx        ON todos (version);
+CREATE INDEX IF NOT EXISTS notes_version_idx        ON notes (version);
+CREATE INDEX IF NOT EXISTS lists_version_idx        ON lists (version);
+CREATE INDEX IF NOT EXISTS note_folders_version_idx ON note_folders (version);

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -1,11 +1,23 @@
+-- gen_random_uuid() ships with core Postgres 13+, but pgcrypto is a safe shim
+-- for older builds. Idempotent; CREATE EXTENSION IF NOT EXISTS is a no-op when
+-- the function is already in core.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Global monotonic sync version sequence. Every UPDATE on a synced table bumps
+-- the row's `version` to nextval(). The iOS sync engine watermarks on the max
+-- version it has seen and asks the server for everything newer in one call.
+CREATE SEQUENCE IF NOT EXISTS sync_version_seq;
+
 CREATE TABLE IF NOT EXISTS todos (
     id SERIAL PRIMARY KEY,
+    client_uuid UUID UNIQUE DEFAULT gen_random_uuid(),
     title TEXT NOT NULL,
     description TEXT,
     completed BOOLEAN DEFAULT FALSE,
     due_date TIMESTAMP,
     tag TEXT,
     position INTEGER, -- ordering for drag-to-reorder; NULL allowed so legacy inserts still work
+    version BIGINT NOT NULL DEFAULT nextval('sync_version_seq'),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     deleted_at TIMESTAMP DEFAULT NULL
@@ -57,21 +69,28 @@ END $$;
 
 CREATE TABLE IF NOT EXISTS note_folders (
     id SERIAL PRIMARY KEY,
+    client_uuid UUID UNIQUE DEFAULT gen_random_uuid(),
     name TEXT NOT NULL,
     position INTEGER, -- ordering for drag-to-reorder; NULL allowed so legacy inserts still work
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    version BIGINT NOT NULL DEFAULT nextval('sync_version_seq'),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP DEFAULT NULL
 );
 
 CREATE INDEX IF NOT EXISTS note_folders_position_idx ON note_folders (position);
 
 CREATE TABLE IF NOT EXISTS notes (
     id SERIAL PRIMARY KEY,
+    client_uuid UUID UNIQUE DEFAULT gen_random_uuid(),
     folder_id INTEGER REFERENCES note_folders(id) ON DELETE CASCADE,
     title TEXT,
     content TEXT,
     position INTEGER, -- ordering within a folder (or unfiled scope when folder_id IS NULL)
+    version BIGINT NOT NULL DEFAULT nextval('sync_version_seq'),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP DEFAULT NULL
 );
 
 CREATE INDEX IF NOT EXISTS notes_folder_position_idx ON notes (folder_id, position);
@@ -89,10 +108,14 @@ END $$;
 
 CREATE TABLE IF NOT EXISTS lists (
     id SERIAL PRIMARY KEY,
+    client_uuid UUID UNIQUE DEFAULT gen_random_uuid(),
     title TEXT NOT NULL,
     items JSONB DEFAULT '[]',
     position INTEGER, -- ordering for drag-to-reorder; NULL allowed so legacy inserts still work
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    version BIGINT NOT NULL DEFAULT nextval('sync_version_seq'),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP DEFAULT NULL
 );
 
 CREATE INDEX IF NOT EXISTS lists_position_idx ON lists (position);
@@ -155,3 +178,39 @@ CREATE TABLE IF NOT EXISTS ai_messages (
     response_id TEXT, -- OpenAI response ID for debugging
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- =============================================================================
+-- Sync metadata triggers
+-- =============================================================================
+-- Each synced table has a BEFORE UPDATE trigger that bumps `version` to the
+-- next value of `sync_version_seq` and refreshes `updated_at`. The iOS sync
+-- engine uses `version` as the sole watermark for delta pulls.
+
+CREATE OR REPLACE FUNCTION bump_sync_metadata() RETURNS trigger AS $$
+BEGIN
+    NEW.version := nextval('sync_version_seq');
+    NEW.updated_at := CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS todos_bump_sync ON todos;
+CREATE TRIGGER todos_bump_sync BEFORE UPDATE ON todos
+    FOR EACH ROW EXECUTE FUNCTION bump_sync_metadata();
+
+DROP TRIGGER IF EXISTS notes_bump_sync ON notes;
+CREATE TRIGGER notes_bump_sync BEFORE UPDATE ON notes
+    FOR EACH ROW EXECUTE FUNCTION bump_sync_metadata();
+
+DROP TRIGGER IF EXISTS lists_bump_sync ON lists;
+CREATE TRIGGER lists_bump_sync BEFORE UPDATE ON lists
+    FOR EACH ROW EXECUTE FUNCTION bump_sync_metadata();
+
+DROP TRIGGER IF EXISTS note_folders_bump_sync ON note_folders;
+CREATE TRIGGER note_folders_bump_sync BEFORE UPDATE ON note_folders
+    FOR EACH ROW EXECUTE FUNCTION bump_sync_metadata();
+
+CREATE INDEX IF NOT EXISTS todos_version_idx        ON todos (version);
+CREATE INDEX IF NOT EXISTS notes_version_idx        ON notes (version);
+CREATE INDEX IF NOT EXISTS lists_version_idx        ON lists (version);
+CREATE INDEX IF NOT EXISTS note_folders_version_idx ON note_folders (version);

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -84,6 +84,7 @@ CREATE TABLE IF NOT EXISTS notes (
     id SERIAL PRIMARY KEY,
     client_uuid UUID UNIQUE DEFAULT gen_random_uuid(),
     folder_id INTEGER REFERENCES note_folders(id) ON DELETE CASCADE,
+    folder_client_uuid UUID REFERENCES note_folders(client_uuid) ON DELETE CASCADE,
     title TEXT,
     content TEXT,
     position INTEGER, -- ordering within a folder (or unfiled scope when folder_id IS NULL)

--- a/server/sync.js
+++ b/server/sync.js
@@ -1,0 +1,205 @@
+/**
+ * Sync endpoints for the iOS local-first data layer (#14).
+ *
+ * Two endpoints:
+ *
+ *   GET  /api/sync/changes?since_version=N
+ *     Returns every row across todos, notes, lists, and note_folders whose
+ *     `version` is strictly greater than `since_version`. Includes
+ *     soft-deleted rows so the iOS engine receives tombstones and can prune
+ *     local state. Response includes `max_version`, the new watermark the
+ *     client should pass on the next pull.
+ *
+ *   POST /api/sync/upsert
+ *     Accepts a batch of changes from the client keyed by `client_uuid`.
+ *     For each row:
+ *       - If no row with this client_uuid exists on the server, INSERT.
+ *       - If a row exists and the server's updated_at is OLDER than the
+ *         client's, UPDATE (client wins).
+ *       - If a row exists and the server's updated_at is NEWER, REJECT
+ *         (server wins; client should adopt server's row on next pull).
+ *
+ * Conflict policy: last-write-wins by `updated_at`. The trigger
+ * `bump_sync_metadata()` handles version + updated_at on every UPDATE so
+ * application code does not need to set them.
+ */
+
+const TABLES = ['todos', 'notes', 'lists', 'note_folders'];
+
+// Schemas describe which columns a client may upsert per table. id and
+// auto-managed columns (version, created_at, updated_at) are NOT in this list.
+// `deleted_at` is allowed so a client can submit a soft-delete intent.
+const TABLE_SCHEMAS = {
+    todos: ['title', 'description', 'completed', 'due_date', 'tag', 'position', 'deleted_at'],
+    notes: ['title', 'content', 'folder_id', 'position', 'deleted_at'],
+    lists: ['title', 'items', 'position', 'deleted_at'],
+    note_folders: ['name', 'position', 'deleted_at'],
+};
+
+/**
+ * GET /api/sync/changes?since_version=N
+ * Returns the delta across all synced tables.
+ */
+async function handleChanges(req, res, db) {
+    const since = Number.parseInt(req.query.since_version, 10);
+    const sinceVersion = Number.isFinite(since) && since >= 0 ? since : 0;
+
+    try {
+        const result = {};
+        let maxVersion = sinceVersion;
+
+        for (const table of TABLES) {
+            const { rows } = await db.query(
+                `SELECT * FROM ${table} WHERE version > $1 ORDER BY version ASC`,
+                [sinceVersion]
+            );
+            result[table] = rows;
+            for (const row of rows) {
+                const v = Number(row.version);
+                if (v > maxVersion) maxVersion = v;
+            }
+        }
+
+        result.max_version = maxVersion;
+        res.json(result);
+    } catch (err) {
+        console.error('[SYNC] /changes failed:', err);
+        res.status(500).json({ error: err.message });
+    }
+}
+
+/**
+ * POST /api/sync/upsert
+ * Body: { todos?: [...], notes?: [...], lists?: [...], note_folders?: [...] }
+ * Each row must include client_uuid + updated_at. Other columns may be omitted.
+ */
+async function handleUpsert(req, res, db) {
+    const body = req.body || {};
+    const result = {
+        applied: { todos: [], notes: [], lists: [], note_folders: [] },
+        rejected: { todos: [], notes: [], lists: [], note_folders: [] },
+        max_version: 0,
+    };
+
+    try {
+        await db.withTransaction(async (client) => {
+            for (const table of TABLES) {
+                const incoming = Array.isArray(body[table]) ? body[table] : [];
+                for (const row of incoming) {
+                    if (!row || !row.client_uuid) {
+                        result.rejected[table].push({ client_uuid: row?.client_uuid ?? null, reason: 'missing_client_uuid' });
+                        continue;
+                    }
+                    if (!row.updated_at) {
+                        result.rejected[table].push({ client_uuid: row.client_uuid, reason: 'missing_updated_at' });
+                        continue;
+                    }
+
+                    const { rows: existingRows } = await client.query(
+                        `SELECT * FROM ${table} WHERE client_uuid = $1`,
+                        [row.client_uuid]
+                    );
+
+                    if (existingRows.length === 0) {
+                        // INSERT path. Build column list from schema, only
+                        // including keys present on the incoming row.
+                        const cols = ['client_uuid'];
+                        const vals = [row.client_uuid];
+                        for (const col of TABLE_SCHEMAS[table]) {
+                            if (Object.prototype.hasOwnProperty.call(row, col)) {
+                                cols.push(col);
+                                vals.push(serializeValue(table, col, row[col]));
+                            }
+                        }
+                        const placeholders = vals.map((_, i) => `$${i + 1}`).join(', ');
+                        const { rows: inserted } = await client.query(
+                            `INSERT INTO ${table} (${cols.join(', ')}) VALUES (${placeholders}) RETURNING *`,
+                            vals
+                        );
+                        result.applied[table].push(inserted[0]);
+                    } else {
+                        // UPDATE path with last-write-wins conflict check.
+                        const server = existingRows[0];
+                        const serverUpdated = new Date(server.updated_at).getTime();
+                        const clientUpdated = new Date(row.updated_at).getTime();
+
+                        if (Number.isNaN(clientUpdated)) {
+                            result.rejected[table].push({ client_uuid: row.client_uuid, reason: 'invalid_updated_at' });
+                            continue;
+                        }
+
+                        if (serverUpdated >= clientUpdated) {
+                            // Server wins. Return the current server row so
+                            // the client adopts it on this round-trip without
+                            // needing a follow-up GET.
+                            result.rejected[table].push({
+                                client_uuid: row.client_uuid,
+                                reason: 'server_newer',
+                                server_row: server,
+                            });
+                            continue;
+                        }
+
+                        // Client wins: build SET clause from schema-allowed keys.
+                        const sets = [];
+                        const vals = [];
+                        for (const col of TABLE_SCHEMAS[table]) {
+                            if (Object.prototype.hasOwnProperty.call(row, col)) {
+                                sets.push(`${col} = $${vals.length + 1}`);
+                                vals.push(serializeValue(table, col, row[col]));
+                            }
+                        }
+                        if (sets.length === 0) {
+                            // Nothing to update; treat as applied with no diff.
+                            result.applied[table].push(server);
+                            continue;
+                        }
+                        vals.push(row.client_uuid);
+                        const { rows: updated } = await client.query(
+                            `UPDATE ${table} SET ${sets.join(', ')} WHERE client_uuid = $${vals.length} RETURNING *`,
+                            vals
+                        );
+                        result.applied[table].push(updated[0]);
+                    }
+                }
+            }
+        });
+
+        // Compute max_version across applied rows.
+        for (const table of TABLES) {
+            for (const row of result.applied[table]) {
+                const v = Number(row.version);
+                if (v > result.max_version) result.max_version = v;
+            }
+            for (const reject of result.rejected[table]) {
+                if (reject.server_row) {
+                    const v = Number(reject.server_row.version);
+                    if (v > result.max_version) result.max_version = v;
+                }
+            }
+        }
+
+        res.json(result);
+    } catch (err) {
+        console.error('[SYNC] /upsert failed:', err);
+        res.status(500).json({ error: err.message });
+    }
+}
+
+/**
+ * Some columns need explicit serialization (JSONB, dates).
+ */
+function serializeValue(table, column, value) {
+    if (value === null || value === undefined) return null;
+    if (table === 'lists' && column === 'items') {
+        return typeof value === 'string' ? value : JSON.stringify(value);
+    }
+    return value;
+}
+
+function mountSyncRoutes(app, db) {
+    app.get('/api/sync/changes', (req, res) => handleChanges(req, res, db));
+    app.post('/api/sync/upsert', (req, res) => handleUpsert(req, res, db));
+}
+
+module.exports = { mountSyncRoutes, TABLES, TABLE_SCHEMAS };

--- a/server/sync.js
+++ b/server/sync.js
@@ -24,14 +24,23 @@
  * application code does not need to set them.
  */
 
-const TABLES = ['todos', 'notes', 'lists', 'note_folders'];
+// Order matters for /api/sync/upsert: note_folders must be processed
+// BEFORE notes so an offline-created folder + offline-created note can
+// be upserted in the same batch and the note's folder_client_uuid
+// resolves to a row that already exists.
+const TABLES = ['note_folders', 'todos', 'notes', 'lists'];
 
 // Schemas describe which columns a client may upsert per table. id and
 // auto-managed columns (version, created_at, updated_at) are NOT in this list.
 // `deleted_at` is allowed so a client can submit a soft-delete intent.
+//
+// Notes use folder_client_uuid (UUID) as the canonical FK going forward.
+// folder_id (server int) is derived inside the upsert handler so legacy
+// readers that join by folder_id keep working without iOS having to know
+// the server's integer ids.
 const TABLE_SCHEMAS = {
     todos: ['title', 'description', 'completed', 'due_date', 'tag', 'position', 'deleted_at'],
-    notes: ['title', 'content', 'folder_id', 'position', 'deleted_at'],
+    notes: ['title', 'content', 'folder_client_uuid', 'position', 'deleted_at'],
     lists: ['title', 'items', 'position', 'deleted_at'],
     note_folders: ['name', 'position', 'deleted_at'],
 };
@@ -95,6 +104,30 @@ async function handleUpsert(req, res, db) {
                         continue;
                     }
 
+                    // For notes, derive folder_id (server int) from
+                    // folder_client_uuid so legacy GET /api/notes (which
+                    // joins by folder_id) keeps working. The note row
+                    // itself stores both columns; folder_client_uuid is
+                    // the canonical link.
+                    if (table === 'notes' && Object.prototype.hasOwnProperty.call(row, 'folder_client_uuid')) {
+                        if (row.folder_client_uuid === null) {
+                            row.folder_id = null;
+                        } else {
+                            const { rows: folderRows } = await client.query(
+                                `SELECT id FROM note_folders WHERE client_uuid = $1`,
+                                [row.folder_client_uuid]
+                            );
+                            if (folderRows.length === 0) {
+                                result.rejected[table].push({
+                                    client_uuid: row.client_uuid,
+                                    reason: 'folder_not_found',
+                                });
+                                continue;
+                            }
+                            row.folder_id = folderRows[0].id;
+                        }
+                    }
+
                     const { rows: existingRows } = await client.query(
                         `SELECT * FROM ${table} WHERE client_uuid = $1`,
                         [row.client_uuid]
@@ -105,7 +138,10 @@ async function handleUpsert(req, res, db) {
                         // including keys present on the incoming row.
                         const cols = ['client_uuid'];
                         const vals = [row.client_uuid];
-                        for (const col of TABLE_SCHEMAS[table]) {
+                        const insertableCols = [...TABLE_SCHEMAS[table]];
+                        // Notes also write folder_id (derived above).
+                        if (table === 'notes') insertableCols.push('folder_id');
+                        for (const col of insertableCols) {
                             if (Object.prototype.hasOwnProperty.call(row, col)) {
                                 cols.push(col);
                                 vals.push(serializeValue(table, col, row[col]));
@@ -143,7 +179,9 @@ async function handleUpsert(req, res, db) {
                         // Client wins: build SET clause from schema-allowed keys.
                         const sets = [];
                         const vals = [];
-                        for (const col of TABLE_SCHEMAS[table]) {
+                        const updatableCols = [...TABLE_SCHEMAS[table]];
+                        if (table === 'notes') updatableCols.push('folder_id');
+                        for (const col of updatableCols) {
                             if (Object.prototype.hasOwnProperty.call(row, col)) {
                                 sets.push(`${col} = $${vals.length + 1}`);
                                 vals.push(serializeValue(table, col, row[col]));

--- a/server/tests/sync-endpoints.test.js
+++ b/server/tests/sync-endpoints.test.js
@@ -1,0 +1,201 @@
+/**
+ * Sync endpoint tests for #14.
+ *
+ * Spins up the real Express app against the test DB and exercises:
+ *   GET /api/sync/changes?since_version=N
+ *     - returns rows with version > N across all four synced tables
+ *     - reports a max_version watermark the client can use next
+ *     - includes soft-deleted rows so deletes propagate
+ *
+ *   POST /api/sync/upsert
+ *     - INSERTs a new row keyed by client_uuid
+ *     - UPDATEs an existing row when client's updated_at is newer
+ *     - REJECTs (server wins) when server's updated_at is newer; returns
+ *       the server's row in the rejection so the client can adopt it
+ */
+
+const { test, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { pool, applySchema, applyMigration, resetDb, close } = require('./helpers');
+
+let server;
+let baseUrl;
+
+before(async () => {
+    await applySchema();
+    await applyMigration();
+    const { app } = require('../index');
+    server = http.createServer(app);
+    await new Promise((resolve) => server.listen(0, resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+});
+
+beforeEach(async () => {
+    await resetDb();
+});
+
+after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await close();
+});
+
+async function fetchJSON(method, path, body) {
+    const url = baseUrl + path;
+    const opts = {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+    };
+    const res = await fetch(url, body !== undefined ? { ...opts, body: JSON.stringify(body) } : opts);
+    const text = await res.text();
+    return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+test('GET /api/sync/changes returns rows with version > since_version', async () => {
+    // Seed three rows directly so they have known initial versions.
+    await pool.query(`INSERT INTO todos (title) VALUES ('alpha'), ('bravo'), ('charlie')`);
+
+    const { status, body } = await fetchJSON('GET', '/api/sync/changes?since_version=0');
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.todos.length, 3);
+    assert.ok(body.max_version > 0);
+
+    // Watermark on the second row's version: should return only the third.
+    const sortedVersions = body.todos.map((t) => Number(t.version)).sort((a, b) => a - b);
+    const second = sortedVersions[1];
+    const after = await fetchJSON('GET', `/api/sync/changes?since_version=${second}`);
+    assert.strictEqual(after.body.todos.length, 1);
+    assert.ok(Number(after.body.todos[0].version) > second);
+});
+
+test('GET /api/sync/changes includes soft-deleted rows as tombstones', async () => {
+    const { rows } = await pool.query(`INSERT INTO notes (title) VALUES ('alpha') RETURNING *`);
+    const note = rows[0];
+
+    // Soft-delete via the actual DELETE endpoint, which now updates deleted_at.
+    const del = await fetchJSON('DELETE', `/api/notes/${note.id}`);
+    assert.strictEqual(del.status, 204);
+
+    const { body } = await fetchJSON('GET', '/api/sync/changes?since_version=0');
+    assert.strictEqual(body.notes.length, 1);
+    assert.ok(body.notes[0].deleted_at !== null, 'deleted_at must be present on the tombstone');
+});
+
+test('POST /api/sync/upsert INSERTs a new row keyed by client_uuid', async () => {
+    const clientUuid = '11111111-1111-4111-8111-111111111111';
+    const { status, body } = await fetchJSON('POST', '/api/sync/upsert', {
+        todos: [{
+            client_uuid: clientUuid,
+            title: 'from-iphone',
+            completed: false,
+            updated_at: new Date().toISOString(),
+        }],
+    });
+    assert.strictEqual(status, 200);
+    assert.strictEqual(body.applied.todos.length, 1);
+    assert.strictEqual(body.applied.todos[0].title, 'from-iphone');
+    assert.strictEqual(body.applied.todos[0].client_uuid, clientUuid);
+
+    const { rows } = await pool.query(
+        `SELECT * FROM todos WHERE client_uuid = $1`,
+        [clientUuid]
+    );
+    assert.strictEqual(rows.length, 1);
+});
+
+test('POST /api/sync/upsert UPDATEs when client updated_at is newer', async () => {
+    const { rows } = await pool.query(`INSERT INTO todos (title) VALUES ('original') RETURNING *`);
+    const todo = rows[0];
+
+    // Wait so the new updated_at is strictly greater.
+    await new Promise((r) => setTimeout(r, 30));
+    const newer = new Date(Date.now() + 60_000).toISOString();
+    const { body } = await fetchJSON('POST', '/api/sync/upsert', {
+        todos: [{
+            client_uuid: todo.client_uuid,
+            title: 'edited-on-phone',
+            updated_at: newer,
+        }],
+    });
+    assert.strictEqual(body.applied.todos.length, 1);
+    assert.strictEqual(body.applied.todos[0].title, 'edited-on-phone');
+    assert.strictEqual(body.rejected.todos.length, 0);
+});
+
+test('POST /api/sync/upsert REJECTs when server updated_at is newer (server wins)', async () => {
+    const { rows } = await pool.query(`INSERT INTO todos (title) VALUES ('original') RETURNING *`);
+    const todo = rows[0];
+
+    // Bump server side via a real UPDATE (trigger refreshes updated_at).
+    await new Promise((r) => setTimeout(r, 30));
+    await pool.query(`UPDATE todos SET title = 'edited-on-mac' WHERE id = $1`, [todo.id]);
+
+    // Client's updated_at is the OLD value, so server should win.
+    const { body } = await fetchJSON('POST', '/api/sync/upsert', {
+        todos: [{
+            client_uuid: todo.client_uuid,
+            title: 'stale-from-phone',
+            updated_at: todo.updated_at,
+        }],
+    });
+
+    assert.strictEqual(body.applied.todos.length, 0);
+    assert.strictEqual(body.rejected.todos.length, 1);
+    assert.strictEqual(body.rejected.todos[0].reason, 'server_newer');
+    assert.strictEqual(body.rejected.todos[0].server_row.title, 'edited-on-mac');
+
+    // Verify DB still has the server's value.
+    const { rows: after } = await pool.query(`SELECT title FROM todos WHERE id = $1`, [todo.id]);
+    assert.strictEqual(after[0].title, 'edited-on-mac');
+});
+
+test('POST /api/sync/upsert can submit a soft-delete intent via deleted_at', async () => {
+    const { rows } = await pool.query(`INSERT INTO lists (title) VALUES ('groceries') RETURNING *`);
+    const list = rows[0];
+
+    await new Promise((r) => setTimeout(r, 30));
+    const newer = new Date(Date.now() + 60_000).toISOString();
+    const { body } = await fetchJSON('POST', '/api/sync/upsert', {
+        lists: [{
+            client_uuid: list.client_uuid,
+            deleted_at: newer,
+            updated_at: newer,
+        }],
+    });
+
+    assert.strictEqual(body.applied.lists.length, 1);
+    assert.ok(body.applied.lists[0].deleted_at !== null);
+
+    // GET /api/lists must NOT return it any longer.
+    const { body: listsBody } = await fetchJSON('GET', '/api/lists');
+    assert.strictEqual(listsBody.length, 0);
+});
+
+test('POST /api/sync/upsert handles multiple tables in one batch', async () => {
+    const { body } = await fetchJSON('POST', '/api/sync/upsert', {
+        todos: [{
+            client_uuid: '22222222-2222-4222-8222-222222222222',
+            title: 't1',
+            updated_at: new Date().toISOString(),
+        }],
+        notes: [{
+            client_uuid: '33333333-3333-4333-8333-333333333333',
+            title: 'n1',
+            content: 'hello',
+            updated_at: new Date().toISOString(),
+        }],
+        lists: [{
+            client_uuid: '44444444-4444-4444-8444-444444444444',
+            title: 'l1',
+            items: [{ text: 'milk', checked: false }],
+            updated_at: new Date().toISOString(),
+        }],
+    });
+
+    assert.strictEqual(body.applied.todos.length, 1);
+    assert.strictEqual(body.applied.notes.length, 1);
+    assert.strictEqual(body.applied.lists.length, 1);
+    assert.ok(body.max_version > 0);
+});

--- a/server/tests/sync-metadata.test.js
+++ b/server/tests/sync-metadata.test.js
@@ -1,0 +1,112 @@
+/**
+ * Sync metadata tests.
+ *
+ * Confirms the schema additions for the iOS local-first data layer (#14):
+ *   - every synced row gets a non-null `version` and `client_uuid` on insert
+ *   - UPDATE bumps `version` to a strictly greater value
+ *   - UPDATE refreshes `updated_at` automatically (trigger handles it)
+ *   - `version` is globally monotonic across todos/notes/lists/note_folders
+ *   - `deleted_at` exists on all four tables and defaults to NULL
+ */
+
+const { test, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+const { pool, applySchema, applyMigration, resetDb, close } = require('./helpers');
+
+before(async () => {
+    await applySchema();
+    await applyMigration();
+});
+
+beforeEach(async () => {
+    await resetDb();
+});
+
+after(async () => {
+    await close();
+});
+
+test('insert assigns version and client_uuid automatically', async () => {
+    const { rows } = await pool.query(
+        `INSERT INTO todos (title) VALUES ('alpha') RETURNING *`
+    );
+    const todo = rows[0];
+    assert.ok(todo.version > 0, 'version should be a positive number');
+    assert.ok(todo.client_uuid, 'client_uuid should be populated');
+    assert.match(
+        String(todo.client_uuid),
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+        'client_uuid should look like a UUID'
+    );
+    assert.strictEqual(todo.deleted_at, null);
+});
+
+test('UPDATE bumps version monotonically and refreshes updated_at', async () => {
+    const { rows: insertRows } = await pool.query(
+        `INSERT INTO todos (title) VALUES ('alpha') RETURNING *`
+    );
+    const before = insertRows[0];
+
+    // Wait 50ms so updated_at has a chance to differ.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const { rows: updateRows } = await pool.query(
+        `UPDATE todos SET title = 'alpha-edited' WHERE id = $1 RETURNING *`,
+        [before.id]
+    );
+    const after = updateRows[0];
+
+    assert.ok(after.version > before.version, 'version must strictly increase on update');
+    assert.ok(
+        new Date(after.updated_at).getTime() >= new Date(before.updated_at).getTime(),
+        'updated_at must be at least the original'
+    );
+    assert.strictEqual(after.client_uuid, before.client_uuid, 'client_uuid is stable across updates');
+});
+
+test('version is globally monotonic across todos, notes, lists, folders', async () => {
+    const t = await pool.query(`INSERT INTO todos (title) VALUES ('a') RETURNING version`);
+    const f = await pool.query(`INSERT INTO note_folders (name) VALUES ('inbox') RETURNING version, id`);
+    const n = await pool.query(
+        `INSERT INTO notes (title, folder_id) VALUES ('note', $1) RETURNING version`,
+        [f.rows[0].id]
+    );
+    const l = await pool.query(`INSERT INTO lists (title) VALUES ('groceries') RETURNING version`);
+
+    const versions = [t.rows[0].version, f.rows[0].version, n.rows[0].version, l.rows[0].version].map(Number);
+    const sorted = [...versions].sort((a, b) => a - b);
+    // Each insert must have produced a strictly greater version than the previous one.
+    for (let i = 1; i < sorted.length; i++) {
+        assert.ok(sorted[i] > sorted[i - 1], `version[${i}] (${sorted[i]}) must be > version[${i-1}] (${sorted[i-1]})`);
+    }
+});
+
+test('soft-delete columns exist and default to null on every synced table', async () => {
+    const tables = ['todos', 'notes', 'lists', 'note_folders'];
+    for (const tbl of tables) {
+        const { rows } = await pool.query(
+            `SELECT column_name, is_nullable
+             FROM information_schema.columns
+             WHERE table_name = $1 AND column_name = 'deleted_at'`,
+            [tbl]
+        );
+        assert.strictEqual(rows.length, 1, `${tbl} should have a deleted_at column`);
+        assert.strictEqual(rows[0].is_nullable, 'YES', `${tbl}.deleted_at should be nullable`);
+    }
+});
+
+test('client_uuid is unique across rows in the same table', async () => {
+    const a = await pool.query(`INSERT INTO todos (title) VALUES ('a') RETURNING client_uuid`);
+    const b = await pool.query(`INSERT INTO todos (title) VALUES ('b') RETURNING client_uuid`);
+    assert.notStrictEqual(a.rows[0].client_uuid, b.rows[0].client_uuid);
+
+    // Forcing the same client_uuid must fail.
+    await assert.rejects(
+        pool.query(
+            `INSERT INTO todos (title, client_uuid) VALUES ('c', $1)`,
+            [a.rows[0].client_uuid]
+        ),
+        /duplicate key|unique/i
+    );
+});


### PR DESCRIPTION
## Summary

Closes #14. Makes the iOS app fully usable for todos, notes, checklists, and folders when the Mac is off. Reads come from a SwiftData store on the device; every mutation lands locally with a \`needsSync\` flag and is pushed to the server in the background. Pulls fetch deltas keyed on a global monotonic version watermark.

- **Server**: per-row \`version\` (global \`sync_version_seq\`) + \`client_uuid\` + \`deleted_at\` across todos, notes, lists, note_folders. New \`/api/sync/changes\` and \`/api/sync/upsert\` endpoints with last-write-wins by \`updated_at\`. Notes carry \`folder_client_uuid\` so iOS can link offline-created notes to offline-created folders by UUID. Notes/lists/folders switched to soft-delete; folder delete soft-cascades to child notes.
- **iOS**: \`LocalTodo\` / \`LocalNoteFolder\` / \`LocalNote\` / \`LocalList\` SwiftData models keyed on \`clientUUID\`. \`SyncEngine\` does push-then-pull in one round-trip across all four entity types. View models hydrate from SwiftData synchronously on init for first-paint, then refresh after sync settles. Identity is UUID across the network so locally-created rows render correctly before they have ever reached the server.
- **CacheStore retired** for entity CRUD — it survives only for the dashboard-stats payload, which is a derived/aggregated view that needs the network anyway.

## Test plan

- [x] \`cd server && npm test\` — 53/53 green (including new sync metadata + sync endpoint tests)
- [x] Simulator (iPhone 17 Pro): launch hydrates SwiftData end-to-end (12 todos, 8 notes, 3 folders, 6 lists in dev DB) with no decode errors. \`[SyncEngine] sync() begin → pushOutbox done → pullChanges done\` confirmed via NSLog.
- [x] iOS device install + launch verified by user (Tasks page renders todos from local store).
- [ ] **Device QA on iPhone 16 Pro Max (cabled)**:
  - [ ] Tasks: airplane-mode add / edit / complete / delete a todo. Reconnect. Watch sync settle on web.
  - [ ] Notes: same flow with a folder + note pair created offline.
  - [ ] Lists: same flow.
  - [ ] Power Mac fully off (server + Postgres). Repeat any of the above. Data persists locally; no errors.
  - [ ] Force-kill the app. Reopen. Data is intact (proves SwiftData, not the JSON cache, is authoritative).

## Notes

- Schema additions are additive + idempotent. \`migration.sql\` is now run alongside \`schema.sql\` on server boot per the convention already documented in CLAUDE.md.
- Conflict policy: last-write-wins by \`updated_at\`. Edge case (same row edited concurrently on web + iOS while offline) accepts the loss and is documented.
- \`folder_id\` is kept on \`notes\` and synced with \`folder_client_uuid\` so legacy server-side callers (e.g. AI capture, chat draft confirmation) keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)