### PR TITLE
fix(ios): bump sync watermark key for rehydration after #14 upgrade

### DIFF
--- a/mobile/PersonalDashboard/Sync/SyncWatermark.swift
+++ b/mobile/PersonalDashboard/Sync/SyncWatermark.swift
@@ -4,7 +4,12 @@ import Foundation
 /// `version` the iOS client has seen from the server. The next pull asks
 /// `/api/sync/changes?since_version=<watermark>`.
 enum SyncWatermark {
-    private static let key = "sync.lastVersion.v1"
+    // Bumped to v2 when notes/lists/folders joined the SwiftData store —
+    // previously-installed builds had a high watermark from todos-only
+    // pulls, so the new build was asking the server for "changes since N"
+    // and missing the historical notes/lists rows. v2 forces a single
+    // full re-pull on first launch after upgrade.
+    private static let key = "sync.lastVersion.v2"
 
     static var current: Int64 {
         get { Int64(UserDefaults.standard.integer(forKey: key)) }


### PR DESCRIPTION
## Summary

Hotfix on top of #17. After the merge, devices that already had the previous build (todos-only schema) had their SyncWatermark UserDefault sitting at a high version from the todos-pull cycles. The new build's first launch then asked the server for "changes since N" — and the historical notes / lists / folders rows had versions below N, so they never made it into SwiftData. Result: Notes and Lists pages came up empty until the user typed something new.

Bumping the watermark key to v2 forces a single full re-pull on first launch after upgrade. Idempotent across existing rows.

## Test plan

- [x] iPhone 17 Pro simulator: clean install (uninstall + install) lands 12 todos / 8 notes / 3 folders / 6 lists in SwiftData on first launch
- [x] iPhone 16 Pro Max: install over previous build, Notes + Lists tabs now populate without the user creating a new row

🤖 Generated with [Claude Code](https://claude.com/claude-code)