### PR TITLE
feat(capture): autonomous shortcut/App Intent capture for every draft type

### DIFF
--- a/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
@@ -1,24 +1,21 @@
 import AppIntents
 import Foundation
 
-/// Adds a task / note / list to the personal dashboard from a free-text or
-/// dictated phrase, without opening the app.
+/// Adds a task / note / list (or edits one) on the personal dashboard from
+/// a free-text or dictated phrase, without opening the app.
 ///
-/// Wired into Shortcuts so the iPhone Action Button (or back-tap / Lock
-/// Screen / Siri) can trigger:
+/// Wired into Shortcuts so the iPhone Action Button (or back-tap, Lock
+/// Screen, Siri) can trigger:
 ///   Dictate Text -> CaptureToDashboard(input: $dictation) -> Show Notification
 ///
-/// The server's smart auto-confirm rule decides what happens to the input:
-///   - one CREATE_TODO/NOTE/LIST draft -> created and persisted, dialog
-///     reports what was added.
-///   - multiple drafts or any edit/delete draft -> left pending, dialog
-///     asks the user to open Dashboard to confirm.
-///   - LLM follow-up question -> dialog surfaces the question, nothing
-///     persisted.
+/// Server behaviour: every draft the LLM produces from the dictated input
+/// is auto-executed. Single create, multi-create, add-to-list, edit, even
+/// delete — all run autonomously. The dialog reports what changed, item by
+/// item, so the user gets confirmation without opening the app.
 struct CaptureToDashboardIntent: AppIntent {
     static var title: LocalizedStringResource = "Capture to Dashboard"
     static var description = IntentDescription(
-        "Add a task, note, or list to your dashboard from text or voice. Nothing risky is auto-saved — edits and multi-item captures are queued for review in the app."
+        "Add or update a task, note, or list on your dashboard from text or voice. Runs autonomously — the dictated phrase is parsed and applied without opening the app."
     )
 
     /// Stay backgrounded so the side button feels instant and the user
@@ -32,7 +29,7 @@ struct CaptureToDashboardIntent: AppIntent {
     /// prompts the user with the keyboard.
     @Parameter(
         title: "Capture",
-        description: "What you want to add — for example 'remind me to call John tomorrow at 3' or 'note: book ideas — Lisbon, Tokyo'.",
+        description: "What you want to add or change — for example 'remind me to call John tomorrow at 3', 'add milk and eggs to my groceries list', 'mark the dentist task as done'.",
         requestValueDialog: "What do you want to capture?"
     )
     var input: String
@@ -57,37 +54,79 @@ struct CaptureToDashboardIntent: AppIntent {
         }
 
         switch response.status {
-        case .created:
-            let summary = Self.createdDialog(for: response.created ?? [])
+        case .executed:
+            let summary = Self.executedDialog(executed: response.executed ?? [], failed: response.failed ?? [])
             return .result(dialog: IntentDialog(stringLiteral: summary))
         case .needsClarification:
             let q = response.followUpQuestion ?? "I need a bit more detail."
             return .result(dialog: IntentDialog(stringLiteral: q))
-        case .needsReview:
-            let count = response.pendingDrafts?.count ?? 0
-            let plural = count == 1 ? "item" : "items"
-            return .result(dialog: IntentDialog(stringLiteral:
-                "Drafted \(count) \(plural) — open Dashboard to review and confirm."
-            ))
         case .error:
             let first = response.errors?.first?.message ?? "something went wrong"
             return .result(dialog: IntentDialog(stringLiteral: "Couldn't capture — \(first)"))
         }
     }
 
-    private static func createdDialog(for items: [CapturedItem]) -> String {
-        guard let item = items.first else { return "Captured." }
-        let typeLabel: String
-        switch item.type {
-        case "todo": typeLabel = "task"
-        case "note": typeLabel = "note"
-        case "list": typeLabel = "list"
-        default: typeLabel = item.type
+    // MARK: - Dialog builder
+
+    private static func executedDialog(executed: [ExecutedDraft], failed: [FailedDraft]) -> String {
+        let lines = executed.map(sentence(for:))
+        var text: String
+        switch lines.count {
+        case 0: text = "Nothing to apply."
+        case 1: text = lines[0]
+        default: text = lines.joined(separator: " ")
         }
-        if let due = item.dueDate {
-            return "Added \(typeLabel) \"\(item.title)\" — due \(Self.dueFormatter.string(from: due))."
+        if !failed.isEmpty {
+            let plural = failed.count == 1 ? "item" : "items"
+            text += " (\(failed.count) \(plural) couldn't be applied.)"
         }
-        return "Added \(typeLabel) \"\(item.title)\"."
+        return text
+    }
+
+    private static func sentence(for item: ExecutedDraft) -> String {
+        let title = item.title ?? ""
+        switch (item.type, item.action) {
+        case ("todo", "created"):
+            if let due = item.dueDate {
+                return "Added task \"\(title)\" — due \(dueFormatter.string(from: due))."
+            }
+            return "Added task \"\(title)\"."
+        case ("todo", "completed"):
+            return "Marked \"\(title)\" complete."
+        case ("todo", "reopened"):
+            return "Reopened \"\(title)\"."
+        case ("todo", "updated"):
+            return "Updated task \"\(title)\"."
+        case ("todo", "deleted"):
+            return "Deleted task \"\(title)\"."
+        case ("note", "created"):
+            return "Added note \"\(title)\"."
+        case ("note", "updated"):
+            return "Updated note \"\(title)\"."
+        case ("note", "deleted"):
+            return "Deleted note \"\(title)\"."
+        case ("list", "created"):
+            return "Created list \"\(title)\"."
+        case ("list", "items_added"):
+            if let added = item.addedNames, !added.isEmpty {
+                return "Added \(added) to \"\(title)\"."
+            }
+            return "Added items to \"\(title)\"."
+        case ("list", "item_updated"):
+            return "Updated an item in \"\(title)\"."
+        case ("list", "item_removed"):
+            return "Removed an item from \"\(title)\"."
+        case ("list", "updated"):
+            return "Updated list \"\(title)\"."
+        case ("list", "deleted"):
+            return "Deleted list \"\(title)\"."
+        case ("folder", "updated"):
+            return "Renamed folder \"\(title)\"."
+        case ("folder", "deleted"):
+            return "Deleted folder \"\(title)\"."
+        default:
+            return "Done."
+        }
     }
 
     private static let dueFormatter: DateFormatter = {

--- a/mobile/PersonalDashboard/Services/CaptureService.swift
+++ b/mobile/PersonalDashboard/Services/CaptureService.swift
@@ -6,17 +6,30 @@ struct CaptureRequest: Encodable {
     let timezone: String?
 }
 
-struct CapturedItem: Decodable, Sendable {
+/// Server's per-draft summary after auto-execution. The same shape covers
+/// creates, updates, deletes, and add-to-list intents — `action` tells the
+/// dialog builder which sentence to emit.
+struct ExecutedDraft: Decodable, Sendable {
     let type: String
-    let title: String
+    let action: String
     let id: Int
+    let title: String?
     let dueDate: Date?
+    let addedNames: String?
 }
 
-struct PendingDraftSummary: Decodable, Sendable {
+struct FailedDraft: Decodable, Sendable {
     let id: Int
-    let type: String
-    let title: String
+    let actionType: String
+    let title: String?
+    let reason: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case actionType
+        case title
+        case reason
+    }
 }
 
 struct CaptureErrorEntry: Decodable, Sendable {
@@ -26,15 +39,14 @@ struct CaptureErrorEntry: Decodable, Sendable {
 
 struct CaptureResponse: Decodable, Sendable {
     let status: Status
-    let created: [CapturedItem]?
-    let pendingDrafts: [PendingDraftSummary]?
+    let executed: [ExecutedDraft]?
+    let failed: [FailedDraft]?
     let assistantText: String?
     let followUpQuestion: String?
     let errors: [CaptureErrorEntry]?
 
     enum Status: String, Decodable, Sendable {
-        case created
-        case needsReview = "needs_review"
+        case executed
         case needsClarification = "needs_clarification"
         case error
     }

--- a/server/ai/executeDraftAction.js
+++ b/server/ai/executeDraftAction.js
@@ -1,0 +1,282 @@
+/**
+ * Execute a draft action server-side.
+ *
+ * Used by /api/ai/execute (chat confirm flow), /api/drafts/:id/confirm, and
+ * /api/ai/capture (App Intent / Shortcut path that auto-executes everything).
+ *
+ * Throws DraftExecutionError on validation problems (missing entity, bad
+ * input). Callers translate those into HTTP responses or AppIntent dialog
+ * text. Throwing keeps the helper free of res/req coupling.
+ *
+ * Returns: {
+ *   result,            // raw row returned by the SQL RETURNING clause
+ *   resultEntityId,    // server's integer id (used by draftStore.confirmDraft)
+ *   summary: { type, title, id, action, dueDate? }
+ * }
+ *
+ * `summary` is shaped for human-friendly dialog rendering — the App Intent
+ * builds its spoken response from it ("Added 'milk' to Groceries", etc.).
+ */
+
+class DraftExecutionError extends Error {
+    constructor(message, { status = 400 } = {}) {
+        super(message);
+        this.name = 'DraftExecutionError';
+        this.status = status;
+    }
+}
+
+async function executeDraftAction(draft, draftData, deps) {
+    const { db, logTodoHistory, logNoteHistory, logListHistory } = deps;
+
+    let result;
+    let resultEntityId;
+    let summary;
+
+    switch (draft.action_type) {
+        // ========== CREATE OPERATIONS ==========
+        case 'CREATE_TODO': {
+            const { rows } = await db.query(
+                'INSERT INTO todos (title, description, due_date, tag) VALUES ($1, $2, $3, $4) RETURNING *',
+                [draftData.title, draftData.description || null, draftData.due_date || null, draftData.tag || null]
+            );
+            result = rows[0];
+            resultEntityId = result.id;
+            await logTodoHistory(result.id, 'created', null, null, JSON.stringify(draftData));
+            summary = { type: 'todo', action: 'created', id: result.id, title: draftData.title, dueDate: result.due_date || null };
+            break;
+        }
+
+        case 'CREATE_NOTE': {
+            const { rows } = await db.query(
+                'INSERT INTO notes (title, content, folder_id) VALUES ($1, $2, $3) RETURNING *',
+                [draftData.title, draftData.content, draftData.folder_id || null]
+            );
+            result = rows[0];
+            resultEntityId = result.id;
+            await logNoteHistory(result.id, 'created', null, null, JSON.stringify(draftData));
+            summary = { type: 'note', action: 'created', id: result.id, title: draftData.title || '' };
+            break;
+        }
+
+        case 'CREATE_LIST': {
+            const items = Array.isArray(draftData.items)
+                ? draftData.items.map(item => typeof item === 'string' ? { text: item, checked: false } : item)
+                : [];
+            const { rows } = await db.query(
+                'INSERT INTO lists (title, items) VALUES ($1, $2) RETURNING *',
+                [draftData.title, JSON.stringify(items)]
+            );
+            result = rows[0];
+            resultEntityId = result.id;
+            await logListHistory(result.id, 'created', null, null, JSON.stringify(draftData));
+            summary = { type: 'list', action: 'created', id: result.id, title: draftData.title };
+            break;
+        }
+
+        // ========== UPDATE OPERATIONS ==========
+        case 'COMPLETE_TODO': {
+            const { rows } = await db.query(
+                'UPDATE todos SET completed = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2 RETURNING *',
+                [draftData.completed, draftData.id]
+            );
+            if (rows.length === 0) throw new DraftExecutionError('Task not found', { status: 404 });
+            result = rows[0];
+            resultEntityId = result.id;
+            await logTodoHistory(result.id, draftData.completed ? 'completed' : 'uncompleted', 'completed', !draftData.completed, draftData.completed);
+            summary = { type: 'todo', action: draftData.completed ? 'completed' : 'reopened', id: result.id, title: result.title };
+            break;
+        }
+
+        case 'UPDATE_TODO': {
+            const updates = [];
+            const values = [];
+            let p = 1;
+            if (draftData.title !== undefined) { updates.push(`title = $${p++}`); values.push(draftData.title); }
+            if (draftData.description !== undefined) { updates.push(`description = $${p++}`); values.push(draftData.description); }
+            if (draftData.due_date !== undefined) { updates.push(`due_date = $${p++}`); values.push(draftData.due_date); }
+            if (draftData.tag !== undefined) { updates.push(`tag = $${p++}`); values.push(draftData.tag); }
+            if (updates.length === 0) throw new DraftExecutionError('No fields to update');
+            values.push(draftData.id);
+            const { rows } = await db.query(
+                `UPDATE todos SET ${updates.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = $${p} AND deleted_at IS NULL RETURNING *`,
+                values
+            );
+            if (rows.length === 0) throw new DraftExecutionError('Task not found', { status: 404 });
+            result = rows[0];
+            resultEntityId = result.id;
+            await logTodoHistory(result.id, 'updated', null, null, JSON.stringify(draftData));
+            summary = { type: 'todo', action: 'updated', id: result.id, title: result.title };
+            break;
+        }
+
+        case 'UPDATE_NOTE': {
+            const updates = [];
+            const values = [];
+            let p = 1;
+            if (draftData.title !== undefined) { updates.push(`title = $${p++}`); values.push(draftData.title); }
+            if (draftData.content !== undefined) { updates.push(`content = $${p++}`); values.push(draftData.content); }
+            if (draftData.folder_id !== undefined) { updates.push(`folder_id = $${p++}`); values.push(draftData.folder_id); }
+            if (updates.length === 0) throw new DraftExecutionError('No fields to update');
+            values.push(draftData.id);
+            const { rows } = await db.query(
+                `UPDATE notes SET ${updates.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = $${p} RETURNING *`,
+                values
+            );
+            if (rows.length === 0) throw new DraftExecutionError('Note not found', { status: 404 });
+            result = rows[0];
+            resultEntityId = result.id;
+            await logNoteHistory(result.id, 'updated', null, null, JSON.stringify(draftData));
+            summary = { type: 'note', action: 'updated', id: result.id, title: result.title || '' };
+            break;
+        }
+
+        case 'UPDATE_LIST': {
+            const updates = [];
+            const values = [];
+            let p = 1;
+            if (draftData.title !== undefined) { updates.push(`title = $${p++}`); values.push(draftData.title); }
+            if (draftData.items !== undefined) { updates.push(`items = $${p++}`); values.push(JSON.stringify(draftData.items)); }
+            if (updates.length === 0) throw new DraftExecutionError('No fields to update');
+            values.push(draftData.id);
+            const { rows } = await db.query(
+                `UPDATE lists SET ${updates.join(', ')} WHERE id = $${p} RETURNING *`,
+                values
+            );
+            if (rows.length === 0) throw new DraftExecutionError('List not found', { status: 404 });
+            result = rows[0];
+            resultEntityId = result.id;
+            await logListHistory(result.id, 'updated', null, null, JSON.stringify(draftData));
+            summary = { type: 'list', action: 'updated', id: result.id, title: result.title };
+            break;
+        }
+
+        case 'ADD_TO_LIST': {
+            const { rows: existing } = await db.query('SELECT * FROM lists WHERE id = $1 AND deleted_at IS NULL', [draftData.id]);
+            if (existing.length === 0) throw new DraftExecutionError('List not found', { status: 404 });
+            const currentItems = typeof existing[0].items === 'string' ? JSON.parse(existing[0].items) : (existing[0].items || []);
+            const newItemsRaw = Array.isArray(draftData.new_items) ? draftData.new_items : [];
+            const normalised = newItemsRaw.map(item => typeof item === 'string' ? { text: item, checked: false } : item);
+            const merged = [...currentItems, ...normalised];
+            const { rows } = await db.query('UPDATE lists SET items = $1 WHERE id = $2 RETURNING *', [JSON.stringify(merged), draftData.id]);
+            result = rows[0];
+            resultEntityId = result.id;
+            await logListHistory(result.id, 'updated', null, null, JSON.stringify({ added_items: normalised }));
+            const addedNames = normalised.map(i => i.text).filter(Boolean).join(', ');
+            summary = { type: 'list', action: 'items_added', id: result.id, title: result.title, addedNames };
+            break;
+        }
+
+        case 'UPDATE_LIST_ITEM': {
+            const { rows: listRows } = await db.query('SELECT * FROM lists WHERE id = $1 AND deleted_at IS NULL', [draftData.list_id]);
+            if (listRows.length === 0) throw new DraftExecutionError('List not found', { status: 404 });
+            const items = typeof listRows[0].items === 'string' ? JSON.parse(listRows[0].items) : (listRows[0].items || []);
+            if (draftData.item_index >= items.length) throw new DraftExecutionError('Item index out of range');
+            const oldItem = { ...items[draftData.item_index] };
+            if (draftData.text !== undefined && draftData.text.trim()) {
+                items[draftData.item_index].text = draftData.text;
+            }
+            if (draftData.checked !== undefined) {
+                items[draftData.item_index].completed = draftData.checked;
+                items[draftData.item_index].completedAt = draftData.checked ? new Date().toISOString() : null;
+            }
+            const { rows } = await db.query('UPDATE lists SET items = $1 WHERE id = $2 RETURNING *', [JSON.stringify(items), draftData.list_id]);
+            result = rows[0];
+            resultEntityId = result.id;
+            await logListHistory(result.id, 'updated', 'item', JSON.stringify(oldItem), JSON.stringify(items[draftData.item_index]));
+            summary = { type: 'list', action: 'item_updated', id: result.id, title: result.title };
+            break;
+        }
+
+        case 'REMOVE_LIST_ITEM': {
+            const { rows: listRows } = await db.query('SELECT * FROM lists WHERE id = $1 AND deleted_at IS NULL', [draftData.list_id]);
+            if (listRows.length === 0) throw new DraftExecutionError('List not found', { status: 404 });
+            const items = typeof listRows[0].items === 'string' ? JSON.parse(listRows[0].items) : (listRows[0].items || []);
+            if (draftData.item_index >= items.length) throw new DraftExecutionError('Item index out of range');
+            const removed = items.splice(draftData.item_index, 1)[0];
+            const { rows } = await db.query('UPDATE lists SET items = $1 WHERE id = $2 RETURNING *', [JSON.stringify(items), draftData.list_id]);
+            result = rows[0];
+            resultEntityId = result.id;
+            await logListHistory(result.id, 'item_removed', 'item', JSON.stringify(removed), null);
+            summary = { type: 'list', action: 'item_removed', id: result.id, title: result.title };
+            break;
+        }
+
+        case 'UPDATE_FOLDER': {
+            const { rows } = await db.query(
+                'UPDATE note_folders SET name = $1 WHERE id = $2 RETURNING *',
+                [draftData.name, draftData.id]
+            );
+            if (rows.length === 0) throw new DraftExecutionError('Folder not found', { status: 404 });
+            result = rows[0];
+            resultEntityId = result.id;
+            summary = { type: 'folder', action: 'updated', id: result.id, title: result.name };
+            break;
+        }
+
+        // ========== DELETE OPERATIONS ==========
+        case 'DELETE_TODO': {
+            const { rows } = await db.query(
+                'UPDATE todos SET deleted_at = CURRENT_TIMESTAMP WHERE id = $1 AND deleted_at IS NULL RETURNING *',
+                [draftData.id]
+            );
+            if (rows.length === 0) throw new DraftExecutionError('Task not found or already deleted', { status: 404 });
+            result = rows[0];
+            resultEntityId = result.id;
+            await logTodoHistory(result.id, 'deleted', null, null, null);
+            summary = { type: 'todo', action: 'deleted', id: result.id, title: result.title };
+            break;
+        }
+
+        case 'DELETE_NOTE': {
+            // Soft-delete so the iOS sync engine receives a tombstone.
+            const { rows } = await db.query(
+                'UPDATE notes SET deleted_at = CURRENT_TIMESTAMP WHERE id = $1 AND deleted_at IS NULL RETURNING *',
+                [draftData.id]
+            );
+            if (rows.length === 0) throw new DraftExecutionError('Note not found', { status: 404 });
+            result = rows[0];
+            resultEntityId = result.id;
+            await logNoteHistory(result.id, 'deleted', null, null, null);
+            summary = { type: 'note', action: 'deleted', id: result.id, title: result.title || '' };
+            break;
+        }
+
+        case 'DELETE_LIST': {
+            const { rows } = await db.query(
+                'UPDATE lists SET deleted_at = CURRENT_TIMESTAMP WHERE id = $1 AND deleted_at IS NULL RETURNING *',
+                [draftData.id]
+            );
+            if (rows.length === 0) throw new DraftExecutionError('List not found', { status: 404 });
+            result = rows[0];
+            resultEntityId = result.id;
+            await logListHistory(result.id, 'deleted', null, null, null);
+            summary = { type: 'list', action: 'deleted', id: result.id, title: result.title };
+            break;
+        }
+
+        case 'DELETE_FOLDER': {
+            // Soft-cascade so notes inside also tombstone for sync.
+            await db.query(
+                'UPDATE notes SET deleted_at = CURRENT_TIMESTAMP WHERE folder_id = $1 AND deleted_at IS NULL',
+                [draftData.id]
+            );
+            const { rows } = await db.query(
+                'UPDATE note_folders SET deleted_at = CURRENT_TIMESTAMP WHERE id = $1 AND deleted_at IS NULL RETURNING *',
+                [draftData.id]
+            );
+            if (rows.length === 0) throw new DraftExecutionError('Folder not found', { status: 404 });
+            result = rows[0];
+            resultEntityId = result.id;
+            summary = { type: 'folder', action: 'deleted', id: result.id, title: result.name };
+            break;
+        }
+
+        default:
+            throw new DraftExecutionError(`Unsupported action type: ${draft.action_type}`);
+    }
+
+    return { result, resultEntityId, summary };
+}
+
+module.exports = { executeDraftAction, DraftExecutionError };

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 // v2.0 AI modules
 const { chatToDrafts } = require('./ai/chatToDrafts');
 const draftStore = require('./ai/draftStore');
+const { executeDraftAction, DraftExecutionError } = require('./ai/executeDraftAction');
 
 // v2 refactor helpers
 const { z } = require('zod');
@@ -1680,17 +1681,22 @@ app.post('/api/ai/execute', async (req, res) => {
 
 // AI CAPTURE ENDPOINT - one-shot voice capture for the iOS side-button flow.
 //
-// Takes free text, runs it through chatToDrafts, then applies "smart"
-// auto-confirm:
-//   - exactly 1 CREATE-type draft and no follow-up question -> auto-execute
-//     and return status: "created"
-//   - drafts.length === 0 with a follow-up question -> status: "needs_clarification"
-//   - any other shape (multiple drafts, edit/delete drafts, etc.) ->
-//     status: "needs_review" so the user opens the app and confirms in chat
+// Takes free text, runs it through chatToDrafts, then auto-executes every
+// draft the LLM produced — single or multi, create or edit or delete or
+// add-to-list. Triggered exclusively from the App Intent / Shortcut path,
+// where the user expects a frictionless "speak and it's done" experience.
 //
-// Auto-confirm is intentionally conservative — only safe CREATE actions go
-// through silently. Edits, deletes, and multi-draft batches always fall back
-// to needs_review so a misheard prompt cannot mutate or delete existing data.
+// Statuses:
+//   - drafts.length === 0 with a follow-up question -> "needs_clarification"
+//   - errors with no drafts -> "error"
+//   - any drafts -> auto-executed; "executed" with a summary per draft
+//   - per-draft execution failure -> partial response: `executed` lists
+//     successes, `failed` lists the rest with their error reason.
+//
+// This is autonomous on purpose. Earlier behaviour gated edits/deletes
+// behind UI confirmation, but the result was that ADD_TO_LIST drafts (and
+// similar) were never completed unless the user opened the app. The
+// shortcut now mirrors what the user dictates.
 app.post('/api/ai/capture', async (req, res) => {
     try {
         const { input, sessionId, timezone } = req.body || {};
@@ -1714,13 +1720,6 @@ app.post('/api/ai/capture', async (req, res) => {
         const followUpQuestion = result.followUpQuestion || null;
         const errors = result.errors || [];
 
-        const isCreateAction = (t) => t === 'CREATE_TODO' || t === 'CREATE_NOTE' || t === 'CREATE_LIST';
-        const summarizeDraft = (d) => ({
-            id: d.id,
-            type: d.entity_type,
-            title: d.data?.title || d.data?.name || ''
-        });
-
         if (errors.length > 0 && drafts.length === 0) {
             return res.json({ status: 'error', errors });
         }
@@ -1729,64 +1728,34 @@ app.post('/api/ai/capture', async (req, res) => {
             return res.json({ status: 'needs_clarification', followUpQuestion });
         }
 
-        if (drafts.length === 1 && isCreateAction(drafts[0].action_type) && !followUpQuestion) {
-            const draft = drafts[0];
-            const draftData = draft.data;
-            let createdRow;
+        // Auto-execute every draft. Each success is appended to `executed`,
+        // each failure to `failed` so the iOS dialog can surface partial
+        // results when the LLM produces a mix of valid + invalid actions.
+        const executed = [];
+        const failed = [];
+        const deps = { db, logTodoHistory, logNoteHistory, logListHistory };
 
-            switch (draft.action_type) {
-                case 'CREATE_TODO': {
-                    const { rows } = await db.query(
-                        'INSERT INTO todos (title, description, due_date, tag) VALUES ($1, $2, $3, $4) RETURNING *',
-                        [draftData.title, draftData.description || null, draftData.due_date || null, draftData.tag || null]
-                    );
-                    createdRow = rows[0];
-                    await logTodoHistory(createdRow.id, 'created', null, null, JSON.stringify(draftData));
-                    break;
-                }
-                case 'CREATE_NOTE': {
-                    const { rows } = await db.query(
-                        'INSERT INTO notes (title, content, folder_id) VALUES ($1, $2, $3) RETURNING *',
-                        [draftData.title, draftData.content, draftData.folder_id || null]
-                    );
-                    createdRow = rows[0];
-                    await logNoteHistory(createdRow.id, 'created', null, null, JSON.stringify(draftData));
-                    break;
-                }
-                case 'CREATE_LIST': {
-                    const items = Array.isArray(draftData.items)
-                        ? draftData.items.map(item => typeof item === 'string' ? { text: item, checked: false } : item)
-                        : [];
-                    const { rows } = await db.query(
-                        'INSERT INTO lists (title, items) VALUES ($1, $2) RETURNING *',
-                        [draftData.title, JSON.stringify(items)]
-                    );
-                    createdRow = rows[0];
-                    await logListHistory(createdRow.id, 'created', null, null, JSON.stringify(draftData));
-                    break;
-                }
+        for (const draft of drafts) {
+            try {
+                const { resultEntityId, summary } = await executeDraftAction(draft, draft.data, deps);
+                await draftStore.confirmDraft(draft.id, resultEntityId);
+                executed.push(summary);
+            } catch (err) {
+                console.error(`[CAPTURE] Failed to auto-execute draft ${draft.id} (${draft.action_type}):`, err.message);
+                failed.push({
+                    id: draft.id,
+                    action_type: draft.action_type,
+                    title: draft.data?.title || draft.data?.name || '',
+                    reason: err.message,
+                });
             }
-
-            await draftStore.confirmDraft(draft.id, createdRow.id);
-
-            return res.json({
-                status: 'created',
-                created: [{
-                    type: draft.entity_type,
-                    title: draftData.title,
-                    id: createdRow.id,
-                    dueDate: createdRow.due_date || null
-                }]
-            });
         }
 
-        // Multi-draft, edit/delete drafts, or any mixed shape: leave them
-        // pending. The user opens the app and the chat surface will replay
-        // these drafts so they can confirm or reject explicitly.
         return res.json({
-            status: 'needs_review',
-            pendingDrafts: drafts.map(summarizeDraft),
-            assistantText: result.assistantText || null
+            status: executed.length > 0 ? 'executed' : 'error',
+            executed,
+            failed,
+            assistantText: result.assistantText || null,
         });
 
     } catch (err) {

--- a/server/tests/capture.test.js
+++ b/server/tests/capture.test.js
@@ -1,13 +1,15 @@
 /**
  * Tests for POST /api/ai/capture — the headless voice-capture endpoint
- * powering the iOS side-button shortcut.
+ * powering the iOS side-button shortcut. As of #14 follow-up the endpoint
+ * auto-executes EVERY draft the LLM produces (single, multi, create,
+ * edit, add-to-list, delete) so the shortcut is fully autonomous.
  *
- *  - status: "created" when chatToDrafts returns one CREATE_TODO/NOTE/LIST
- *  - status: "needs_review" for multiple drafts or any edit/delete draft
+ *  - status: "executed" when at least one draft was applied; `executed`
+ *    array carries the per-draft summaries used to build the spoken dialog
  *  - status: "needs_clarification" when LLM asks a follow-up question
+ *  - status: "error" only when zero drafts AND tool errors
  *  - 400 when input is missing or empty
  *  - 500 when ANTHROPIC_API_KEY is missing
- *  - real DB row is created for the auto-confirm path
  */
 
 const { test, before, after, beforeEach } = require('node:test');
@@ -105,9 +107,9 @@ test('rejects non-string input with 400', async () => {
     assert.strictEqual(status, 400);
 });
 
-// --- created (auto-confirm single CREATE) ------------------------------------
+// --- executed (auto-execution covers every draft type) ----------------------
 
-test('auto-confirms a single CREATE_TODO draft and creates the row', async () => {
+test('auto-executes a single CREATE_TODO draft and creates the row', async () => {
     const draft = await seedPendingDraft({
         actionType: 'CREATE_TODO',
         entityType: 'todo',
@@ -122,70 +124,85 @@ test('auto-confirms a single CREATE_TODO draft and creates the row', async () =>
 
     const { status, body } = await api('POST', '/api/ai/capture', { input: 'remind me to call John tomorrow at 3' });
     assert.strictEqual(status, 200);
-    assert.strictEqual(body.status, 'created');
-    assert.strictEqual(body.created.length, 1);
-    assert.strictEqual(body.created[0].type, 'todo');
-    assert.strictEqual(body.created[0].title, 'Call John');
-    assert.ok(body.created[0].id, 'should return the new todo id');
+    assert.strictEqual(body.status, 'executed');
+    assert.strictEqual(body.executed.length, 1);
+    assert.strictEqual(body.executed[0].type, 'todo');
+    assert.strictEqual(body.executed[0].action, 'created');
+    assert.strictEqual(body.executed[0].title, 'Call John');
+    assert.ok(body.executed[0].id, 'should return the new todo id');
 
-    const { rows } = await pool.query('SELECT title, tag, due_date FROM todos WHERE id = $1', [body.created[0].id]);
-    assert.strictEqual(rows.length, 1);
+    const { rows } = await pool.query('SELECT title, tag FROM todos WHERE id = $1', [body.executed[0].id]);
     assert.strictEqual(rows[0].title, 'Call John');
     assert.strictEqual(rows[0].tag, 'work');
 
     const updated = await draftStore.getDraftById(draft.id);
     assert.strictEqual(updated.status, 'confirmed');
-    assert.strictEqual(updated.result_entity_id, body.created[0].id);
+    assert.strictEqual(updated.result_entity_id, body.executed[0].id);
 });
 
-test('auto-confirms a single CREATE_NOTE draft', async () => {
+test('auto-executes a CREATE_NOTE draft', async () => {
     const draft = await seedPendingDraft({
-        actionType: 'CREATE_NOTE',
-        entityType: 'note',
+        actionType: 'CREATE_NOTE', entityType: 'note',
         draftData: { title: 'Trip ideas', content: 'Lisbon, Tokyo, Reykjavik' },
     });
     nextChatToDraftsResponse = {
         drafts: [draftStore.formatDraft(await draftStore.getDraftById(draft.id))],
-        assistantText: 'Drafted the note.',
-        followUpQuestion: null,
-        errors: [],
+        assistantText: 'Drafted the note.', followUpQuestion: null, errors: [],
     };
 
     const { body } = await api('POST', '/api/ai/capture', { input: 'note: Lisbon, Tokyo, Reykjavik' });
-    assert.strictEqual(body.status, 'created');
-    assert.strictEqual(body.created[0].type, 'note');
-    assert.strictEqual(body.created[0].title, 'Trip ideas');
+    assert.strictEqual(body.status, 'executed');
+    assert.strictEqual(body.executed[0].type, 'note');
+    assert.strictEqual(body.executed[0].action, 'created');
 
-    const { rows } = await pool.query('SELECT title, content FROM notes WHERE id = $1', [body.created[0].id]);
+    const { rows } = await pool.query('SELECT content FROM notes WHERE id = $1', [body.executed[0].id]);
     assert.strictEqual(rows[0].content, 'Lisbon, Tokyo, Reykjavik');
 });
 
-test('auto-confirms a single CREATE_LIST draft with items', async () => {
+test('auto-executes a CREATE_LIST draft with items', async () => {
     const draft = await seedPendingDraft({
-        actionType: 'CREATE_LIST',
-        entityType: 'list',
+        actionType: 'CREATE_LIST', entityType: 'list',
         draftData: { title: 'Groceries', items: ['eggs', 'milk', 'bread'] },
     });
     nextChatToDraftsResponse = {
         drafts: [draftStore.formatDraft(await draftStore.getDraftById(draft.id))],
-        assistantText: '',
-        followUpQuestion: null,
-        errors: [],
+        assistantText: '', followUpQuestion: null, errors: [],
     };
 
     const { body } = await api('POST', '/api/ai/capture', { input: 'shopping list eggs milk bread' });
-    assert.strictEqual(body.status, 'created');
-
-    const { rows } = await pool.query('SELECT items FROM lists WHERE id = $1', [body.created[0].id]);
+    assert.strictEqual(body.status, 'executed');
+    const { rows } = await pool.query('SELECT items FROM lists WHERE id = $1', [body.executed[0].id]);
     const items = typeof rows[0].items === 'string' ? JSON.parse(rows[0].items) : rows[0].items;
     assert.strictEqual(items.length, 3);
     assert.strictEqual(items[0].text, 'eggs');
-    assert.strictEqual(items[0].checked, false);
 });
 
-// --- needs_review (multi-draft or non-create) --------------------------------
+test('auto-executes ADD_TO_LIST so shortcut adds items without UI confirmation', async () => {
+    const { rows: listRows } = await pool.query(
+        `INSERT INTO lists (title, items) VALUES ('Groceries', '[{"text":"eggs","checked":false}]') RETURNING id`
+    );
+    const listId = listRows[0].id;
+    const draft = await seedPendingDraft({
+        actionType: 'ADD_TO_LIST', entityType: 'list',
+        draftData: { id: listId, new_items: [{ text: 'milk', checked: false }, { text: 'bread', checked: false }] },
+    });
+    nextChatToDraftsResponse = {
+        drafts: [draftStore.formatDraft(await draftStore.getDraftById(draft.id))],
+        assistantText: '', followUpQuestion: null, errors: [],
+    };
 
-test('returns needs_review for multiple drafts and leaves them pending', async () => {
+    const { body } = await api('POST', '/api/ai/capture', { input: 'add milk and bread to my groceries list' });
+    assert.strictEqual(body.status, 'executed');
+    assert.strictEqual(body.executed[0].action, 'items_added');
+    assert.match(body.executed[0].addedNames || '', /milk.*bread/);
+
+    const { rows } = await pool.query('SELECT items FROM lists WHERE id = $1', [listId]);
+    const items = typeof rows[0].items === 'string' ? JSON.parse(rows[0].items) : rows[0].items;
+    assert.strictEqual(items.length, 3);
+    assert.deepStrictEqual(items.map(i => i.text), ['eggs', 'milk', 'bread']);
+});
+
+test('auto-executes a multi-draft batch (every draft applies)', async () => {
     const todoDraft = await seedPendingDraft({
         actionType: 'CREATE_TODO', entityType: 'todo', draftData: { title: 'Task A' }
     });
@@ -197,43 +214,65 @@ test('returns needs_review for multiple drafts and leaves them pending', async (
             draftStore.formatDraft(await draftStore.getDraftById(todoDraft.id)),
             draftStore.formatDraft(await draftStore.getDraftById(noteDraft.id)),
         ],
-        assistantText: 'I drafted 2 items.',
-        followUpQuestion: null,
-        errors: [],
+        assistantText: 'I drafted 2 items.', followUpQuestion: null, errors: [],
     };
 
-    const { status, body } = await api('POST', '/api/ai/capture', { input: 'task A and note B' });
-    assert.strictEqual(status, 200);
-    assert.strictEqual(body.status, 'needs_review');
-    assert.strictEqual(body.pendingDrafts.length, 2);
-    assert.strictEqual(body.assistantText, 'I drafted 2 items.');
+    const { body } = await api('POST', '/api/ai/capture', { input: 'task A and note B' });
+    assert.strictEqual(body.status, 'executed');
+    assert.strictEqual(body.executed.length, 2);
 
     const todoState = await draftStore.getDraftById(todoDraft.id);
     const noteState = await draftStore.getDraftById(noteDraft.id);
-    assert.strictEqual(todoState.status, 'pending', 'multi-draft must NOT auto-confirm');
-    assert.strictEqual(noteState.status, 'pending', 'multi-draft must NOT auto-confirm');
+    assert.strictEqual(todoState.status, 'confirmed');
+    assert.strictEqual(noteState.status, 'confirmed');
 
     const { rows } = await pool.query('SELECT count(*)::int AS n FROM todos');
-    assert.strictEqual(rows[0].n, 0, 'no rows should be created on needs_review');
+    assert.strictEqual(rows[0].n, 1);
 });
 
-test('returns needs_review for an edit/delete draft (never auto-confirms mutations)', async () => {
-    const editDraft = await seedPendingDraft({
-        actionType: 'UPDATE_TODO', entityType: 'todo', draftData: { id: 42, title: 'New title' }
+test('auto-executes UPDATE_TODO drafts (no UI gate)', async () => {
+    const { rows: existing } = await pool.query(
+        `INSERT INTO todos (title) VALUES ('old title') RETURNING id`
+    );
+    const todoId = existing[0].id;
+    const draft = await seedPendingDraft({
+        actionType: 'UPDATE_TODO', entityType: 'todo', draftData: { id: todoId, title: 'New title' }
     });
     nextChatToDraftsResponse = {
-        drafts: [draftStore.formatDraft(await draftStore.getDraftById(editDraft.id))],
-        assistantText: '',
-        followUpQuestion: null,
-        errors: [],
+        drafts: [draftStore.formatDraft(await draftStore.getDraftById(draft.id))],
+        assistantText: '', followUpQuestion: null, errors: [],
     };
 
     const { body } = await api('POST', '/api/ai/capture', { input: 'rename task to New title' });
-    assert.strictEqual(body.status, 'needs_review');
-    assert.strictEqual(body.pendingDrafts.length, 1);
+    assert.strictEqual(body.status, 'executed');
+    assert.strictEqual(body.executed[0].action, 'updated');
 
-    const after = await draftStore.getDraftById(editDraft.id);
-    assert.strictEqual(after.status, 'pending');
+    const after = await draftStore.getDraftById(draft.id);
+    assert.strictEqual(after.status, 'confirmed');
+    const { rows } = await pool.query('SELECT title FROM todos WHERE id = $1', [todoId]);
+    assert.strictEqual(rows[0].title, 'New title');
+});
+
+test('partial failure: applied drafts succeed, broken ones land in `failed`', async () => {
+    const okDraft = await seedPendingDraft({
+        actionType: 'CREATE_TODO', entityType: 'todo', draftData: { title: 'Works' }
+    });
+    const badDraft = await seedPendingDraft({
+        actionType: 'UPDATE_TODO', entityType: 'todo', draftData: { id: 9999999, title: 'Misses' }
+    });
+    nextChatToDraftsResponse = {
+        drafts: [
+            draftStore.formatDraft(await draftStore.getDraftById(okDraft.id)),
+            draftStore.formatDraft(await draftStore.getDraftById(badDraft.id)),
+        ],
+        assistantText: '', followUpQuestion: null, errors: [],
+    };
+
+    const { body } = await api('POST', '/api/ai/capture', { input: 'mixed' });
+    assert.strictEqual(body.status, 'executed');
+    assert.strictEqual(body.executed.length, 1);
+    assert.strictEqual(body.failed.length, 1);
+    assert.match(body.failed[0].reason, /not found/i);
 });
 
 // --- needs_clarification -----------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #19. The shortcut now applies every draft \`chatToDrafts\` produces — single create, multi-draft, add-to-list, edit, delete, folder cascade — without UI confirmation. Per-draft outcomes split into \`executed\` (applied) and \`failed\` (validation errors) so partial failures don't block the rest.

- Extract /api/ai/execute switch into \`server/ai/executeDraftAction.js\`. Reused by /api/ai/execute, /api/drafts/:id/confirm, and /api/ai/capture so the three paths can never diverge.
- /api/ai/capture loops over every returned draft and calls the helper. Status enum collapses to \`executed | needs_clarification | error\`.
- DELETE_NOTE / DELETE_LIST switch to soft-delete for sync-engine tombstone consistency. DELETE_FOLDER soft-cascades.
- iOS CaptureResponse decodes the new shape; \`CaptureToDashboardIntent\` dialog builder reads back per-action sentences (\"Added Eggs, Bread to Groceries\", \"Marked dentist complete\", etc.) instead of the dead-end \"open app\" prompt.

## Test plan

- [x] \`cd server && npm test\` — 55/55 green (5 capture cases rewritten, 2 added: ADD_TO_LIST, partial failure)
- [x] Live LLM call against /api/ai/capture: \"add eggs and bread to my groceries list\" returns \`executed\` with \`items_added\` and \`addedNames: \"Eggs, Bread\"\`
- [x] iPhone simulator build green
- [ ] iPhone 16 Pro Max device QA: trigger Shortcut for ADD_TO_LIST / UPDATE_TODO / multi-action / partial-failure cases