### PR TITLE
feat: activity timeline (#16)

### DIFF
--- a/.claude/design/activity-timeline.md
+++ b/.claude/design/activity-timeline.md
@@ -1,0 +1,323 @@
+# Activity Timeline — Design Brief
+
+Issue: #16. Worktree: `personal-dashboard-activity-timeline`. Branch: `feat/activity-timeline`. Read-only chronological feed of every note, todo, list, and folder the user has created. Same shape on web and iOS, same API, same design language.
+
+This brief is the source of truth for implementation. Reuse Editorial Calm tokens from `client/src/index.css` (web) and `mobile/PersonalDashboard/Design/Tokens.swift` (iOS). The only new token is `--color-accent-activity` (web) / `Tokens.accentActivity` (iOS).
+
+---
+
+## 1. Information architecture & navigation
+
+### New token: Activity accent
+
+A single new accent slotted alongside the per-section accents. Hue is plum / mauve. It reads as "history" and "archive", does not collide with the existing palette (Today red, Tasks indigo, Notes ochre, Lists teal, Settings slate, Chat/Dashboard ink), and harmonises with the warm-paper ground.
+
+- Light: `#7C3F58` (plum). Contrast on `#FBF9F4` paper = 7.32:1 (AAA for normal and large text). Contrast on `#F4F0E6` paper-2 = 6.95:1 (AAA).
+- Dark:  `#E5A3BA` (rose). Contrast on `#14110D` paper = 10.41:1 (AAA). Contrast on `#1B1813` paper-2 = 9.85:1 (AAA).
+
+CSS additions (do not touch any other token):
+
+```
+@theme {
+  --color-accent-activity: #7C3F58;
+}
+[data-theme="dark"] {
+  --color-accent-activity: #E5A3BA;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --color-accent-activity: #E5A3BA;
+  }
+}
+[data-route="activity"] { --color-accent: var(--color-accent-activity); }
+```
+
+iOS additions (single line in `Tokens.swift`, plus an `AppSection.activity` case and its `accent(for:)` arm):
+
+```
+static let accentActivity = Color.paper(0x7C3F58, 0xE5A3BA)
+```
+
+### Web sidebar placement
+
+Insert `Activity` as a new `NavLink` in `Sidebar.jsx`'s `ITEMS` array, immediately after `Dashboard` and before the divider above `Settings`. Same row treatment as every other entry: the active row gets the standard 3px `--color-accent` left rail (which now resolves to plum on the Activity route) and a `bg-paper-2` fill.
+
+- Label: `Activity`.
+- Icon: `History` from `lucide-react` (clock-counterclockwise glyph). Same size and stroke as siblings (`size={20} strokeWidth={1.75}`).
+- Tooltip when collapsed: `Activity` (matches existing tooltip pattern).
+- Route: `/activity`. Set `<html data-route="activity">` in the page wrapper so the accent token resolves.
+
+Final web sidebar order: `Today, Chat / Tasks, Notes, Lists / Dashboard, Activity / Settings`.
+
+### iOS drawer placement
+
+Add `case activity` to the `AppSection` enum in `Design/Tokens.swift`. Wire it through `surfaceView(for:)` in `ContentView.swift`, and add a `DrawerRow(section: .activity, router: router)` in `SideDrawer.swift` directly below `DrawerRow(section: .dashboard, ...)` and before the divider above Settings. Active rail uses `Tokens.accent(for: .activity)` which returns `accentActivity`.
+
+- `displayName`: `Activity`.
+- `icon` (SF Symbol): `clock.arrow.circlepath`. Same size and weight as siblings (`size: 16, weight: .regular`).
+
+---
+
+## 2. Page-level layout
+
+Container chrome is identical to other widgets so the page feels native to the dashboard.
+
+### Web
+
+- Outer page uses the existing `AppShell` with the `Sidebar`. Set `<html data-route="activity">`.
+- Page body: a single `Card` (existing primitive) at `max-w-3xl mx-auto`, `padding="p-0"` so the sticky day headers can hug the card's inner edge. The `Card` keeps the standard border, radius, and surface fill.
+- Inside the card: a 56px sticky header strip, then the filter strip (also sticky), then the day-grouped list.
+
+### iOS
+
+- Standard `ZStack { Tokens.paper.ignoresSafeArea(); VStack(spacing: 0) { TopBar; ScrollView { LazyVStack } } }`.
+- `TopBar` title: `Activity`. Trailing toggle is the existing theme toggle, no extra controls.
+- `ChatFAB` floats bottom-right as on every other surface.
+
+### Page header
+
+- Web: `h1` reading `Activity`, font `font-display text-2xl text-ink tracking-tight`. To its right, an icon-only refresh button (`RotateCw` from lucide, `text-muted hover:text-ink`, 36px tap target). Caption beneath the title in `text-sm text-muted`: `Everything you have captured, newest first.`
+- iOS: `TopBar` already renders the title. Place the caption as a single `Text` line below the `TopBar`, `Tokens.muted`, `.edSubheadline`, with `Space.lg` horizontal padding and `Space.sm` top padding. No refresh button on iOS — pull-to-refresh on the `ScrollView` covers it.
+
+### Filter strip
+
+Single-select chips. The active filter applies to the API request via the `?type=` query param. `All` clears the param.
+
+- Order: `All, Notes, Todos, Lists, Folders`.
+- Chip styling, inactive: `h-8 px-3 rounded-full bg-paper-2 border border-border text-sm text-ink-soft`. Hover: `border-border-strong text-ink`.
+- Chip styling, active: `bg-[--color-accent-soft] border border-[--color-accent-ring] text-[--color-accent]`. The accent here resolves to the plum because we set `data-route="activity"` on the page. Active chip carries `aria-pressed="true"`.
+- Spacing: `gap-2`, horizontal padding `px-5`, vertical padding `py-3`. Sticky to the top of the scroll container with the day headers (web only — see below).
+- iOS: same chip semantics. `Capsule()` backgrounds. Inactive `Tokens.paper2` with `Tokens.border` overlay; active `Tokens.accentActivity.opacity(0.12)` fill with `Tokens.accentActivity` text and `Tokens.accentActivity.opacity(0.35)` capsule stroke. Horizontally scrollable `ScrollView(.horizontal)` with `showsIndicators: false`. Padding `Space.lg` horizontal, `Space.sm` vertical.
+
+### Day groups & sticky headers
+
+- Group rows by the user's local day (server returns ISO timestamps; clients bucket).
+- Group label rules:
+  - Today: `Today`
+  - Yesterday: `Yesterday`
+  - Within the last 7 days: weekday name (`Monday`, `Tuesday`, ...)
+  - Older same year: `Mon 14 Apr`
+  - Prior years: `14 Apr 2024`
+- Web header: `h2` styled `font-display text-base text-ink tracking-tight uppercase` (the eyebrow style already used on widgets). Background `bg-surface/95` with `backdrop-blur-sm`, a `border-b border-divider`, height 36px, `px-5`, sticky via `position: sticky; top: 56px` so it parks under the page header / filter strip. A 6px `--color-accent-activity` dot precedes the label.
+- iOS header: `Text(label).font(.edEyebrow).foregroundStyle(Tokens.inkSoft)` with the same plum dot prefix. Wrapped in a `LazyVStack(pinnedViews: [.sectionHeaders])` `Section` so the header pins to the top of the scroll viewport.
+- Spacing between groups: `Space.xl` (24px) on iOS, `mt-6` on web. First group starts flush, no top margin.
+
+### Row anatomy
+
+A row is one creation. Three columns: type icon (left, 32px square), title + snippet + parent breadcrumb (centre, flex-grow), relative time (right, `whitespace-nowrap`).
+
+| Type | Web Lucide icon | iOS SF symbol | Icon color (light / dark) |
+|---|---|---|---|
+| `note` | `FileText` | `doc.text` | `accent-notes` (`#B45309` / `#F59E0B`) |
+| `todo` | `CheckSquare` | `checkmark.square` | `accent-tasks` (`#4338CA` / `#818CF8`) |
+| `list` | `List` | `list.bullet` | `accent-lists` (`#0F766E` / `#2DD4BF`) |
+| `folder` | `Folder` | `folder` | `muted` (`#7B7263` / `#A89E8A`) |
+
+- Icon container: 32px square, `rounded-md`, fill is the icon color at 12% opacity (`color-mix(in oklab, var(--color-accent-X) 12%, var(--color-paper))` on web, `accent.opacity(0.12)` on iOS). Icon glyph at 18px, full color. This is the only color cue per row, everything else is ink/muted.
+- Title: web `text-sm font-medium text-ink`, iOS `.edBodyMedium` `Tokens.ink`. Single line, truncate with ellipsis at the column boundary.
+- Snippet: web `text-sm text-muted line-clamp-1`, iOS `.edSubheadline` `Tokens.muted` `.lineLimit(1)`. If `snippet` is null (folders), omit the line entirely so the row collapses to one line of text.
+- Parent breadcrumb (notes only, when `parent` is non-null): rendered inline below the title as `text-xs text-muted-soft` with a leading `Folder` icon at 10px. Format: `[icon] Travel`. Suppressed for todos, lists, and folders.
+- Relative time, right-aligned, web `text-xs text-muted-soft`, iOS `.edCaption` `Tokens.mutedSoft`. Format: `2m`, `47m`, `3h`, `Yesterday`, `Mon`, `14 Apr`, `14 Apr 2024`. Same scheme as day headers but compact. Tooltip on hover (web) shows the full timestamp.
+- Row padding: `py-3 px-5` web, `Space.md` vertical / `Space.lg` horizontal iOS.
+- Divider between rows inside a group: `border-b border-divider` web (last row in group has no border), `Rectangle().fill(Tokens.divider).frame(height: 0.5)` iOS.
+
+### Hover / press affordance
+
+- Web: row hover sets `bg-paper-2` and shows a `ChevronRight` (16px, `text-muted-soft`) at the far right replacing the timestamp's right margin. Cursor `pointer`. Focus ring follows the standard `focus-visible:ring-2 focus-visible:ring-[--color-accent-ring]` pattern.
+- iOS: `.contentShape(Rectangle())` plus a tap gesture, no persistent chevron (mobile convention). Tap sets a brief `Tokens.paper2` highlight via `.scaleEffect` 0.99 for 120ms.
+
+### Deep-link affordance
+
+Tapping a row navigates to the section that owns the item and scrolls to it.
+
+- `note` -> Notes section, scroll the corresponding note into view, pulse the note card with a 600ms `--color-accent-notes` ring.
+- `todo` -> Tasks section, same pattern with `--color-accent-tasks`.
+- `list` -> Lists section, same pattern with `--color-accent-lists`.
+- `folder` -> Notes section with the folder pre-expanded.
+
+The pulse uses opacity-only animation on a 1px outline that shares the row's radius. Honour `prefers-reduced-motion`: skip the pulse and just scroll.
+
+Web routing: navigate to `/notes?focus=<id>`, `/tasks?focus=<id>`, `/lists?focus=<id>`. The destination widget reads `focus` from the URL on mount, scrolls to the item, and then strips the param via `replaceState`.
+
+iOS routing: `router.go(to: .notes)` (etc) plus a new `router.focus: (AppSection, UUID)?` field that the destination view consumes on `task {}`.
+
+---
+
+## 3. Empty state
+
+Two variants, both centred in the scroll area, no illustration.
+
+### "No items yet at all"
+
+- Icon: `Inbox` (lucide) / `tray` (SF Symbol), 28px, `text-muted` / `Tokens.muted`.
+- Headline: web `text-base text-ink-soft`, iOS `.edBodyMedium` `Tokens.inkSoft`. Copy: `Nothing here yet.`
+- Sub: web `text-sm text-muted`, iOS `.edSubheadline` `Tokens.muted`. Copy: `Notes, todos, lists, and folders you create will show up here.`
+- iOS uses `Space.xxxl` vertical padding (matches `TasksView.placeholder`).
+
+### "No items match the active filter"
+
+- Same layout. Icon: `Filter` / `line.3.horizontal.decrease`. Headline: `No <type> here yet.` (e.g. `No notes here yet.`). Sub: `Switch to All to see everything.`
+
+---
+
+## 4. Loading skeleton
+
+Bones use `bg-surface-2` / `Tokens.paper2`. Animation is a 1.4s ease-in-out pulse on opacity (40% to 70%). Disable when `prefers-reduced-motion` is set.
+
+### First-load skeleton (page fresh)
+
+Render 3 day-group placeholders, each containing 4 row placeholders:
+
+- Day header bone: 80px wide x 12px tall, `rounded-sm`. Sit it in the same sticky-header slot so the layout does not shift when real data arrives.
+- Row bone composition: 32px square icon bone (left), then a 60% width title bone (12px tall), then a 90% width snippet bone (10px tall, mt-1.5), then a 32px right-aligned time bone. Row padding matches real rows.
+
+### Subsequent-page skeleton (infinite scroll)
+
+Render 2 row placeholders at the bottom of the list while the next page is fetching. No day header bone. Removed when the fetch resolves.
+
+---
+
+## 5. Filter & cursor interactions
+
+- Filter change: reset cursor, clear current rows, render the first-load skeleton, fetch with the new `type` param. Smooth state transition, do not animate row removal (just swap to skeleton).
+- Web manual refresh (`RotateCw` button): same as filter change. Spin the icon while the request is in flight. Disabled state during the request.
+- iOS pull-to-refresh: `.refreshable { await viewModel.reload() }` on the outer `ScrollView`. Same effect as web manual refresh.
+- "Load more" trigger:
+  - Web: `IntersectionObserver` watching a 1px sentinel placed below the last row. When the sentinel is within 600px of the viewport bottom, fire the next-page request. Show the subsequent-page skeleton at the bottom while loading. Auto-stop when the API returns no `nextCursor`.
+  - iOS: `.onAppear` on the last `LazyVStack` row triggers the next-page request. Same skeleton treatment. Same auto-stop rule.
+- Errors: an inline row at the bottom of the list reading `Couldn't load more. Tap to retry.` styled in `text-danger` / `Tokens.danger`. Tapping retries.
+
+---
+
+## 6. Light & dark mode
+
+- Only one new token pair. Both values verified above.
+- Active filter chip in dark mode: the plum (`#E5A3BA`) on `Tokens.paper2` (`#1B1813`) hits 9.85:1, comfortably AAA.
+- Type icon backgrounds at 12% opacity remain legible in dark mode because the icon glyph itself is full-strength. No new variants needed for the per-section accents.
+
+---
+
+## 7. Accessibility
+
+### Contrast
+
+- Activity accent on paper, light: 7.32:1 (AAA). Dark: 10.41:1 (AAA).
+- Type-icon glyph on its 12% tint: notes 5.4:1, tasks 7.1:1, lists 4.9:1, folders 4.7:1 (light). All clear AA for non-text UI; glyph weight is treated as iconography (3:1 minimum) so this is comfortable.
+- Snippet `text-muted` on `bg-surface` (light): 4.8:1, AA. Dark: 5.9:1, AA.
+- `text-muted-soft` (the relative-time slot) on surface: 3.4:1 light, 3.9:1 dark. This sits on the AA-large-text threshold (3:1) but below normal-text AA. The relative time is decorative when the day header already names the day, and the full timestamp is exposed to assistive tech via the row label, so this is acceptable. If the user later wants it stronger, bump to `text-muted` (4.8:1).
+
+### Keyboard order (web)
+
+Tab order from top of page: refresh button -> filter chips (left to right, arrow keys move within the group, `Tab` exits the group) -> first row -> second row -> ... -> load-more sentinel (skipped, not focusable) -> end of page. `Enter` on a focused row triggers the deep link. `Esc` returns focus to the refresh button.
+
+### Screen reader labels
+
+- Page landmark: `<main aria-labelledby="activity-heading">`.
+- Filter chips group: `role="group" aria-label="Filter by type"`. Each chip is a `<button aria-pressed="true|false">`.
+- Day header: marked as `<h2>` so screen readers announce the date as a section.
+- Row: rendered as `<a href="...">` (web) and `Button` with `accessibilityLabel` (iOS). Composed label per type:
+  - Note: `Note created. <title>. <snippet>. In <parent folder>. <relative time>.`
+  - Todo: `Task created. <title>. <snippet>. <relative time>.`
+  - List: `List created. <title>. <snippet>. <relative time>.`
+  - Folder: `Folder created. <title>. <relative time>.`
+- Relative time: include the absolute timestamp as `aria-label` so SR users hear `2 hours ago, 3 May 2026 at 3:42 PM` instead of just `3h`.
+- Skeleton: container `aria-busy="true"`, no row text exposed.
+- Empty state: just text, no special role.
+
+### Touch targets
+
+All tap targets at least 44x44 (web rows are 60px tall, iOS rows are 60-72px depending on snippet presence, chips are 32px tall on web but include 12px hit padding via the parent `gap-2` + chip internal padding, iOS chips use `.frame(minHeight: 36)` plus `Space.sm` interior padding which extends the hit area to 44).
+
+---
+
+## 8. Reference mockups
+
+### Web (~80 col)
+
+```
++------------------------------------------------------------------------------+
+|  [Sidebar 64px ......collapsed.....]                                          |
+|  | History  Activity  *active*  |  Activity                       [refresh] |
+|  |                                |  Everything you have captured, newest    |
+|  |                                |  first.                                  |
+|  |                                |                                          |
+|  |                                |  ( All )( Notes )( Todos )( Lists )( ...|
+|  |                                |  ----------------------------------------|
+|  |                                |  - Today --------------------------------|
+|  |                                |                                          |
+|  |                                |  [N]  Trip to Lisbon              2m    >|
+|  |                                |       Booked the Alfama airbnb...        |
+|  |                                |       (folder) Travel                    |
+|  |                                |                                          |
+|  |                                |  [T]  Renew passport             1h    >|
+|  |                                |       Embassy slot before May 20         |
+|  |                                |                                          |
+|  |                                |  [L]  Packing list                3h    >|
+|  |                                |       Charger, sunglasses, kindle        |
+|  |                                |                                          |
+|  |                                |  [F]  Travel                      4h    >|
+|  |                                |                                          |
+|  |                                |  - Yesterday ----------------------------|
+|  |                                |                                          |
+|  |                                |  [N]  Sprint retro notes        Yest    >|
+|  |                                |       What worked: pairing on the...     |
+|  |                                |       (folder) Work                      |
+|  |                                |                                          |
+|  |                                |  [T]  Email Rajiv                Yest   >|
+|  |                                |       Re: Q3 roadmap                     |
+|  |                                |                                          |
++------------------------------------------------------------------------------+
+```
+
+Icon colors in the brackets: `[N]` plum-on-ochre tint, `[T]` indigo, `[L]` teal, `[F]` muted slate. The plum dot (the Activity accent) appears only on the day header.
+
+### iOS (~40 col)
+
+```
++--------------------------------------+
+| [=]            Activity         [O]  |
+|--------------------------------------|
+|  Everything you have captured,       |
+|  newest first.                       |
+|                                      |
+|  ( All ) ( Notes ) ( Todos ) ( ...   |
+|--------------------------------------|
+|                                      |
+|  o  Today                            |
+|                                      |
+|  [N]  Trip to Lisbon          2m     |
+|       Booked the Alfama...           |
+|       (folder) Travel                |
+|  -------------------------------     |
+|  [T]  Renew passport          1h     |
+|       Embassy slot before...         |
+|  -------------------------------     |
+|  [L]  Packing list            3h     |
+|       Charger, sunglasses...         |
+|  -------------------------------     |
+|  [F]  Travel                  4h     |
+|                                      |
+|  o  Yesterday                        |
+|                                      |
+|  [N]  Sprint retro notes      Yest   |
+|       What worked: pairing...        |
+|       (folder) Work                  |
+|  -------------------------------     |
+|  [T]  Email Rajiv             Yest   |
+|       Re: Q3 roadmap                 |
+|                                      |
+|                              (chat)  |
++--------------------------------------+
+```
+
+`o` is the plum dot prefix on each day header. `[O]` is the theme toggle. `(chat)` is the floating `ChatFAB` bottom-right.
+
+---
+
+## Hand-off notes for the implementation agent
+
+- One new CSS token (`--color-accent-activity`) plus the `[data-route="activity"]` mapping. One new Swift constant (`Tokens.accentActivity`). No other token changes, no new spacing or radius scales, no new font sizes.
+- Reuse `Card` for the page container on web. Reuse `TopBar`, `ChatFAB`, `Tokens.*` for iOS.
+- Do not invent a custom skeleton component if a project-wide one exists; if it does not, build it inline and keep it local to the Activity page until it earns its way into a shared place.
+- Filter chips and day headers should both be sticky on web, day headers only on iOS. iOS filter chips live above the scroll view, not inside it.
+- Pulse-highlight on deep-link is one of the few places we need to coordinate with the destination widget. Ship the URL/`router.focus` plumbing alongside the Activity page in the same PR; do not split it.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import TasksPage from './pages/TasksPage';
 import NotesPage from './pages/NotesPage';
 import ListsPage from './pages/ListsPage';
 import DashboardPage from './pages/DashboardPage';
+import ActivityPage from './pages/ActivityPage';
 
 /**
  * v2 App — wraps the route tree in PreferencesProvider, then mounts every
@@ -65,6 +66,8 @@ export default function App() {
           <Route path="/lists/:id" element={<ListsPage />} />
 
           <Route path="/dashboard" element={<DashboardPage />} />
+
+          <Route path="/activity" element={<ActivityPage />} />
 
           <Route path="/settings" element={<Navigate to="/settings/appearance" replace />} />
           <Route path="/settings/appearance" element={<SettingsPlaceholder sectionLabel="Appearance" />} />

--- a/client/src/components/AppShell.jsx
+++ b/client/src/components/AppShell.jsx
@@ -9,7 +9,7 @@ import TopBar from './TopBar';
 import ChatPopover from './ChatPopover';
 import { getStats } from '../services/api';
 
-const ROUTE_SEGMENTS = ['today', 'chat', 'tasks', 'notes', 'lists', 'dashboard', 'settings'];
+const ROUTE_SEGMENTS = ['today', 'chat', 'tasks', 'notes', 'lists', 'dashboard', 'activity', 'settings'];
 
 function deriveRoute(pathname) {
   const seg = pathname.split('/').filter(Boolean)[0];

--- a/client/src/components/ListsWidget.jsx
+++ b/client/src/components/ListsWidget.jsx
@@ -236,7 +236,7 @@ const ListsWidget = forwardRef(function ListsWidget({ fullHeight = false }, ref)
                                 lists.map((list) => {
                                     const isExpanded = expandedListIds.has(list.id);
                                     return (
-                                        <div key={list.id} className="rounded-xl border border-transparent hover:border-[--color-accent-soft] transition-all">
+                                        <div key={list.id} data-activity-id={list.id} className="rounded-xl border border-transparent hover:border-[--color-accent-soft] transition-all">
                                             {/* List Header */}
                                             <div
                                                 onClick={() => editingListId !== list.id && toggleExpand(list.id)}

--- a/client/src/components/NotesWidget.jsx
+++ b/client/src/components/NotesWidget.jsx
@@ -5,11 +5,17 @@ import Button from './Button';
 import { getNotes, createNote, updateNote, deleteNote, getNoteFolders, createNoteFolder, updateNoteFolder, deleteNoteFolder } from '../services/api';
 import { Plus, Trash2, Loader2, Save, Folder, FolderOpen, ChevronRight, ChevronLeft, Edit2, Inbox } from 'lucide-react';
 
-const NotesWidget = forwardRef(function NotesWidget({ fullHeight = false, maxHeightPx = null }, ref) {
+const NotesWidget = forwardRef(function NotesWidget({ fullHeight = false, maxHeightPx = null, initialFolderId = null }, ref) {
     const [folders, setFolders] = useState([]);
     const [notes, setNotes] = useState([]);
     const [loading, setLoading] = useState(true);
-    const [selectedFolderId, setSelectedFolderId] = useState(null);
+    // Honour initialFolderId from props (used by Activity timeline deep-link).
+    // Coerced to a number when numeric, since folder ids are integers.
+    const [selectedFolderId, setSelectedFolderId] = useState(() => {
+        if (initialFolderId == null) return null;
+        const asNumber = Number(initialFolderId);
+        return Number.isFinite(asNumber) ? asNumber : initialFolderId;
+    });
     const [currentNote, setCurrentNote] = useState(null); // null = list view, object = edit view
     const [newFolderName, setNewFolderName] = useState('');
     const [editingFolderId, setEditingFolderId] = useState(null);
@@ -52,7 +58,11 @@ const NotesWidget = forwardRef(function NotesWidget({ fullHeight = false, maxHei
             if (selectedFolderId !== null) {
                 fetchNotes(selectedFolderId);
             }
-        }
+        },
+        selectFolder: (id) => {
+            const next = id == null ? 'all' : (Number.isFinite(Number(id)) ? Number(id) : id);
+            setSelectedFolderId(next);
+        },
     }));
 
     const fetchFolders = async () => {
@@ -61,6 +71,7 @@ const NotesWidget = forwardRef(function NotesWidget({ fullHeight = false, maxHei
             const foldersArray = Array.isArray(data) ? data : [];
             setFolders(foldersArray);
             // Default to "All Notes" so unfiled notes are visible.
+            // If a deep-link supplied a starting folder, honour it instead.
             if (selectedFolderId === null) {
                 setSelectedFolderId('all');
             }
@@ -435,6 +446,7 @@ const NotesWidget = forwardRef(function NotesWidget({ fullHeight = false, maxHei
                             notes.map((note) => (
                                 <div
                                     key={note.id}
+                                    data-activity-id={note.id}
                                     className="group p-3 bg-paper-2 hover:bg-surface rounded-xl border border-transparent hover:border-[--color-accent-soft] hover:shadow-md transition-all relative"
                                 >
                                     {/* Title - inline editable */}

--- a/client/src/components/Sidebar.jsx
+++ b/client/src/components/Sidebar.jsx
@@ -4,6 +4,7 @@ import {
   CalendarDays,
   CheckSquare,
   FileText,
+  History,
   LayoutDashboard,
   List as ListIcon,
   MessageSquare,
@@ -30,6 +31,7 @@ const ITEMS = [
   { type: 'item', to: '/lists', label: 'Lists', icon: ListIcon },
   { type: 'divider' },
   { type: 'item', to: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
+  { type: 'item', to: '/activity', label: 'Activity', icon: History },
   { type: 'divider' },
   { type: 'item', to: '/settings', label: 'Settings', icon: Settings },
 ];

--- a/client/src/components/TodoWidget.jsx
+++ b/client/src/components/TodoWidget.jsx
@@ -658,6 +658,7 @@ const TodoWidget = forwardRef(function TodoWidget({ fullHeight = false }, ref) {
         return (
             <div
                 key={todo.id}
+                data-activity-id={todo.id}
                 className="group flex items-start gap-3 p-3 rounded-lg hover:bg-paper-2 border border-transparent hover:border-divider transition-all duration-200"
             >
                 <button

--- a/client/src/hooks/useActivityFocus.js
+++ b/client/src/hooks/useActivityFocus.js
@@ -1,0 +1,78 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+/**
+ * Reads `?focus=<id>` from the current URL. Once the destination widget has
+ * rendered the row with `data-activity-id={id}`, this hook scrolls it into
+ * view, toggles `data-activity-focus="true"` to trigger the 600ms accent
+ * pulse defined in `index.css`, and finally strips the param from the URL
+ * so a refresh doesn't re-pulse forever.
+ *
+ * The hook polls a few times because the widget may not have data on first
+ * paint (it's still fetching). We give it ~2 seconds before giving up.
+ *
+ * Honours `prefers-reduced-motion` by skipping the pulse animation (the
+ * global media query in index.css collapses animation-duration so the
+ * data-activity-focus attribute fades immediately) and using `auto` scroll.
+ */
+export function useActivityFocus(scope = 'activity-id') {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const focusId = params.get('focus');
+    if (!focusId) return undefined;
+
+    const reducedMotion = typeof window !== 'undefined' &&
+      window.matchMedia &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    let cancelled = false;
+    let attempts = 0;
+    const maxAttempts = 20; // ~2s at 100ms intervals
+
+    const tryFocus = () => {
+      if (cancelled) return;
+      const node = document.querySelector(`[data-${scope}="${focusId}"]`);
+      if (node) {
+        try {
+          node.scrollIntoView({
+            behavior: reducedMotion ? 'auto' : 'smooth',
+            block: 'center',
+          });
+        } catch {
+          node.scrollIntoView();
+        }
+        node.setAttribute('data-activity-focus', 'true');
+        // Remove after the 600ms pulse so a re-render doesn't re-trigger.
+        const cleanupId = window.setTimeout(() => {
+          if (!cancelled) node.removeAttribute('data-activity-focus');
+        }, 700);
+        // Strip the param from the URL so refresh doesn't re-pulse.
+        const newSearch = new URLSearchParams(location.search);
+        newSearch.delete('focus');
+        navigate(
+          { pathname: location.pathname, search: newSearch.toString() ? `?${newSearch.toString()}` : '' },
+          { replace: true }
+        );
+        return () => window.clearTimeout(cleanupId);
+      }
+      attempts += 1;
+      if (attempts < maxAttempts) {
+        window.setTimeout(tryFocus, 100);
+      }
+      return undefined;
+    };
+
+    const id = window.setTimeout(tryFocus, 50);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(id);
+    };
+    // We deliberately depend only on the search string so this fires once
+    // per navigation. Re-running on `location.pathname` would loop after we
+    // strip the param.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.search]);
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -32,6 +32,7 @@
   --color-accent-tasks:    #4338CA;
   --color-accent-notes:    #B45309;
   --color-accent-lists:    #0F766E;
+  --color-accent-activity: #7C3F58;
   --color-accent-settings: #475569;
 
   /* Active route accent (defaults to chat = ink; overridden by [data-route="..."]) */
@@ -69,6 +70,7 @@
   --color-accent-tasks:    #818CF8;
   --color-accent-notes:    #F59E0B;
   --color-accent-lists:    #2DD4BF;
+  --color-accent-activity: #E5A3BA;
   --color-accent-settings: #94A3B8;
 
   --color-accent-fg:   #14110D;
@@ -104,6 +106,7 @@
     --color-accent-tasks:    #818CF8;
     --color-accent-notes:    #F59E0B;
     --color-accent-lists:    #2DD4BF;
+    --color-accent-activity: #E5A3BA;
     --color-accent-settings: #94A3B8;
 
     --color-accent-fg:   #14110D;
@@ -126,6 +129,7 @@
 [data-route="tasks"]    { --color-accent: var(--color-accent-tasks); }
 [data-route="notes"]    { --color-accent: var(--color-accent-notes); }
 [data-route="lists"]    { --color-accent: var(--color-accent-lists); }
+[data-route="activity"] { --color-accent: var(--color-accent-activity); }
 [data-route="settings"] { --color-accent: var(--color-accent-settings); }
 
 @layer base {
@@ -142,6 +146,23 @@
     min-height: 100vh;
     min-height: -webkit-fill-available;
   }
+}
+
+/* Activity deep-link pulse. A 1px outline at the current accent ring colour
+   that fades over 600ms. The destination widget toggles `data-activity-focus`
+   on the focused row, scrolls it into view, then removes the attribute when
+   the animation ends. Honours prefers-reduced-motion via the global rule
+   below (animation-duration is collapsed to 0.01ms, so the pulse is skipped). */
+@keyframes activity-focus-pulse {
+  0%   { box-shadow: 0 0 0 0 var(--color-accent-ring); }
+  100% { box-shadow: 0 0 0 6px transparent; }
+}
+
+[data-activity-focus="true"] {
+  outline: 1px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: inherit;
+  animation: activity-focus-pulse 600ms ease-out;
 }
 
 /* Reduced motion — honour OS preference globally */

--- a/client/src/pages/ActivityPage.jsx
+++ b/client/src/pages/ActivityPage.jsx
@@ -1,0 +1,536 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  CheckSquare,
+  ChevronRight,
+  FileText,
+  Filter as FilterIcon,
+  Folder,
+  Inbox,
+  List as ListIcon,
+  RotateCw,
+} from 'lucide-react';
+import Card from '../components/Card';
+import { getActivity } from '../services/api';
+
+// =============================================================================
+// Activity Timeline page (issue #16)
+//
+// Read-only chronological feed of every note, todo, list, and folder the user
+// has created. Renders inside the existing Card primitive at max-w-3xl so it
+// matches the rest of the dashboard surfaces. Day-grouped rows, sticky day
+// headers, single-select filter chips, infinite scroll via IntersectionObserver,
+// deep-link to the owning section with focus + pulse on the destination row.
+// =============================================================================
+
+const FILTERS = [
+  { id: 'all',    label: 'All',     param: null },
+  { id: 'note',   label: 'Notes',   param: 'note' },
+  { id: 'todo',   label: 'Todos',   param: 'todo' },
+  { id: 'list',   label: 'Lists',   param: 'list' },
+  { id: 'folder', label: 'Folders', param: 'folder' },
+];
+
+const TYPE_META = {
+  note:   { Icon: FileText,    label: 'Note',   varName: '--color-accent-notes',    routeFor: (id) => `/notes?focus=${id}` },
+  todo:   { Icon: CheckSquare, label: 'Task',   varName: '--color-accent-tasks',    routeFor: (id) => `/tasks?focus=${id}` },
+  list:   { Icon: ListIcon,    label: 'List',   varName: '--color-accent-lists',    routeFor: (id) => `/lists?focus=${id}` },
+  folder: { Icon: Folder,      label: 'Folder', varName: '--color-muted',           routeFor: (id) => `/notes?folder=${id}` },
+};
+
+// ─── date helpers ────────────────────────────────────────────────────────────
+
+function startOfDay(date) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function dayKey(date) {
+  // YYYY-MM-DD in local time, used as the bucket key for grouping.
+  const d = startOfDay(date);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function formatDayHeader(date) {
+  const today = startOfDay(new Date());
+  const target = startOfDay(date);
+  const diffDays = Math.round((today - target) / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays > 1 && diffDays < 7) {
+    return target.toLocaleDateString(undefined, { weekday: 'long' });
+  }
+  const sameYear = today.getFullYear() === target.getFullYear();
+  if (sameYear) {
+    return target.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' });
+  }
+  return target.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function formatRelativeTime(date) {
+  const d = new Date(date);
+  const now = new Date();
+  const diffMs = now - d;
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return 'now';
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHour = Math.floor(diffMin / 60);
+  if (diffHour < 24) return `${diffHour}h`;
+  const today = startOfDay(now);
+  const target = startOfDay(d);
+  const diffDays = Math.round((today - target) / (1000 * 60 * 60 * 24));
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return target.toLocaleDateString(undefined, { weekday: 'short' });
+  const sameYear = today.getFullYear() === target.getFullYear();
+  if (sameYear) {
+    return target.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
+  }
+  return target.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function formatAbsolute(date) {
+  const d = new Date(date);
+  return d.toLocaleString(undefined, {
+    weekday: 'short', day: 'numeric', month: 'short', year: 'numeric',
+    hour: 'numeric', minute: '2-digit',
+  });
+}
+
+// ─── small UI atoms ──────────────────────────────────────────────────────────
+
+function FilterChips({ active, onChange }) {
+  return (
+    <div
+      role="group"
+      aria-label="Filter by type"
+      className="sticky top-[56px] z-10 flex flex-wrap items-center gap-2 px-5 py-3 bg-surface/95 backdrop-blur-sm border-b border-divider"
+    >
+      {FILTERS.map((f) => {
+        const isActive = active === f.id;
+        return (
+          <button
+            key={f.id}
+            type="button"
+            onClick={() => onChange(f.id)}
+            aria-pressed={isActive}
+            className={
+              'h-8 px-3 rounded-full text-sm transition-colors duration-150 ease-out ' +
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--color-accent-ring] ' +
+              (isActive
+                ? 'bg-[--color-accent-soft] border border-[--color-accent-ring] text-[--color-accent] font-medium'
+                : 'bg-paper-2 border border-border text-ink-soft hover:border-border-strong hover:text-ink')
+            }
+          >
+            {f.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function DayHeader({ label }) {
+  return (
+    <h2
+      className="sticky top-[112px] z-[5] flex items-center gap-2 px-5 h-9 bg-surface/95 backdrop-blur-sm border-b border-divider font-display text-base text-ink tracking-tight uppercase"
+      style={{ letterSpacing: '0.04em' }}
+    >
+      <span
+        aria-hidden="true"
+        className="inline-block w-1.5 h-1.5 rounded-full"
+        style={{ backgroundColor: 'var(--color-accent-activity)' }}
+      />
+      <span className="text-[13px] text-ink-soft">{label}</span>
+    </h2>
+  );
+}
+
+function ActivityRow({ item, isLast }) {
+  const navigate = useNavigate();
+  const meta = TYPE_META[item.type] ?? TYPE_META.note;
+  const { Icon, label, varName, routeFor } = meta;
+
+  const handleClick = () => {
+    navigate(routeFor(item.id));
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  };
+
+  // Composed accessible label per the design brief.
+  const ariaLabelParts = [`${label} created.`, item.title || 'Untitled'];
+  if (item.snippet) ariaLabelParts.push(item.snippet);
+  if (item.parent && item.type === 'note') ariaLabelParts.push(`In ${item.parent} folder.`);
+  ariaLabelParts.push(formatAbsolute(item.createdAt));
+  const ariaLabel = ariaLabelParts.join(' ');
+
+  return (
+    <div
+      role="link"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      aria-label={ariaLabel}
+      className={
+        'group flex items-center gap-3 px-5 py-3 cursor-pointer ' +
+        'hover:bg-paper-2 transition-colors duration-150 ease-out ' +
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[--color-accent-ring] ' +
+        (isLast ? '' : 'border-b border-divider')
+      }
+    >
+      {/* Tinted icon square: the only colour cue in the row. */}
+      <div
+        aria-hidden="true"
+        className="flex-shrink-0 w-8 h-8 rounded-md flex items-center justify-center"
+        style={{
+          backgroundColor: `color-mix(in oklab, var(${varName}) 12%, var(--color-paper))`,
+        }}
+      >
+        <Icon
+          size={18}
+          strokeWidth={1.75}
+          style={{ color: `var(${varName})` }}
+        />
+      </div>
+
+      {/* Title + snippet + parent breadcrumb */}
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-ink truncate">
+          {item.title || 'Untitled'}
+        </div>
+        {item.snippet ? (
+          <div className="text-sm text-muted line-clamp-1 mt-0.5">{item.snippet}</div>
+        ) : null}
+        {item.type === 'note' && item.parent ? (
+          <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-soft">
+            <Folder size={10} strokeWidth={1.75} aria-hidden="true" />
+            <span className="truncate">{item.parent}</span>
+          </div>
+        ) : null}
+      </div>
+
+      {/* Right-aligned time + chevron-on-hover */}
+      <div className="flex-shrink-0 flex items-center gap-1">
+        <span
+          className="text-xs text-muted-soft whitespace-nowrap group-hover:hidden"
+          title={formatAbsolute(item.createdAt)}
+          aria-label={formatAbsolute(item.createdAt)}
+        >
+          {formatRelativeTime(item.createdAt)}
+        </span>
+        <ChevronRight
+          size={16}
+          strokeWidth={1.75}
+          className="hidden group-hover:block text-muted-soft"
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── skeleton bones ──────────────────────────────────────────────────────────
+
+function PulseBone({ className = '', style = {} }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`bg-paper-2 rounded-sm activity-skeleton-pulse ${className}`}
+      style={style}
+    />
+  );
+}
+
+function RowSkeleton({ isLast }) {
+  return (
+    <div className={`flex items-center gap-3 px-5 py-3 ${isLast ? '' : 'border-b border-divider'}`}>
+      <PulseBone className="flex-shrink-0 w-8 h-8 rounded-md" />
+      <div className="flex-1 min-w-0 space-y-1.5">
+        <PulseBone className="h-3 rounded-sm" style={{ width: '60%' }} />
+        <PulseBone className="h-2.5 rounded-sm" style={{ width: '90%' }} />
+      </div>
+      <PulseBone className="flex-shrink-0 w-8 h-3" />
+    </div>
+  );
+}
+
+function FirstLoadSkeleton() {
+  return (
+    <div aria-busy="true" aria-label="Loading activity">
+      {[0, 1, 2].map((groupIdx) => (
+        <div key={groupIdx} className={groupIdx === 0 ? '' : 'mt-6'}>
+          <div className="flex items-center gap-2 px-5 h-9 border-b border-divider">
+            <PulseBone className="w-1.5 h-1.5 rounded-full" />
+            <PulseBone className="h-3" style={{ width: 80 }} />
+          </div>
+          {[0, 1, 2, 3].map((rowIdx) => (
+            <RowSkeleton key={rowIdx} isLast={rowIdx === 3} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function NextPageSkeleton() {
+  return (
+    <div aria-busy="true" aria-label="Loading more">
+      <RowSkeleton isLast={false} />
+      <RowSkeleton isLast />
+    </div>
+  );
+}
+
+// ─── empty state ─────────────────────────────────────────────────────────────
+
+function EmptyState({ filterId }) {
+  if (filterId === 'all') {
+    return (
+      <div className="flex flex-col items-center text-center py-20 px-5">
+        <Inbox size={28} className="text-muted mb-3" strokeWidth={1.5} aria-hidden="true" />
+        <div className="text-base text-ink-soft">Nothing here yet.</div>
+        <div className="text-sm text-muted mt-1 max-w-xs">
+          Notes, todos, lists, and folders you create will show up here.
+        </div>
+      </div>
+    );
+  }
+  const filter = FILTERS.find((f) => f.id === filterId);
+  const typeLabel = filter ? filter.label.toLowerCase() : 'items';
+  return (
+    <div className="flex flex-col items-center text-center py-20 px-5">
+      <FilterIcon size={28} className="text-muted mb-3" strokeWidth={1.5} aria-hidden="true" />
+      <div className="text-base text-ink-soft">No {typeLabel} here yet.</div>
+      <div className="text-sm text-muted mt-1">Switch to All to see everything.</div>
+    </div>
+  );
+}
+
+// ─── main page ───────────────────────────────────────────────────────────────
+
+export default function ActivityPage() {
+  const [filterId, setFilterId] = useState('all');
+  const [items, setItems] = useState([]);
+  const [cursor, setCursor] = useState(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [isFirstLoad, setIsFirstLoad] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  const sentinelRef = useRef(null);
+  // Guard against stale-filter races: if the user flips the filter mid-fetch,
+  // any still-in-flight response should be ignored when it eventually arrives.
+  const requestIdRef = useRef(0);
+
+  // Group items by local day. Memoised so we don't re-bucket on every render.
+  const groups = useMemo(() => {
+    const map = new Map();
+    for (const item of items) {
+      const key = dayKey(item.createdAt);
+      if (!map.has(key)) {
+        map.set(key, { key, date: new Date(item.createdAt), items: [] });
+      }
+      map.get(key).items.push(item);
+    }
+    // Map iteration preserves insertion order, which mirrors server order
+    // (newest first), so we don't need to re-sort.
+    return Array.from(map.values());
+  }, [items]);
+
+  // ── fetch first page (or refetch on filter / refresh) ──────────────────────
+  const loadFirst = useCallback(async (selectedFilterId) => {
+    const myRequestId = ++requestIdRef.current;
+    setIsFirstLoad(true);
+    setError(null);
+    setItems([]);
+    setCursor(null);
+    setHasMore(false);
+
+    const filter = FILTERS.find((f) => f.id === selectedFilterId);
+    try {
+      const { data } = await getActivity({ type: filter?.param ?? null });
+      if (myRequestId !== requestIdRef.current) return; // stale response
+      const nextItems = Array.isArray(data?.items) ? data.items : [];
+      setItems(nextItems);
+      setCursor(data?.nextCursor ?? null);
+      setHasMore(Boolean(data?.nextCursor));
+    } catch (err) {
+      if (myRequestId !== requestIdRef.current) return;
+      setError(err?.message || 'Failed to load activity.');
+    } finally {
+      if (myRequestId === requestIdRef.current) {
+        setIsFirstLoad(false);
+      }
+    }
+  }, []);
+
+  // ── fetch next page ────────────────────────────────────────────────────────
+  const loadMore = useCallback(async () => {
+    if (!cursor || isLoadingMore || isFirstLoad) return;
+    const myRequestId = requestIdRef.current; // no bump: appending under same filter
+    setIsLoadingMore(true);
+    setError(null);
+    const filter = FILTERS.find((f) => f.id === filterId);
+    try {
+      const { data } = await getActivity({ cursor, type: filter?.param ?? null });
+      if (myRequestId !== requestIdRef.current) return; // filter changed mid-flight
+      const nextItems = Array.isArray(data?.items) ? data.items : [];
+      setItems((prev) => [...prev, ...nextItems]);
+      setCursor(data?.nextCursor ?? null);
+      setHasMore(Boolean(data?.nextCursor));
+    } catch (err) {
+      if (myRequestId !== requestIdRef.current) return;
+      setError(err?.message || 'Failed to load more.');
+    } finally {
+      if (myRequestId === requestIdRef.current) {
+        setIsLoadingMore(false);
+      }
+    }
+  }, [cursor, filterId, isLoadingMore, isFirstLoad]);
+
+  // Trigger first-page fetch on mount + on filter change + on manual refresh.
+  useEffect(() => {
+    loadFirst(filterId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterId, refreshTick]);
+
+  // IntersectionObserver on the sentinel: fires loadMore when within 600px
+  // of the viewport bottom. Only attached when there's more to load.
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node || !hasMore || isFirstLoad) return undefined;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            loadMore();
+            break;
+          }
+        }
+      },
+      { rootMargin: '600px 0px' }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [hasMore, isFirstLoad, loadMore, items.length]);
+
+  const handleRefresh = () => {
+    setRefreshTick((t) => t + 1);
+  };
+
+  const isEmpty = !isFirstLoad && items.length === 0 && !error;
+
+  return (
+    <>
+      <style>{`
+        @keyframes activity-skeleton {
+          0%   { opacity: 0.4; }
+          50%  { opacity: 0.7; }
+          100% { opacity: 0.4; }
+        }
+        .activity-skeleton-pulse {
+          animation: activity-skeleton 1.4s ease-in-out infinite;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .activity-skeleton-pulse { animation: none; opacity: 0.55; }
+        }
+      `}</style>
+
+      <main
+        aria-labelledby="activity-heading"
+        className="px-6 md:px-10 py-8 max-w-3xl mx-auto w-full"
+      >
+        {/* Page header: matches PageTitle vibe but adds a refresh control. */}
+        <header className="flex items-start justify-between gap-4 mb-6">
+          <div>
+            <h1
+              id="activity-heading"
+              className="font-display text-3xl text-ink leading-tight tracking-tight"
+              style={{ letterSpacing: '-0.01em' }}
+            >
+              Activity
+            </h1>
+            <span
+              aria-hidden="true"
+              className="block h-[2px] w-8 bg-[--color-accent] mt-2"
+            />
+            <p className="mt-3 text-sm text-muted leading-[1.55]">
+              Everything you have captured, newest first.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={isFirstLoad}
+            aria-label="Refresh activity"
+            title="Refresh"
+            className={
+              'flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center ' +
+              'text-muted hover:text-ink hover:bg-paper-2 transition-colors duration-150 ease-out ' +
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--color-accent-ring] ' +
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            }
+          >
+            <RotateCw
+              size={18}
+              strokeWidth={1.75}
+              className={isFirstLoad ? 'animate-spin' : ''}
+              aria-hidden="true"
+            />
+          </button>
+        </header>
+
+        <Card padding="p-0" className="overflow-hidden">
+          <FilterChips active={filterId} onChange={setFilterId} />
+
+          {isFirstLoad ? (
+            <FirstLoadSkeleton />
+          ) : isEmpty ? (
+            <EmptyState filterId={filterId} />
+          ) : (
+            <div>
+              {groups.map((group, gi) => (
+                <section key={group.key} className={gi === 0 ? '' : 'mt-6'}>
+                  <DayHeader label={formatDayHeader(group.date)} />
+                  <div>
+                    {group.items.map((item, idx) => (
+                      <ActivityRow
+                        key={`${item.type}-${item.id}`}
+                        item={item}
+                        isLast={idx === group.items.length - 1}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))}
+
+              {/* Subsequent-page skeleton + sentinel */}
+              {isLoadingMore ? <NextPageSkeleton /> : null}
+
+              {error && !isFirstLoad ? (
+                <button
+                  type="button"
+                  onClick={loadMore}
+                  className="w-full text-center py-4 text-sm text-danger hover:bg-paper-2 transition-colors"
+                >
+                  Couldn't load more. Tap to retry.
+                </button>
+              ) : null}
+
+              {hasMore ? (
+                <div ref={sentinelRef} aria-hidden="true" className="h-px" />
+              ) : null}
+            </div>
+          )}
+        </Card>
+      </main>
+    </>
+  );
+}

--- a/client/src/pages/ListsPage.jsx
+++ b/client/src/pages/ListsPage.jsx
@@ -1,10 +1,13 @@
 import ListsWidget from '../components/ListsWidget';
 import PageTitle from '../components/PageTitle';
+import { useActivityFocus } from '../hooks/useActivityFocus';
 
 /**
  * v2 Lists page — wraps ListsWidget under the new shell.
+ * Honours `?focus=<id>` from the Activity timeline deep-link.
  */
 export default function ListsPage() {
+  useActivityFocus();
   return (
     <div className="px-6 md:px-10 py-8 max-w-3xl mx-auto w-full h-full flex flex-col min-h-0">
       <PageTitle subtitle="Curated checklists.">

--- a/client/src/pages/NotesPage.jsx
+++ b/client/src/pages/NotesPage.jsx
@@ -1,18 +1,50 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import NotesWidget from '../components/NotesWidget';
 import PageTitle from '../components/PageTitle';
+import { useActivityFocus } from '../hooks/useActivityFocus';
 
 /**
- * v2 Notes page — wraps NotesWidget under the new shell. Folder/note
- * URL params will be picked up by the widget itself in step 7.
+ * v2 Notes page — wraps NotesWidget under the new shell.
+ *
+ * Activity timeline deep-link:
+ *   - `?focus=<note-id>` scrolls to the matching note (handled by useActivityFocus).
+ *   - `?folder=<folder-id>` pre-selects the folder via the widget's imperative
+ *     `selectFolder` method, so the user lands inside that folder's note list.
  */
 export default function NotesPage() {
+  const location = useLocation();
+  const widgetRef = useRef(null);
+
+  useActivityFocus();
+
+  // Read `?folder=<id>` once on mount + whenever it changes. Pull from
+  // location.search rather than useSearchParams to keep this minimal and not
+  // pull in extra dependencies.
+  const params = new URLSearchParams(location.search);
+  const folderParam = params.get('folder');
+
+  useEffect(() => {
+    if (!folderParam) return;
+    // Defer the imperative call so the widget has time to mount its state
+    // and resolve `selectedFolderId` past its initial value.
+    const id = window.setTimeout(() => {
+      widgetRef.current?.selectFolder?.(folderParam);
+    }, 50);
+    return () => window.clearTimeout(id);
+  }, [folderParam]);
+
   return (
     <div className="px-6 md:px-10 py-8 max-w-5xl mx-auto w-full h-full flex flex-col min-h-0">
       <PageTitle subtitle="Your notebook.">
         Notes
       </PageTitle>
       <div className="mt-8 flex-1 min-h-0">
-        <NotesWidget fullHeight />
+        <NotesWidget
+          ref={widgetRef}
+          fullHeight
+          initialFolderId={folderParam ?? null}
+        />
       </div>
     </div>
   );

--- a/client/src/pages/TasksPage.jsx
+++ b/client/src/pages/TasksPage.jsx
@@ -1,12 +1,18 @@
 import TodoWidget from '../components/TodoWidget';
 import PageTitle from '../components/PageTitle';
+import { useActivityFocus } from '../hooks/useActivityFocus';
 
 /**
  * v2 Tasks page — thin wrapper around the existing TodoWidget so it
  * mounts under the new AppShell. The widget itself doesn't get the
  * v2 visual treatment yet (that's step 7); this just re-parents it.
+ *
+ * Activity timeline deep-link: when arriving with `?focus=<id>` the
+ * useActivityFocus hook scrolls the matching row (data-activity-id) into
+ * view and pulses it via the global `[data-activity-focus]` CSS rule.
  */
 export default function TasksPage() {
+  useActivityFocus();
   return (
     <div className="px-6 md:px-10 py-8 max-w-3xl mx-auto w-full h-full flex flex-col min-h-0">
       <PageTitle subtitle="Capture, defer, complete.">

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -42,6 +42,16 @@ export const updateConfig = (layout_preference) => api.put('/config', { layout_p
 
 export const getStats = () => api.get('/stats');
 
+// Activity timeline (issue #16): read-only feed of every create event.
+// Server contract: /api/dashboard/activity?cursor=<iso>:<type>:<id>&type=<note|todo|list|folder>&limit=<n>
+export const getActivity = ({ cursor, type, limit } = {}) => {
+  const params = {};
+  if (cursor) params.cursor = cursor;
+  if (type) params.type = type;
+  if (limit) params.limit = limit;
+  return api.get('/dashboard/activity', { params });
+};
+
 // AI Parse endpoint
 export const aiParse = (input) => api.post('/ai/parse', { input });
 

--- a/mobile/PersonalDashboard/App/AppRouter.swift
+++ b/mobile/PersonalDashboard/App/AppRouter.swift
@@ -1,6 +1,27 @@
 import SwiftUI
 import Observation
 
+/// Activity timeline deep-link payload. The Activity surface sets this when
+/// the user taps a row, then pushes the destination section. The destination
+/// view consumes the focus on appearance: scrolls the matching item into
+/// view, plays the 600ms accent pulse, then clears the field. Folder
+/// deep-links re-use the `id` slot for the folder identifier; section
+/// disambiguates the meaning.
+struct ActivityFocus: Equatable {
+    /// Where the focus should land. Determines which destination view reads it.
+    let section: AppSection
+    /// Server-side integer id of the row (or folder) to focus.
+    let id: Int
+    /// True for a folder deep-link (section is .notes, but the id is a folder).
+    let isFolder: Bool
+
+    init(section: AppSection, id: Int, isFolder: Bool = false) {
+        self.section = section
+        self.id = id
+        self.isFolder = isFolder
+    }
+}
+
 /// Holds navigation state for the chat-rooted stack and the drawer.
 @Observable
 @MainActor
@@ -14,6 +35,11 @@ final class AppRouter {
         return []
     }()
     var drawerOpen: Bool = (ProcessInfo.processInfo.environment["LAUNCH_DRAWER"] == "1")
+
+    /// Pending Activity timeline deep-link target. The destination view reads
+    /// this on `task` / `onAppear`, applies the scroll + pulse, then sets it
+    /// back to nil so it doesn't fire again on the next appearance.
+    var focus: ActivityFocus?
 
     /// Push a section into the chat-rooted stack and close the drawer.
     func go(to section: AppSection) {

--- a/mobile/PersonalDashboard/Design/Tokens.swift
+++ b/mobile/PersonalDashboard/Design/Tokens.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // MARK: - Section identity
 

--- a/mobile/PersonalDashboard/Design/Tokens.swift
+++ b/mobile/PersonalDashboard/Design/Tokens.swift
@@ -9,6 +9,7 @@ enum AppSection: String, CaseIterable, Identifiable, Hashable {
     case notes
     case lists
     case dashboard
+    case activity
     case settings
 
     var id: String { rawValue }
@@ -21,6 +22,7 @@ enum AppSection: String, CaseIterable, Identifiable, Hashable {
         case .notes:     return "Notes"
         case .lists:     return "Lists"
         case .dashboard: return "Dashboard"
+        case .activity:  return "Activity"
         case .settings:  return "Settings"
         }
     }
@@ -34,6 +36,7 @@ enum AppSection: String, CaseIterable, Identifiable, Hashable {
         case .notes:     return "doc.text"
         case .lists:     return "list.bullet"
         case .dashboard: return "rectangle.grid.2x2"
+        case .activity:  return "clock.arrow.circlepath"
         case .settings:  return "gearshape"
         }
     }
@@ -80,6 +83,7 @@ enum Tokens {
     static let accentNotes     = Color.paper(0xB45309, 0xF59E0B)
     static let accentLists     = Color.paper(0x0F766E, 0x2DD4BF)
     static let accentDashboard = Color.paper(0x1F1B16, 0xF2EBDA)
+    static let accentActivity  = Color.paper(0x7C3F58, 0xE5A3BA)
     static let accentSettings  = Color.paper(0x475569, 0x94A3B8)
     static let accentFg        = Color.paper(0xFFFFFF, 0x14110D)
 
@@ -100,6 +104,7 @@ enum Tokens {
         case .notes:     return accentNotes
         case .lists:     return accentLists
         case .dashboard: return accentDashboard
+        case .activity:  return accentActivity
         case .settings:  return accentSettings
         }
     }

--- a/mobile/PersonalDashboard/Models/ActivityItem.swift
+++ b/mobile/PersonalDashboard/Models/ActivityItem.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// One row from `GET /api/dashboard/activity`. Server identity is the integer
+/// `id`; type discriminates the entity. The activity surface is read-only:
+/// the iOS app never writes to this endpoint.
+struct ActivityItem: Decodable, Identifiable, Equatable {
+    enum ItemType: String, Decodable, CaseIterable {
+        case note
+        case todo
+        case list
+        case folder
+    }
+
+    let id: Int
+    let type: ItemType
+    let title: String
+    let snippet: String?
+    let parent: String?
+    let createdAt: Date
+
+    /// SwiftUI `ForEach` needs a stable identifier and we may show the same
+    /// integer id for two different types in the same feed (a note id 5 and a
+    /// folder id 5). Combine the two into a string key.
+    var rowKey: String { "\(type.rawValue)-\(id)" }
+}
+
+/// Payload returned by the activity endpoint. `nextCursor` is null on the
+/// last page; clients stop paginating when it disappears.
+struct ActivityPage: Decodable {
+    let items: [ActivityItem]
+    let nextCursor: String?
+}

--- a/mobile/PersonalDashboard/Services/ActivityService.swift
+++ b/mobile/PersonalDashboard/Services/ActivityService.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Read-only client for the activity timeline endpoint.
+///
+/// The activity feed is server-driven (UNION across todos, notes, lists,
+/// note_folders) rather than reading from the local SwiftData store, so the
+/// surface always reflects what's actually on the Mac. There is no offline
+/// fallback in v1: if the request fails, the view shows an empty/error
+/// state and the user can pull to refresh.
+struct ActivityService: Sendable {
+    let api: APIClient
+
+    init(api: APIClient = .shared) {
+        self.api = api
+    }
+
+    /// Fetch one page of activity. Pass `cursor` (the value from the previous
+    /// page's `nextCursor`) to load the next page; pass `type` to filter to
+    /// a single entity type.
+    func page(cursor: String? = nil, type: ActivityItem.ItemType? = nil, limit: Int = 50) async throws -> ActivityPage {
+        var query: [URLQueryItem] = []
+        if let cursor { query.append(URLQueryItem(name: "cursor", value: cursor)) }
+        if let type { query.append(URLQueryItem(name: "type", value: type.rawValue)) }
+        query.append(URLQueryItem(name: "limit", value: String(limit)))
+        return try await api.get("dashboard/activity", query: query)
+    }
+}

--- a/mobile/PersonalDashboard/ViewModels/ActivityViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ActivityViewModel.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Observation
+
+/// State holder for the Activity surface. Pure remote, no local cache. The
+/// service is injected so tests can stub it.
+///
+/// Pagination model: the server returns up to `limit` items plus a
+/// `nextCursor`. When `nextCursor` is null, we stop paginating. Filter
+/// changes reset the cursor and clear the items.
+@Observable
+@MainActor
+final class ActivityViewModel {
+    enum Filter: Equatable, CaseIterable, Identifiable {
+        case all
+        case note
+        case todo
+        case list
+        case folder
+
+        var id: String {
+            switch self {
+            case .all:    return "all"
+            case .note:   return "note"
+            case .todo:   return "todo"
+            case .list:   return "list"
+            case .folder: return "folder"
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .all:    return "All"
+            case .note:   return "Notes"
+            case .todo:   return "Todos"
+            case .list:   return "Lists"
+            case .folder: return "Folders"
+            }
+        }
+
+        /// `nil` for `.all`; the wire value otherwise.
+        var typeParam: ActivityItem.ItemType? {
+            switch self {
+            case .all:    return nil
+            case .note:   return .note
+            case .todo:   return .todo
+            case .list:   return .list
+            case .folder: return .folder
+            }
+        }
+    }
+
+    private(set) var items: [ActivityItem] = []
+    private(set) var nextCursor: String?
+    private(set) var isLoading = false
+    private(set) var isLoadingMore = false
+    var errorMessage: String?
+    var filter: Filter = .all
+
+    /// Bumped on every fresh load so a stale-filter response can be discarded
+    /// when the user flips filters mid-fetch.
+    private var requestGeneration = 0
+
+    private let service: ActivityService
+
+    init(service: ActivityService = ActivityService()) {
+        self.service = service
+    }
+
+    /// First page or refresh after filter change. Clears items, shows the
+    /// first-load skeleton in the view, and resets the cursor.
+    func loadFirstPage() async {
+        let myGen = bumpGeneration()
+        isLoading = true
+        errorMessage = nil
+        items = []
+        nextCursor = nil
+
+        do {
+            let page = try await service.page(cursor: nil, type: filter.typeParam)
+            guard myGen == requestGeneration else { return }
+            items = page.items
+            nextCursor = page.nextCursor
+        } catch {
+            guard myGen == requestGeneration else { return }
+            errorMessage = error.localizedDescription
+        }
+        if myGen == requestGeneration {
+            isLoading = false
+        }
+    }
+
+    /// Append the next page if a cursor exists. No-op while another fetch is
+    /// in flight or there are no more pages.
+    func loadNextPage() async {
+        guard let cursor = nextCursor, !isLoadingMore, !isLoading else { return }
+        let myGen = requestGeneration
+        isLoadingMore = true
+        errorMessage = nil
+        do {
+            let page = try await service.page(cursor: cursor, type: filter.typeParam)
+            guard myGen == requestGeneration else { return }
+            items.append(contentsOf: page.items)
+            nextCursor = page.nextCursor
+        } catch {
+            guard myGen == requestGeneration else { return }
+            errorMessage = error.localizedDescription
+        }
+        if myGen == requestGeneration {
+            isLoadingMore = false
+        }
+    }
+
+    /// Pull-to-refresh hook. Same effect as `loadFirstPage`.
+    func refresh() async {
+        await loadFirstPage()
+    }
+
+    /// Switch the active filter and re-fetch. No-op if the filter is unchanged.
+    func setFilter(_ next: Filter) async {
+        guard next != filter else { return }
+        filter = next
+        await loadFirstPage()
+    }
+
+    private func bumpGeneration() -> Int {
+        requestGeneration += 1
+        return requestGeneration
+    }
+}

--- a/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
+++ b/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
@@ -1,0 +1,489 @@
+import SwiftUI
+
+/// Activity timeline surface (issue #16). Read-only chronological feed of
+/// every note, todo, list, and folder the user has created. Same shape as the
+/// web version: filter chips, day-grouped rows with sticky headers, infinite
+/// scroll via the last-row sentinel, deep-link to the owning section with a
+/// brief accent pulse on the focused row.
+struct ActivityView: View {
+    @State private var viewModel = ActivityViewModel()
+
+    @Bindable var router: AppRouter
+    @Binding var schemePref: ColorSchemePref
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Tokens.paper.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                TopBar(
+                    title: "Activity",
+                    onMenu: {
+                        withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true }
+                    },
+                    onToggleTheme: { schemePref = schemePref.next }
+                )
+
+                // Caption sits under TopBar, mirroring the web subtitle.
+                Text("Everything you have captured, newest first.")
+                    .font(.edSubheadline)
+                    .foregroundStyle(Tokens.muted)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, Space.lg)
+                    .padding(.top, Space.sm)
+                    .padding(.bottom, Space.sm)
+
+                FilterChipBar(
+                    selected: viewModel.filter,
+                    onSelect: { next in
+                        Task { await viewModel.setFilter(next) }
+                    }
+                )
+                .padding(.horizontal, Space.lg)
+                .padding(.vertical, Space.sm)
+
+                Divider().background(Tokens.divider)
+
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0, pinnedViews: [.sectionHeaders]) {
+                        if viewModel.isLoading {
+                            FirstLoadSkeleton()
+                        } else if viewModel.items.isEmpty {
+                            EmptyStateView(filter: viewModel.filter)
+                                .frame(maxWidth: .infinity)
+                                .padding(.top, Space.xxxl)
+                        } else {
+                            ForEach(groups, id: \.key) { group in
+                                Section(header: dayHeader(for: group)) {
+                                    ForEach(Array(group.items.enumerated()), id: \.element.rowKey) { idx, item in
+                                        ActivityRow(item: item) {
+                                            handleTap(item: item)
+                                        }
+                                        if idx < group.items.count - 1 {
+                                            Rectangle()
+                                                .fill(Tokens.divider)
+                                                .frame(height: 0.5)
+                                                .padding(.leading, Space.lg)
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Subsequent-page skeleton + load-more sentinel
+                            if viewModel.isLoadingMore {
+                                NextPageSkeleton()
+                            }
+
+                            if viewModel.nextCursor != nil {
+                                Color.clear
+                                    .frame(height: 1)
+                                    .onAppear {
+                                        Task { await viewModel.loadNextPage() }
+                                    }
+                            }
+
+                            if let err = viewModel.errorMessage, !viewModel.isLoading {
+                                Button {
+                                    Task { await viewModel.loadNextPage() }
+                                } label: {
+                                    Text("Couldn't load more. Tap to retry.")
+                                        .font(.edSubheadline)
+                                        .foregroundStyle(Tokens.danger)
+                                        .frame(maxWidth: .infinity)
+                                        .padding(.vertical, Space.lg)
+                                        .accessibilityLabel("Retry loading more. \(err)")
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                    .padding(.bottom, 96) // FAB clearance
+                }
+                .refreshable { await viewModel.refresh() }
+            }
+
+            ChatFAB { router.popToChat() }
+        }
+        .activeSection(.activity)
+        .task { await viewModel.loadFirstPage() }
+    }
+
+    // MARK: - Tap → deep-link
+
+    private func handleTap(item: ActivityItem) {
+        let target: AppSection
+        let isFolder: Bool
+        switch item.type {
+        case .note:   target = .notes; isFolder = false
+        case .todo:   target = .tasks; isFolder = false
+        case .list:   target = .lists; isFolder = false
+        case .folder: target = .notes; isFolder = true // folder deep-link lands in Notes
+        }
+        router.focus = ActivityFocus(section: target, id: item.id, isFolder: isFolder)
+        router.go(to: target)
+    }
+
+    // MARK: - Grouping
+
+    /// Bucket items by local-day. Server delivers them newest-first already,
+    /// so we just walk in order and group.
+    private var groups: [DayGroup] {
+        var result: [DayGroup] = []
+        var current: DayGroup?
+        let calendar = Calendar.current
+        for item in viewModel.items {
+            let key = calendar.startOfDay(for: item.createdAt)
+            if current?.key != key {
+                if let c = current { result.append(c) }
+                current = DayGroup(key: key, items: [item])
+            } else {
+                current?.items.append(item)
+            }
+        }
+        if let c = current { result.append(c) }
+        return result
+    }
+
+    private func dayHeader(for group: DayGroup) -> some View {
+        HStack(spacing: Space.sm) {
+            Circle()
+                .fill(Tokens.accentActivity)
+                .frame(width: 6, height: 6)
+            Text(formatDayHeader(group.key))
+                .font(.edEyebrow)
+                .textCase(.uppercase)
+                .tracking(1.4)
+                .foregroundStyle(Tokens.inkSoft)
+            Spacer()
+        }
+        .frame(height: 36)
+        .padding(.horizontal, Space.lg)
+        .background(
+            Tokens.paper
+                .opacity(0.95)
+                .overlay(alignment: .bottom) {
+                    Rectangle().fill(Tokens.divider).frame(height: 0.5)
+                }
+        )
+    }
+}
+
+// MARK: - Day group helper
+
+private struct DayGroup {
+    let key: Date
+    var items: [ActivityItem]
+}
+
+// MARK: - Filter chips
+
+private struct FilterChipBar: View {
+    let selected: ActivityViewModel.Filter
+    let onSelect: (ActivityViewModel.Filter) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Space.sm) {
+                ForEach(ActivityViewModel.Filter.allCases) { filter in
+                    let isActive = filter == selected
+                    Button {
+                        onSelect(filter)
+                    } label: {
+                        Text(filter.label)
+                            .font(.edSubheadline)
+                            .foregroundStyle(isActive ? Tokens.accentActivity : Tokens.inkSoft)
+                            .padding(.horizontal, Space.md)
+                            .frame(minHeight: 36)
+                            .background(
+                                Capsule().fill(isActive ? Tokens.accentActivity.opacity(0.12) : Tokens.paper2)
+                            )
+                            .overlay(
+                                Capsule().stroke(
+                                    isActive ? Tokens.accentActivity.opacity(0.35) : Tokens.border,
+                                    lineWidth: 0.5
+                                )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityAddTraits(isActive ? [.isSelected, .isButton] : .isButton)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct ActivityRow: View {
+    let item: ActivityItem
+    let onTap: () -> Void
+
+    @State private var pressed = false
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(alignment: .center, spacing: Space.md) {
+                tintedIcon
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.title.isEmpty ? "Untitled" : item.title)
+                        .font(.edBodyMedium)
+                        .foregroundStyle(Tokens.ink)
+                        .lineLimit(1)
+                    if let snippet = item.snippet, !snippet.isEmpty {
+                        Text(snippet)
+                            .font(.edSubheadline)
+                            .foregroundStyle(Tokens.muted)
+                            .lineLimit(1)
+                    }
+                    if item.type == .note, let parent = item.parent, !parent.isEmpty {
+                        HStack(spacing: 4) {
+                            Image(systemName: "folder")
+                                .font(.system(size: 10))
+                            Text(parent)
+                                .lineLimit(1)
+                        }
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.mutedSoft)
+                    }
+                }
+
+                Spacer(minLength: Space.sm)
+
+                Text(formatRelative(item.createdAt))
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+                    .accessibilityLabel(formatAbsolute(item.createdAt))
+            }
+            .padding(.horizontal, Space.lg)
+            .padding(.vertical, Space.md)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .scaleEffect(pressed ? 0.99 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var tintedIcon: some View {
+        let accent = iconAccent(for: item.type)
+        return Image(systemName: iconName(for: item.type))
+            .font(.system(size: 16, weight: .regular))
+            .foregroundStyle(accent)
+            .frame(width: 32, height: 32)
+            .background(accent.opacity(0.12), in: RoundedRectangle(cornerRadius: Radius.sm, style: .continuous))
+    }
+
+    private func iconName(for type: ActivityItem.ItemType) -> String {
+        switch type {
+        case .note:   return "note.text"
+        case .todo:   return "checkmark.square"
+        case .list:   return "list.bullet"
+        case .folder: return "folder"
+        }
+    }
+
+    private func iconAccent(for type: ActivityItem.ItemType) -> Color {
+        switch type {
+        case .note:   return Tokens.accentNotes
+        case .todo:   return Tokens.accentTasks
+        case .list:   return Tokens.accentLists
+        case .folder: return Tokens.muted
+        }
+    }
+
+    private var accessibilityLabel: String {
+        let kind: String
+        switch item.type {
+        case .note:   kind = "Note"
+        case .todo:   kind = "Task"
+        case .list:   kind = "List"
+        case .folder: kind = "Folder"
+        }
+        var parts = ["\(kind) created.", item.title.isEmpty ? "Untitled" : item.title]
+        if let s = item.snippet, !s.isEmpty { parts.append(s) }
+        if item.type == .note, let p = item.parent, !p.isEmpty {
+            parts.append("In \(p) folder.")
+        }
+        parts.append(formatAbsolute(item.createdAt))
+        return parts.joined(separator: " ")
+    }
+}
+
+// MARK: - Skeletons
+
+private struct FirstLoadSkeleton: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(0..<3, id: \.self) { groupIdx in
+                if groupIdx > 0 {
+                    Color.clear.frame(height: Space.xl)
+                }
+                // Day header bone
+                HStack(spacing: Space.sm) {
+                    Circle().fill(Tokens.paper2).frame(width: 6, height: 6)
+                    PulseBone()
+                        .frame(width: 80, height: 12)
+                        .clipShape(RoundedRectangle(cornerRadius: 3))
+                    Spacer()
+                }
+                .padding(.horizontal, Space.lg)
+                .frame(height: 36)
+                .overlay(alignment: .bottom) {
+                    Rectangle().fill(Tokens.divider).frame(height: 0.5)
+                }
+
+                ForEach(0..<4, id: \.self) { rowIdx in
+                    SkeletonRow()
+                    if rowIdx < 3 {
+                        Rectangle()
+                            .fill(Tokens.divider)
+                            .frame(height: 0.5)
+                            .padding(.leading, Space.lg)
+                    }
+                }
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+private struct NextPageSkeleton: View {
+    var body: some View {
+        VStack(spacing: 0) {
+            SkeletonRow()
+            Rectangle().fill(Tokens.divider).frame(height: 0.5).padding(.leading, Space.lg)
+            SkeletonRow()
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+private struct SkeletonRow: View {
+    var body: some View {
+        HStack(alignment: .center, spacing: Space.md) {
+            PulseBone()
+                .frame(width: 32, height: 32)
+                .clipShape(RoundedRectangle(cornerRadius: Radius.sm, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 6) {
+                PulseBone()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 12)
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                    .padding(.trailing, 100) // simulate ~60% width
+                PulseBone()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 10)
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                    .padding(.trailing, 30)
+            }
+
+            PulseBone()
+                .frame(width: 32, height: 12)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+        }
+        .padding(.horizontal, Space.lg)
+        .padding(.vertical, Space.md)
+    }
+}
+
+/// 1.4s ease-in-out opacity pulse on `Tokens.paper2`. Honours the system
+/// reduced-motion preference by holding at a static 55% opacity.
+private struct PulseBone: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var animate = false
+
+    var body: some View {
+        Tokens.paper2
+            .opacity(reduceMotion ? 0.55 : (animate ? 0.7 : 0.4))
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
+                    animate = true
+                }
+            }
+    }
+}
+
+// MARK: - Empty state
+
+private struct EmptyStateView: View {
+    let filter: ActivityViewModel.Filter
+
+    var body: some View {
+        VStack(spacing: Space.sm) {
+            Image(systemName: filter == .all ? "tray" : "line.3.horizontal.decrease")
+                .font(.system(size: 28, weight: .regular))
+                .foregroundStyle(Tokens.muted)
+            Text(headline)
+                .font(.edBodyMedium)
+                .foregroundStyle(Tokens.inkSoft)
+            Text(sub)
+                .font(.edSubheadline)
+                .foregroundStyle(Tokens.muted)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Space.lg)
+        }
+        .padding(.vertical, Space.xxxl)
+        .frame(maxWidth: .infinity)
+    }
+
+    private var headline: String {
+        if filter == .all { return "Nothing here yet." }
+        return "No \(filter.label.lowercased()) here yet."
+    }
+
+    private var sub: String {
+        if filter == .all { return "Notes, todos, lists, and folders you create will show up here." }
+        return "Switch to All to see everything."
+    }
+}
+
+// MARK: - Date formatting helpers (file-private)
+
+private func formatDayHeader(_ date: Date) -> String {
+    let calendar = Calendar.current
+    let now = Date()
+    let today = calendar.startOfDay(for: now)
+    let target = calendar.startOfDay(for: date)
+    let days = calendar.dateComponents([.day], from: target, to: today).day ?? 0
+    if days == 0 { return "Today" }
+    if days == 1 { return "Yesterday" }
+    if days > 1 && days < 7 {
+        return target.formatted(.dateTime.weekday(.wide))
+    }
+    let sameYear = calendar.component(.year, from: today) == calendar.component(.year, from: target)
+    if sameYear {
+        return target.formatted(.dateTime.weekday(.abbreviated).day().month(.abbreviated))
+    }
+    return target.formatted(.dateTime.day().month(.abbreviated).year())
+}
+
+private func formatRelative(_ date: Date) -> String {
+    let now = Date()
+    let diff = now.timeIntervalSince(date)
+    if diff < 60 { return "now" }
+    let minutes = Int(diff / 60)
+    if minutes < 60 { return "\(minutes)m" }
+    let hours = minutes / 60
+    if hours < 24 { return "\(hours)h" }
+    let calendar = Calendar.current
+    let today = calendar.startOfDay(for: now)
+    let target = calendar.startOfDay(for: date)
+    let days = calendar.dateComponents([.day], from: target, to: today).day ?? 0
+    if days == 1 { return "Yesterday" }
+    if days < 7 {
+        return target.formatted(.dateTime.weekday(.abbreviated))
+    }
+    let sameYear = calendar.component(.year, from: today) == calendar.component(.year, from: target)
+    if sameYear {
+        return target.formatted(.dateTime.day().month(.abbreviated))
+    }
+    return target.formatted(.dateTime.day().month(.abbreviated).year())
+}
+
+private func formatAbsolute(_ date: Date) -> String {
+    date.formatted(date: .abbreviated, time: .shortened)
+}

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -54,6 +54,8 @@ struct ContentView: View {
             ListsView(router: router, schemePref: schemePref)
         case .dashboard:
             DashboardView(router: router, schemePref: schemePref)
+        case .activity:
+            ActivityView(router: router, schemePref: schemePref)
         case .settings:
             SettingsView(router: router, schemePref: schemePref)
         case .today:

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -40,6 +40,15 @@ struct ListsView: View {
         }
         .activeSection(.lists)
         .task { await viewModel.load() }
+        .onAppear {
+            // Activity timeline deep-link consumption. Same caveat as TasksView:
+            // local lists use clientUUID as identity, so the activity endpoint's
+            // integer id can't resolve into the local store today. Clear the
+            // field to avoid re-firing on subsequent appearances.
+            if router.focus?.section == .lists {
+                router.focus = nil
+            }
+        }
         .sheet(isPresented: $showingNewList) {
             NewListSheet(viewModel: viewModel)
         }

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -53,6 +53,15 @@ struct NotesView: View {
                 pendingFolderLaunchId = nil
             }
         }
+        .onAppear {
+            // Activity timeline deep-link consumption. Same caveat as the
+            // other surfaces: local notes/folders are keyed by clientUUID,
+            // so the activity endpoint's integer id can't currently resolve
+            // to a SwiftData row. Clear the focus so it doesn't loop.
+            if router.focus?.section == .notes {
+                router.focus = nil
+            }
+        }
         .sheet(isPresented: $showingNewFolder) {
             NewFolderSheet(viewModel: viewModel)
         }

--- a/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
+++ b/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
@@ -85,6 +85,9 @@ struct SideDrawer: View {
             // Dashboard
             DrawerRow(section: .dashboard, router: router)
 
+            // Activity (read-only chronological feed of all creations)
+            DrawerRow(section: .activity, router: router)
+
             DrawerDivider()
 
             // Settings

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -46,6 +46,18 @@ struct TasksView: View {
         }
         .activeSection(.tasks)
         .task { await viewModel.load() }
+        .onAppear {
+            // Activity timeline deep-link consumption. The Activity surface
+            // sets `router.focus` to ActivityFocus(section: .tasks, id: serverId)
+            // before pushing the section. Local todos are keyed by clientUUID,
+            // so the integer id can't currently be resolved back to a SwiftData
+            // row; we clear the field here so the focus doesn't fire again on
+            // the next appearance. If a serverId column is added to the local
+            // model later, scroll + pulse can be implemented in this hook.
+            if router.focus?.section == .tasks {
+                router.focus = nil
+            }
+        }
         .sheet(isPresented: $showingEditor) {
             TaskEditorSheet(viewModel: viewModel, todo: nil)
         }

--- a/server/index.js
+++ b/server/index.js
@@ -977,6 +977,236 @@ app.patch('/api/dashboard/config/preferences', async (req, res) => {
 });
 
 // =============================================================================
+// ACTIVITY TIMELINE  (issue #16)
+// =============================================================================
+// Read-only feed. UNIONs todos, notes, lists, note_folders keyed on created_at
+// and returns a unified shape with keyset cursor pagination.
+//
+// GET /api/dashboard/activity
+//   ?limit=50       (default 50, clamp [1,100])
+//   ?cursor=<iso>:<type>:<id>   keyset cursor from the last item on the prev page
+//   ?type=note|todo|list|folder  optional single-type filter
+//   ?includeDeleted=1            include soft-deleted rows
+//
+// Response: { items: [...], nextCursor: string|null }
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Valid entity types for the ?type filter. */
+const ACTIVITY_TYPES = new Set(['note', 'todo', 'list', 'folder']);
+
+/**
+ * Build the UNION query for the activity feed.
+ *
+ * Each arm projects to a common shape:
+ *   id, type, title, snippet, parent_name, created_at
+ *
+ * The outer SELECT applies the keyset cursor + ordering + LIMIT.
+ *
+ * @param {object} opts
+ * @param {string|null}  opts.typeFilter      - single type to restrict to
+ * @param {boolean}      opts.includeDeleted  - strip deleted_at IS NULL filter
+ * @param {boolean}      opts.hasCursor       - whether a cursor is provided
+ * @param {number}       opts.limit
+ * @returns {{ sql: string, params: unknown[] }}
+ */
+function buildActivityQuery({ typeFilter, includeDeleted, hasCursor, limit }) {
+    const notDeleted = includeDeleted ? '' : 'AND deleted_at IS NULL';
+
+    // ── per-table SELECT arms ─────────────────────────────────────────────
+    const arms = [];
+
+    // Cast created_at to TIMESTAMPTZ in every arm so:
+    //   1. The pg driver always returns a UTC-normalised Date object (no session-tz surprise).
+    //   2. The cursor predicate can compare $1::timestamptz against it without implicit
+    //      timezone loss.  Postgres converts TIMESTAMP WITHOUT TIME ZONE → TIMESTAMPTZ
+    //      using the session timezone, so the cast is semantically correct on any host.
+    if (!typeFilter || typeFilter === 'todo') {
+        arms.push(`
+            SELECT
+                id,
+                'todo'::text AS type,
+                title,
+                CASE
+                    WHEN description IS NOT NULL AND description <> ''
+                    THEN LEFT(REPLACE(description, E'\\n', ' '), 140)
+                    ELSE NULL
+                END AS snippet,
+                NULL::text AS parent_name,
+                created_at::timestamptz AS created_at
+            FROM todos
+            WHERE TRUE ${notDeleted}
+        `);
+    }
+
+    if (!typeFilter || typeFilter === 'note') {
+        arms.push(`
+            SELECT
+                n.id,
+                'note'::text AS type,
+                COALESCE(n.title, '') AS title,
+                CASE
+                    WHEN n.content IS NOT NULL AND n.content <> ''
+                    THEN LEFT(REPLACE(n.content, E'\\n', ' '), 140)
+                    ELSE NULL
+                END AS snippet,
+                f.name AS parent_name,
+                n.created_at::timestamptz AS created_at
+            FROM notes n
+            LEFT JOIN note_folders f ON f.id = n.folder_id
+            WHERE TRUE ${notDeleted.replace('deleted_at', 'n.deleted_at')}
+        `);
+    }
+
+    if (!typeFilter || typeFilter === 'list') {
+        arms.push(`
+            SELECT
+                id,
+                'list'::text AS type,
+                title,
+                CASE
+                    WHEN jsonb_array_length(items) > 0
+                    THEN items->0->>'text'
+                    ELSE NULL
+                END AS snippet,
+                NULL::text AS parent_name,
+                created_at::timestamptz AS created_at
+            FROM lists
+            WHERE TRUE ${notDeleted}
+        `);
+    }
+
+    if (!typeFilter || typeFilter === 'folder') {
+        arms.push(`
+            SELECT
+                id,
+                'folder'::text AS type,
+                name AS title,
+                NULL::text AS snippet,
+                NULL::text AS parent_name,
+                created_at::timestamptz AS created_at
+            FROM note_folders
+            WHERE TRUE ${notDeleted}
+        `);
+    }
+
+    const union = arms.join('\nUNION ALL\n');
+
+    // ── cursor predicate ──────────────────────────────────────────────────
+    // Order is (created_at DESC, type ASC, id DESC).
+    // "Strictly less than" the cursor triple means:
+    //   created_at < $1  OR  (created_at = $1 AND type > $2)
+    //                    OR  (created_at = $1 AND type = $2 AND id < $3)
+    // We cast $1 to TIMESTAMPTZ explicitly so Postgres does a timezone-aware
+    // comparison against the TIMESTAMPTZ column from the union arms.
+    const cursorPredicate = hasCursor
+        ? `AND (
+            t.created_at < $1::timestamptz
+            OR (t.created_at = $1::timestamptz AND t.type > $2)
+            OR (t.created_at = $1::timestamptz AND t.type = $2 AND t.id < $3)
+           )`
+        : '';
+
+    const limitParam = hasCursor ? '$4' : '$1';
+
+    const sql = `
+        SELECT t.id, t.type, t.title, t.snippet, t.parent_name, t.created_at
+        FROM (${union}) t
+        WHERE TRUE ${cursorPredicate}
+        ORDER BY t.created_at DESC, t.type ASC, t.id DESC
+        LIMIT ${limitParam}
+    `;
+
+    return { sql };
+}
+
+app.get('/api/dashboard/activity', async (req, res) => {
+    try {
+        // ── parse + validate query params ─────────────────────────────────
+        let limit = parseInt(req.query.limit ?? '50', 10);
+        if (isNaN(limit)) limit = 50;
+        limit = Math.max(1, Math.min(100, limit));
+
+        const typeFilter = req.query.type ?? null;
+        if (typeFilter !== null && !ACTIVITY_TYPES.has(typeFilter)) {
+            return res.status(400).json({
+                error: `Invalid type "${typeFilter}". Must be one of: note, todo, list, folder`,
+            });
+        }
+
+        const includeDeleted = req.query.includeDeleted === '1' || req.query.includeDeleted === 'true';
+
+        // ── parse keyset cursor ───────────────────────────────────────────
+        // Format: <iso-ts>:<type>:<id>
+        // Example: 2026-01-15T12:00:00.000Z:note:42
+        let cursorTs = null;
+        let cursorType = null;
+        let cursorId = null;
+        const rawCursor = req.query.cursor ?? null;
+
+        if (rawCursor) {
+            // Split on the last two colons that precede type and id.
+            // ISO timestamps contain colons, so we split from the right.
+            const lastColon = rawCursor.lastIndexOf(':');
+            if (lastColon === -1) {
+                return res.status(400).json({ error: 'Invalid cursor format. Expected <iso-ts>:<type>:<id>' });
+            }
+            const idPart = rawCursor.slice(lastColon + 1);
+            const remainder = rawCursor.slice(0, lastColon);
+            const secondColon = remainder.lastIndexOf(':');
+            if (secondColon === -1) {
+                return res.status(400).json({ error: 'Invalid cursor format. Expected <iso-ts>:<type>:<id>' });
+            }
+            const typePart = remainder.slice(secondColon + 1);
+            const tsPart = remainder.slice(0, secondColon);
+
+            cursorId = parseInt(idPart, 10);
+            if (!ACTIVITY_TYPES.has(typePart) || isNaN(cursorId) || !tsPart) {
+                return res.status(400).json({ error: 'Invalid cursor: could not parse ts/type/id' });
+            }
+            cursorTs = tsPart;
+            cursorType = typePart;
+        }
+
+        const hasCursor = cursorTs !== null;
+
+        // ── build + run query ─────────────────────────────────────────────
+        const { sql } = buildActivityQuery({ typeFilter, includeDeleted, hasCursor, limit });
+
+        const params = hasCursor
+            ? [cursorTs, cursorType, cursorId, limit]
+            : [limit];
+
+        const { rows } = await db.query(sql, params);
+
+        // ── shape response ────────────────────────────────────────────────
+        const items = rows.map((r) => ({
+            id: r.id,
+            type: r.type,
+            title: r.title ?? '',
+            snippet: r.snippet ?? null,
+            parent: r.parent_name ?? null,
+            createdAt: r.created_at instanceof Date
+                ? r.created_at.toISOString()
+                : r.created_at,
+        }));
+
+        // Emit nextCursor only when the page is full (more pages likely exist).
+        let nextCursor = null;
+        if (rows.length === limit) {
+            const last = rows[rows.length - 1];
+            const ts = last.created_at instanceof Date
+                ? last.created_at.toISOString()
+                : last.created_at;
+            nextCursor = `${ts}:${last.type}:${last.id}`;
+        }
+
+        res.json({ items, nextCursor });
+    } catch (err) {
+        sendErrorResponse(res, err);
+    }
+});
+
+// =============================================================================
 // REORDER ENDPOINTS (v2 drag-to-reorder)
 // =============================================================================
 // All four endpoints share the same body schema and the same midpoint /

--- a/server/tests/activity.test.mjs
+++ b/server/tests/activity.test.mjs
@@ -1,0 +1,244 @@
+/**
+ * Activity timeline endpoint tests for issue #16.
+ *
+ * Exercises GET /api/dashboard/activity against the personal_dashboard_test DB.
+ * Covers: empty state, mixed-type ordering, pagination round-trip, type filter,
+ * soft-delete exclusion/inclusion, note parent, list snippet, and limit clamping.
+ */
+
+import { test, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { createRequire } from 'node:module';
+
+// helpers.js is CommonJS; import works because Node ESM can import CJS modules.
+const require = createRequire(import.meta.url);
+const { pool, applySchema, applyMigration, resetDb, close } = require('./helpers.js');
+
+let server;
+let baseUrl;
+
+before(async () => {
+    await applySchema();
+    await applyMigration();
+    // helpers.js sets DATABASE_URL to the test DB before this import fires,
+    // so the server's db pool connects to the right database.
+    const { app } = require('../index');
+    server = http.createServer(app);
+    await new Promise((resolve) => server.listen(0, resolve));
+    const addr = server.address();
+    baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+beforeEach(async () => {
+    await resetDb();
+});
+
+after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await close();
+});
+
+/** Convenience: GET a path and return { status, body }. */
+async function get(path) {
+    const res = await fetch(baseUrl + path);
+    const text = await res.text();
+    return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+// ─── Helper seeders with explicit created_at values ──────────────────────────
+
+async function insertTodo(title, { description = null, createdAt = new Date(), deletedAt = null } = {}) {
+    const { rows } = await pool.query(
+        `INSERT INTO todos (title, description, created_at, updated_at, deleted_at)
+         VALUES ($1, $2, $3, $3, $4) RETURNING *`,
+        [title, description, createdAt, deletedAt]
+    );
+    return rows[0];
+}
+
+async function insertNote(title, { content = null, folderId = null, createdAt = new Date(), deletedAt = null } = {}) {
+    const { rows } = await pool.query(
+        `INSERT INTO notes (title, content, folder_id, created_at, updated_at, deleted_at)
+         VALUES ($1, $2, $3, $4, $4, $5) RETURNING *`,
+        [title, content, folderId, createdAt, deletedAt]
+    );
+    return rows[0];
+}
+
+async function insertFolder(name, { createdAt = new Date(), deletedAt = null } = {}) {
+    const { rows } = await pool.query(
+        `INSERT INTO note_folders (name, created_at, updated_at, deleted_at)
+         VALUES ($1, $2, $2, $3) RETURNING *`,
+        [name, createdAt, deletedAt]
+    );
+    return rows[0];
+}
+
+async function insertList(title, { items = [], createdAt = new Date(), deletedAt = null } = {}) {
+    const { rows } = await pool.query(
+        `INSERT INTO lists (title, items, created_at, updated_at, deleted_at)
+         VALUES ($1, $2::jsonb, $3, $3, $4) RETURNING *`,
+        [title, JSON.stringify(items), createdAt, deletedAt]
+    );
+    return rows[0];
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test('1. empty state returns {items:[], nextCursor:null}', async () => {
+    const { status, body } = await get('/api/dashboard/activity');
+    assert.equal(status, 200);
+    assert.deepEqual(body, { items: [], nextCursor: null });
+});
+
+test('2. mixed-type fixtures return items in reverse-chronological order', async () => {
+    // Insert four items with distinct timestamps: folder first, then todo, note, list
+    const t0 = new Date('2026-01-01T10:00:00.000Z');
+    const t1 = new Date('2026-01-01T11:00:00.000Z');
+    const t2 = new Date('2026-01-01T12:00:00.000Z');
+    const t3 = new Date('2026-01-01T13:00:00.000Z');
+
+    await insertFolder('Work',   { createdAt: t0 });
+    await insertTodo('Buy milk', { createdAt: t1 });
+    await insertNote('Meeting notes', { createdAt: t2 });
+    await insertList('Groceries', { createdAt: t3 });
+
+    const { status, body } = await get('/api/dashboard/activity?limit=10');
+    assert.equal(status, 200);
+
+    // Most recent first
+    const types = body.items.map((i) => i.type);
+    assert.deepEqual(types, ['list', 'note', 'todo', 'folder']);
+
+    // Verify ISO timestamps are descending
+    const timestamps = body.items.map((i) => i.createdAt);
+    for (let i = 1; i < timestamps.length; i++) {
+        assert.ok(timestamps[i - 1] >= timestamps[i],
+            `Expected descending order at position ${i}`);
+    }
+
+    // nextCursor is null because we got all 4 items with limit=10
+    assert.equal(body.nextCursor, null);
+});
+
+test('3. pagination round-trip: page 1 + cursor -> page 2; no duplicates, no gaps', async () => {
+    // Seed 5 items at distinct timestamps so we can paginate with limit=3
+    const base = new Date('2026-02-01T00:00:00.000Z');
+    for (let i = 0; i < 5; i++) {
+        const t = new Date(base.getTime() + i * 60_000);
+        await insertTodo(`todo-${i}`, { createdAt: t });
+    }
+
+    // Full set (no pagination) to compare against
+    const { body: full } = await get('/api/dashboard/activity?limit=100');
+    assert.equal(full.items.length, 5);
+
+    // Page 1
+    const { body: page1 } = await get('/api/dashboard/activity?limit=3');
+    assert.equal(page1.items.length, 3, 'page 1 should have 3 items');
+    assert.notEqual(page1.nextCursor, null, 'page 1 should have a nextCursor');
+
+    // Page 2
+    const { body: page2 } = await get(`/api/dashboard/activity?limit=3&cursor=${encodeURIComponent(page1.nextCursor)}`);
+    assert.equal(page2.items.length, 2, 'page 2 should have the remaining 2 items');
+    assert.equal(page2.nextCursor, null, 'page 2 should have no nextCursor');
+
+    // Concatenated pages must equal full set
+    const combined = [...page1.items, ...page2.items];
+    assert.equal(combined.length, 5);
+
+    const fullIds = full.items.map((i) => `${i.type}:${i.id}`);
+    const combinedIds = combined.map((i) => `${i.type}:${i.id}`);
+    assert.deepEqual(combinedIds, fullIds, 'Combined pages should match full result exactly');
+
+    // No duplicates
+    const uniqueIds = new Set(combinedIds);
+    assert.equal(uniqueIds.size, 5, 'No duplicate items across pages');
+});
+
+test('4. ?type=note filter returns only notes', async () => {
+    await insertTodo('A todo');
+    await insertNote('A note');
+    await insertList('A list');
+    await insertFolder('A folder');
+
+    const { status, body } = await get('/api/dashboard/activity?type=note');
+    assert.equal(status, 200);
+    assert.equal(body.items.length, 1);
+    assert.equal(body.items[0].type, 'note');
+    assert.equal(body.items[0].title, 'A note');
+});
+
+test('5. soft-deleted rows excluded by default; included when includeDeleted=1', async () => {
+    const now = new Date();
+    await insertTodo('Active todo',   { createdAt: now });
+    await insertTodo('Deleted todo',  { createdAt: now, deletedAt: now });
+    await insertNote('Active note',   { createdAt: now });
+    await insertNote('Deleted note',  { createdAt: now, deletedAt: now });
+
+    // Default: only active items
+    const { body: defaultBody } = await get('/api/dashboard/activity');
+    const defaultTitles = defaultBody.items.map((i) => i.title);
+    assert.ok(defaultTitles.includes('Active todo'),    'Active todo should be present');
+    assert.ok(defaultTitles.includes('Active note'),    'Active note should be present');
+    assert.ok(!defaultTitles.includes('Deleted todo'),  'Deleted todo should be excluded');
+    assert.ok(!defaultTitles.includes('Deleted note'),  'Deleted note should be excluded');
+
+    // With includeDeleted=1: all four items present
+    const { body: allBody } = await get('/api/dashboard/activity?includeDeleted=1');
+    const allTitles = allBody.items.map((i) => i.title);
+    assert.ok(allTitles.includes('Deleted todo'), 'Deleted todo should appear with includeDeleted=1');
+    assert.ok(allTitles.includes('Deleted note'), 'Deleted note should appear with includeDeleted=1');
+    assert.equal(allBody.items.length, 4);
+});
+
+test('6. notes show parent populated when folder_id is set, null when not', async () => {
+    const folder = await insertFolder('Work');
+    await insertNote('In folder',   { folderId: folder.id });
+    await insertNote('Unfiled',     { folderId: null });
+
+    const { body } = await get('/api/dashboard/activity?type=note');
+    assert.equal(body.items.length, 2);
+
+    const inFolder = body.items.find((i) => i.title === 'In folder');
+    const unfiled  = body.items.find((i) => i.title === 'Unfiled');
+
+    assert.ok(inFolder, 'In-folder note must be present');
+    assert.ok(unfiled,  'Unfiled note must be present');
+    assert.equal(inFolder.parent, 'Work', 'parent should be the folder name');
+    assert.equal(unfiled.parent,  null,   'parent should be null for unfiled note');
+});
+
+test('7a. list with empty items array returns snippet: null', async () => {
+    await insertList('Empty list', { items: [] });
+
+    const { body } = await get('/api/dashboard/activity?type=list');
+    assert.equal(body.items.length, 1);
+    assert.equal(body.items[0].snippet, null, 'Empty list should have null snippet');
+});
+
+test('7b. list with items returns first item text as snippet', async () => {
+    await insertList('Shopping', { items: [{ text: 'Milk', checked: false }, { text: 'Eggs', checked: false }] });
+
+    const { body } = await get('/api/dashboard/activity?type=list');
+    assert.equal(body.items.length, 1);
+    assert.equal(body.items[0].snippet, 'Milk', 'Snippet should be first item text');
+});
+
+test('8. limit clamping: limit=0 -> 1, limit=999 -> 100', async () => {
+    // Seed 10 todos so there is data to paginate.
+    for (let i = 0; i < 10; i++) {
+        await insertTodo(`todo-${i}`);
+    }
+
+    // limit=0 should be clamped to 1 (one item returned)
+    const { body: withZero } = await get('/api/dashboard/activity?limit=0');
+    assert.equal(withZero.items.length, 1, 'limit=0 should clamp to 1');
+
+    // limit=999 should be clamped to 100 (only 10 items exist so we get 10)
+    const { body: withHuge } = await get('/api/dashboard/activity?limit=999');
+    assert.equal(withHuge.items.length, 10, 'limit=999 should clamp to 100 (only 10 items exist)');
+    // nextCursor is null because 10 < 100
+    assert.equal(withHuge.nextCursor, null, 'nextCursor should be null when returned count < clamped limit');
+});


### PR DESCRIPTION
## Summary

- New Activity timeline view on web and iOS that lists every note, todo, list, and folder created across the dashboard, in reverse-chronological order with day grouping and filter chips.
- New `GET /api/dashboard/activity` endpoint that UNIONs the four source tables on `created_at` with cursor pagination. No schema migration; v1 reuses existing `created_at` columns.
- Deep-link from Activity rows into the source widget (`?focus=<id>` on web; `router.focus` on iOS, with the visual pulse pending an id-bridging follow-up).

## Test plan

- [x] `cd server && npm test` passes (62/62)
- [x] `xcodebuild -scheme PersonalDashboard -destination 'generic/platform=iOS Simulator' build` returns BUILD SUCCEEDED
- [x] `cd client && npm run build` clean
- [x] Manual browser smoke test at `:5173`: filter chips, day groups, infinite scroll, deep-link, light + dark
- [x] iOS simulator smoke test (iPhone 17 / iOS 26.4): drawer placement, filter chips, day groups, light + dark
- [ ] iOS real-device install via `bash mobile/ota/ship-lan.sh` (deferred to user; simulator-only QA per project iOS QA framing rule)

QA evidence with screenshots: https://github.com/akshaydotsharma/personal-dashboard/issues/16#issuecomment-4366273553

## Deviations from the v1 brief

- Source tagging on every create path is deferred to v2 (scattered write sites; v1 ships without provenance).
- iOS deep-link pulse is plumbed but the scroll + accent ring are not wired, because the activity endpoint returns server integer ids and the iOS SwiftData store keys by clientUUID. Routing works; visual flourish needs a `serverId: Int?` column on the local models. Deferred follow-up.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)