### PR TITLE
fix(ios): project activity timeline from SwiftData (#25)

### DIFF
--- a/mobile/PersonalDashboard/App/AppRouter.swift
+++ b/mobile/PersonalDashboard/App/AppRouter.swift
@@ -10,12 +10,12 @@ import Observation
 struct ActivityFocus: Equatable {
     /// Where the focus should land. Determines which destination view reads it.
     let section: AppSection
-    /// Server-side integer id of the row (or folder) to focus.
-    let id: Int
+    /// Local `clientUUID` of the row (or folder) to focus.
+    let id: UUID
     /// True for a folder deep-link (section is .notes, but the id is a folder).
     let isFolder: Bool
 
-    init(section: AppSection, id: Int, isFolder: Bool = false) {
+    init(section: AppSection, id: UUID, isFolder: Bool = false) {
         self.section = section
         self.id = id
         self.isFolder = isFolder

--- a/mobile/PersonalDashboard/Models/ActivityItem.swift
+++ b/mobile/PersonalDashboard/Models/ActivityItem.swift
@@ -1,32 +1,36 @@
 import Foundation
 
-/// One row from `GET /api/dashboard/activity`. Server identity is the integer
-/// `id`; type discriminates the entity. The activity surface is read-only:
-/// the iOS app never writes to this endpoint.
-struct ActivityItem: Decodable, Identifiable, Equatable {
-    enum ItemType: String, Decodable, CaseIterable {
+/// One row of the activity timeline. Built locally by `ActivityService` from
+/// the SwiftData store: each `LocalTodo / LocalNote / LocalList / LocalNoteFolder`
+/// projects to one item at its `createdAt` time. Soft-deleted rows are excluded.
+struct ActivityItem: Identifiable, Equatable {
+    enum ItemType: String, CaseIterable {
         case note
         case todo
         case list
         case folder
     }
 
-    let id: Int
+    /// Stable per-item identity: the entity's `clientUUID`. Two different
+    /// entity types can share neither identity nor row position because the
+    /// projection enforces uniqueness on (type, UUID).
+    let id: UUID
     let type: ItemType
     let title: String
     let snippet: String?
     let parent: String?
     let createdAt: Date
 
-    /// SwiftUI `ForEach` needs a stable identifier and we may show the same
-    /// integer id for two different types in the same feed (a note id 5 and a
-    /// folder id 5). Combine the two into a string key.
-    var rowKey: String { "\(type.rawValue)-\(id)" }
+    /// SwiftUI `ForEach` needs a stable identifier and we may show a note and
+    /// a folder that share the same UUID slot in unrelated stores. Combine
+    /// type + id into a single key to be safe.
+    var rowKey: String { "\(type.rawValue)-\(id.uuidString.lowercased())" }
 }
 
-/// Payload returned by the activity endpoint. `nextCursor` is null on the
-/// last page; clients stop paginating when it disappears.
-struct ActivityPage: Decodable {
+/// Page of activity items. `nextCursor` is null on the last page; clients
+/// stop paginating when it disappears. The cursor encodes the (createdAt, type, id)
+/// triple of the last row on the page so we can fetch strictly-older rows next.
+struct ActivityPage: Equatable {
     let items: [ActivityItem]
     let nextCursor: String?
 }

--- a/mobile/PersonalDashboard/Services/ActivityService.swift
+++ b/mobile/PersonalDashboard/Services/ActivityService.swift
@@ -1,27 +1,171 @@
 import Foundation
+import SwiftData
 
-/// Read-only client for the activity timeline endpoint.
+/// Local activity timeline projection. Reads `LocalTodo / LocalNote / LocalList /
+/// LocalNoteFolder` rows out of SwiftData, projects each to an `ActivityItem`
+/// at its `createdAt`, and orders by (createdAt DESC, type ASC, id DESC) so
+/// the page is stable across mutations.
 ///
-/// The activity feed is server-driven (UNION across todos, notes, lists,
-/// note_folders) rather than reading from the local SwiftData store, so the
-/// surface always reflects what's actually on the Mac. There is no offline
-/// fallback in v1: if the request fails, the view shows an empty/error
-/// state and the user can pull to refresh.
+/// Mirrors the previous `GET /api/dashboard/activity` shape so the view layer
+/// did not need to change. Soft-deleted rows are excluded.
+@MainActor
 struct ActivityService: Sendable {
-    let api: APIClient
+    let context: ModelContext
 
-    init(api: APIClient = .shared) {
-        self.api = api
+    init() {
+        self.context = SwiftDataStore.shared.context
+    }
+
+    init(context: ModelContext) {
+        self.context = context
     }
 
     /// Fetch one page of activity. Pass `cursor` (the value from the previous
-    /// page's `nextCursor`) to load the next page; pass `type` to filter to
-    /// a single entity type.
-    func page(cursor: String? = nil, type: ActivityItem.ItemType? = nil, limit: Int = 50) async throws -> ActivityPage {
-        var query: [URLQueryItem] = []
-        if let cursor { query.append(URLQueryItem(name: "cursor", value: cursor)) }
-        if let type { query.append(URLQueryItem(name: "type", value: type.rawValue)) }
-        query.append(URLQueryItem(name: "limit", value: String(limit)))
-        return try await api.get("dashboard/activity", query: query)
+    /// page's `nextCursor`) to load the next page; pass `type` to filter to a
+    /// single entity type.
+    func page(cursor: String? = nil, type: ActivityItem.ItemType? = nil, limit: Int = 50) -> ActivityPage {
+        var all: [ActivityItem] = []
+
+        if type == nil || type == .todo {
+            let rows = (try? context.fetch(FetchDescriptor<LocalTodo>(
+                predicate: #Predicate { $0.deletedAt == nil }
+            ))) ?? []
+            all.append(contentsOf: rows.map { row in
+                ActivityItem(
+                    id: row.clientUUID,
+                    type: .todo,
+                    title: row.title,
+                    snippet: snippet(from: row.todoDescription),
+                    parent: nil,
+                    createdAt: row.createdAt
+                )
+            })
+        }
+
+        if type == nil || type == .note {
+            let rows = (try? context.fetch(FetchDescriptor<LocalNote>(
+                predicate: #Predicate { $0.deletedAt == nil }
+            ))) ?? []
+            let folderNamesByUUID = folderNameLookup()
+            all.append(contentsOf: rows.map { row in
+                ActivityItem(
+                    id: row.clientUUID,
+                    type: .note,
+                    title: row.title ?? "",
+                    snippet: snippet(from: row.content),
+                    parent: row.folderClientUUID.flatMap { folderNamesByUUID[$0] },
+                    createdAt: row.createdAt
+                )
+            })
+        }
+
+        if type == nil || type == .list {
+            let rows = (try? context.fetch(FetchDescriptor<LocalList>(
+                predicate: #Predicate { $0.deletedAt == nil }
+            ))) ?? []
+            all.append(contentsOf: rows.map { row in
+                ActivityItem(
+                    id: row.clientUUID,
+                    type: .list,
+                    title: row.title,
+                    snippet: row.items.first?.text,
+                    parent: nil,
+                    createdAt: row.createdAt
+                )
+            })
+        }
+
+        if type == nil || type == .folder {
+            let rows = (try? context.fetch(FetchDescriptor<LocalNoteFolder>(
+                predicate: #Predicate { $0.deletedAt == nil }
+            ))) ?? []
+            all.append(contentsOf: rows.map { row in
+                ActivityItem(
+                    id: row.clientUUID,
+                    type: .folder,
+                    title: row.name,
+                    snippet: nil,
+                    parent: nil,
+                    createdAt: row.createdAt
+                )
+            })
+        }
+
+        // Sort: createdAt DESC, type ASC (folder, list, note, todo alphabetic),
+        // id DESC. Matches the server's keyset ordering so cursor pagination
+        // is stable across calls.
+        all.sort { a, b in
+            if a.createdAt != b.createdAt { return a.createdAt > b.createdAt }
+            if a.type.rawValue != b.type.rawValue { return a.type.rawValue < b.type.rawValue }
+            return a.id.uuidString > b.id.uuidString
+        }
+
+        // Drop everything <= the cursor triple (strictly-older).
+        let after: [ActivityItem]
+        if let cursor, let cursorTriple = parseCursor(cursor) {
+            after = all.drop(while: { item in
+                if item.createdAt > cursorTriple.createdAt { return true }
+                if item.createdAt == cursorTriple.createdAt {
+                    if item.type.rawValue < cursorTriple.type { return true }
+                    if item.type.rawValue == cursorTriple.type {
+                        return item.id.uuidString >= cursorTriple.id
+                    }
+                }
+                return false
+            }).map { $0 }
+        } else {
+            after = all
+        }
+
+        let page = Array(after.prefix(limit))
+        let nextCursor: String?
+        if after.count > limit, let last = page.last {
+            nextCursor = formatCursor(createdAt: last.createdAt, type: last.type.rawValue, id: last.id.uuidString)
+        } else {
+            nextCursor = nil
+        }
+        return ActivityPage(items: page, nextCursor: nextCursor)
+    }
+
+    // MARK: - Helpers
+
+    private func folderNameLookup() -> [UUID: String] {
+        let rows = (try? context.fetch(FetchDescriptor<LocalNoteFolder>(
+            predicate: #Predicate { $0.deletedAt == nil }
+        ))) ?? []
+        return Dictionary(uniqueKeysWithValues: rows.map { ($0.clientUUID, $0.name) })
+    }
+
+    private func snippet(from raw: String?) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+        let collapsed = raw.replacingOccurrences(of: "\n", with: " ")
+        if collapsed.count <= 140 { return collapsed }
+        return String(collapsed.prefix(140))
+    }
+
+    private struct CursorTriple {
+        let createdAt: Date
+        let type: String
+        let id: String
+    }
+
+    private static let cursorFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private func formatCursor(createdAt: Date, type: String, id: String) -> String {
+        let ts = Self.cursorFormatter.string(from: createdAt)
+        return "\(ts)|\(type)|\(id)"
+    }
+
+    private func parseCursor(_ raw: String) -> CursorTriple? {
+        let parts = raw.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
+        guard parts.count == 3,
+              let ts = Self.cursorFormatter.date(from: String(parts[0])) else {
+            return nil
+        }
+        return CursorTriple(createdAt: ts, type: String(parts[1]), id: String(parts[2]))
     }
 }

--- a/mobile/PersonalDashboard/ViewModels/ActivityViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ActivityViewModel.swift
@@ -1,12 +1,9 @@
 import Foundation
 import Observation
 
-/// State holder for the Activity surface. Pure remote, no local cache. The
-/// service is injected so tests can stub it.
-///
-/// Pagination model: the server returns up to `limit` items plus a
-/// `nextCursor`. When `nextCursor` is null, we stop paginating. Filter
-/// changes reset the cursor and clear the items.
+/// State holder for the Activity surface. Reads from local SwiftData via
+/// `ActivityService`; no remote / no error path. Pagination is keyset-based
+/// over (createdAt, type, id) so a fresh insert can't shuffle pages.
 @Observable
 @MainActor
 final class ActivityViewModel {
@@ -37,7 +34,6 @@ final class ActivityViewModel {
             }
         }
 
-        /// `nil` for `.all`; the wire value otherwise.
         var typeParam: ActivityItem.ItemType? {
             switch self {
             case .all:    return nil
@@ -53,77 +49,51 @@ final class ActivityViewModel {
     private(set) var nextCursor: String?
     private(set) var isLoading = false
     private(set) var isLoadingMore = false
-    var errorMessage: String?
     var filter: Filter = .all
-
-    /// Bumped on every fresh load so a stale-filter response can be discarded
-    /// when the user flips filters mid-fetch.
-    private var requestGeneration = 0
 
     private let service: ActivityService
 
-    init(service: ActivityService = ActivityService()) {
+    init() {
+        self.service = ActivityService()
+    }
+
+    init(service: ActivityService) {
         self.service = service
     }
 
-    /// First page or refresh after filter change. Clears items, shows the
-    /// first-load skeleton in the view, and resets the cursor.
-    func loadFirstPage() async {
-        let myGen = bumpGeneration()
+    /// First page or refresh after filter change. Clears items and resets the
+    /// cursor.
+    func loadFirstPage() {
         isLoading = true
-        errorMessage = nil
         items = []
         nextCursor = nil
 
-        do {
-            let page = try await service.page(cursor: nil, type: filter.typeParam)
-            guard myGen == requestGeneration else { return }
-            items = page.items
-            nextCursor = page.nextCursor
-        } catch {
-            guard myGen == requestGeneration else { return }
-            errorMessage = error.localizedDescription
-        }
-        if myGen == requestGeneration {
-            isLoading = false
-        }
+        let page = service.page(cursor: nil, type: filter.typeParam)
+        items = page.items
+        nextCursor = page.nextCursor
+        isLoading = false
     }
 
     /// Append the next page if a cursor exists. No-op while another fetch is
     /// in flight or there are no more pages.
-    func loadNextPage() async {
+    func loadNextPage() {
         guard let cursor = nextCursor, !isLoadingMore, !isLoading else { return }
-        let myGen = requestGeneration
         isLoadingMore = true
-        errorMessage = nil
-        do {
-            let page = try await service.page(cursor: cursor, type: filter.typeParam)
-            guard myGen == requestGeneration else { return }
-            items.append(contentsOf: page.items)
-            nextCursor = page.nextCursor
-        } catch {
-            guard myGen == requestGeneration else { return }
-            errorMessage = error.localizedDescription
-        }
-        if myGen == requestGeneration {
-            isLoadingMore = false
-        }
+        let page = service.page(cursor: cursor, type: filter.typeParam)
+        items.append(contentsOf: page.items)
+        nextCursor = page.nextCursor
+        isLoadingMore = false
     }
 
     /// Pull-to-refresh hook. Same effect as `loadFirstPage`.
-    func refresh() async {
-        await loadFirstPage()
+    func refresh() {
+        loadFirstPage()
     }
 
     /// Switch the active filter and re-fetch. No-op if the filter is unchanged.
-    func setFilter(_ next: Filter) async {
+    func setFilter(_ next: Filter) {
         guard next != filter else { return }
         filter = next
-        await loadFirstPage()
-    }
-
-    private func bumpGeneration() -> Int {
-        requestGeneration += 1
-        return requestGeneration
+        loadFirstPage()
     }
 }

--- a/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
+++ b/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
@@ -36,7 +36,7 @@ struct ActivityView: View {
                 FilterChipBar(
                     selected: viewModel.filter,
                     onSelect: { next in
-                        Task { await viewModel.setFilter(next) }
+                        viewModel.setFilter(next)
                     }
                 )
                 .padding(.horizontal, Space.lg)
@@ -78,34 +78,20 @@ struct ActivityView: View {
                                 Color.clear
                                     .frame(height: 1)
                                     .onAppear {
-                                        Task { await viewModel.loadNextPage() }
+                                        viewModel.loadNextPage()
                                     }
-                            }
-
-                            if let err = viewModel.errorMessage, !viewModel.isLoading {
-                                Button {
-                                    Task { await viewModel.loadNextPage() }
-                                } label: {
-                                    Text("Couldn't load more. Tap to retry.")
-                                        .font(.edSubheadline)
-                                        .foregroundStyle(Tokens.danger)
-                                        .frame(maxWidth: .infinity)
-                                        .padding(.vertical, Space.lg)
-                                        .accessibilityLabel("Retry loading more. \(err)")
-                                }
-                                .buttonStyle(.plain)
                             }
                         }
                     }
                     .padding(.bottom, 96) // FAB clearance
                 }
-                .refreshable { await viewModel.refresh() }
+                .refreshable { viewModel.refresh() }
             }
 
             ChatFAB { router.popToChat() }
         }
         .activeSection(.activity)
-        .task { await viewModel.loadFirstPage() }
+        .onAppear { viewModel.loadFirstPage() }
     }
 
     // MARK: - Tap → deep-link


### PR DESCRIPTION
## Summary
- Activity feed stops calling `GET /api/dashboard/activity`. `ActivityService.page(...)` now fetches live `LocalTodo / LocalNote / LocalList / LocalNoteFolder` rows from SwiftData and projects each to an `ActivityItem` at its `createdAt`.
- Sort + paginate use a keyset cursor on (createdAt DESC, type ASC, id DESC) — same ordering the server used, so a fresh insert can't shuffle pages mid-scroll.
- `ActivityItem.id` and `ActivityFocus.id` change from `Int` to `UUID`. The Int-based deep-link was already dead code (destination views just cleared the field).
- `ActivityViewModel` drops async/throws and `errorMessage`; local fetch is infallible. The "couldn't load more, retry" UI goes with it.

Closes #25.

## Note on the ticket premise
The ticket's "the server unions across four `*_history` tables" turned out to be wrong on inspection — `/api/dashboard/activity` actually unioned the live entity tables (`todos`, `notes`, `lists`, `note_folders`), so the feed only ever showed creates. This PR mirrors that real behaviour rather than building a new history model. If a richer "everything that happened" feed is wanted later, that's a separate piece of work.

## APIClient cleanup
Not deleted in this PR. Remaining callers after #25:
- `PersonalDashboardApp.swift` — Local Network permission preflight (`dashboard/config` GET).
- `APIClient.swift` itself.

After both #24 and #25 merge, the preflight + APIClient become orphans. Tracking that as a small follow-up commit on `main`.

## Static checks (passed)
- `xcodegen generate` clean.
- `xcodebuild build` for `generic/platform=iOS` Debug clean.

## Device verification (pending — needs to run on your iPhone)
```bash
cd mobile && bash ota/ship-lan.sh
xcrun devicectl device install app --device <UDID> /tmp/ota/app.ipa
```

## Test plan
- [ ] Mac dev server off, iPhone on cellular only — Activity timeline shows recent items.
- [ ] Capture / chat-confirmed / hand-edit creates appear in the timeline within one frame.
- [ ] Filter chips (All / Notes / Todos / Lists / Folders) change the visible rows.
- [ ] Scroll past the first page loads the next batch (50 items per page).
- [ ] Pull-to-refresh re-runs the local fetch.
- [ ] No network call leaves the device for the activity feed.