### PR TITLE
fix(ios): tappable capture banner with deeplink (#13)

### DIFF
--- a/mobile/PersonalDashboard/App/AppRouter.swift
+++ b/mobile/PersonalDashboard/App/AppRouter.swift
@@ -26,6 +26,11 @@ struct ActivityFocus: Equatable {
 @Observable
 @MainActor
 final class AppRouter {
+    /// Process-wide router so the URL handler (.onOpenURL) and the
+    /// notification-tap delegate can route into the same instance the views
+    /// observe.
+    static let shared = AppRouter()
+
     var path: [AppSection] = {
         if let raw = ProcessInfo.processInfo.environment["LAUNCH_SECTION"]?.lowercased(),
            let s = AppSection(rawValue: raw),
@@ -63,4 +68,32 @@ final class AppRouter {
 
     /// The currently active section (top of the stack, or chat when empty).
     var currentSection: AppSection { path.last ?? .chat }
+
+    // MARK: - Deeplinks
+
+    /// Handle a `personaldashboard://` URL by navigating to the right surface
+    /// and (if a UUID is present) setting `focus` so the destination view can
+    /// scroll the row into view.
+    ///
+    /// Recognised forms:
+    ///   personaldashboard://chat
+    ///   personaldashboard://tasks[/<uuid>]
+    ///   personaldashboard://notes[/<uuid>]    -- uuid may be a folder
+    ///   personaldashboard://lists[/<uuid>]
+    ///   personaldashboard://activity
+    ///   personaldashboard://dashboard
+    func handle(url: URL) {
+        guard url.scheme == "personaldashboard" else { return }
+        guard let host = url.host?.lowercased(), let section = AppSection(rawValue: host) else { return }
+
+        let trimmedPath = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let uuid = trimmedPath.isEmpty ? nil : UUID(uuidString: trimmedPath)
+
+        if let uuid {
+            let isFolder = (section == .notes) && (URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "folder" })?.value == "1")
+            focus = ActivityFocus(section: section, id: uuid, isFolder: isFolder)
+        }
+        go(to: section)
+    }
 }

--- a/mobile/PersonalDashboard/App/PersonalDashboardApp.swift
+++ b/mobile/PersonalDashboard/App/PersonalDashboardApp.swift
@@ -1,8 +1,15 @@
 import SwiftUI
 import SwiftData
+import UserNotifications
 
 @main
 struct PersonalDashboardApp: App {
+    init() {
+        // Bridge notification taps into AppRouter so capture-confirmation
+        // banners can deeplink into the app. Issue #13.
+        UNUserNotificationCenter.current().delegate = CaptureNotificationDelegate.shared
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -15,6 +22,9 @@ struct PersonalDashboardApp: App {
                     // Also make one real API call so the app shows up in
                     // iOS Settings with a Local Network toggle on first run.
                     let _: EmptyResponse? = try? await APIClient.shared.get("dashboard/config")
+                }
+                .onOpenURL { url in
+                    AppRouter.shared.handle(url: url)
                 }
         }
         .modelContainer(SwiftDataStore.shared.container)

--- a/mobile/PersonalDashboard/Info.plist
+++ b/mobile/PersonalDashboard/Info.plist
@@ -20,6 +20,17 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.akshaysharma.personaldashboard</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>personaldashboard</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
@@ -56,7 +56,18 @@ struct CaptureToDashboardIntent: AppIntent {
 
         switch response.status {
         case .executed:
-            let summary = Self.executedDialog(for: response.executed ?? [])
+            let executed = response.executed ?? []
+            let summary = Self.executedDialog(for: executed)
+            // Issue #13: post a tappable confirmation notification with a
+            // deeplink target so the user can jump from the banner into the
+            // owning surface. The App Intent's own ProvidesDialog is read-only
+            // and stays as the immediate confirmation.
+            let deeplink = CaptureNotification.deeplink(for: executed)
+            await CaptureNotification.schedule(
+                title: "Captured to Dashboard",
+                body: summary,
+                deeplink: deeplink
+            )
             return .result(dialog: IntentDialog(stringLiteral: summary))
         case .needsClarification:
             let q = response.followUpQuestion ?? "I need a bit more detail."

--- a/mobile/PersonalDashboard/Services/CaptureNotification.swift
+++ b/mobile/PersonalDashboard/Services/CaptureNotification.swift
@@ -1,0 +1,125 @@
+import Foundation
+import UserNotifications
+
+/// Posts a tappable confirmation notification after the side-button capture
+/// flow lands. Tapping the banner deeplinks into the app via a
+/// `personaldashboard://` URL stored in the notification's `userInfo`.
+///
+/// Issue #13: the App Intent's own `ProvidesDialog` is read-only — a separate
+/// notification carries the navigation intent and persists in Notification
+/// Center until the user dismisses it.
+enum CaptureNotification {
+    /// Key under which the deeplink URL is stored in `UNNotificationContent.userInfo`.
+    /// `CaptureNotificationDelegate` reads this on tap and routes via `AppRouter`.
+    static let deeplinkKey = "personaldashboard.deeplink"
+
+    /// Schedule a confirmation notification for an executed capture.
+    ///
+    /// - Parameter title: notification title (e.g. "Captured to Dashboard").
+    /// - Parameter body: human-readable description of what was applied.
+    /// - Parameter deeplink: target URL for the tap action; nil suppresses
+    ///   navigation (still posts the notification but tapping just opens the
+    ///   app at its last screen).
+    static func schedule(title: String, body: String, deeplink: URL?) async {
+        let granted = await ensureAuthorization()
+        guard granted else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = nil
+        content.interruptionLevel = .active
+        if let deeplink {
+            content.userInfo[deeplinkKey] = deeplink.absoluteString
+        }
+
+        // Identifier is unique-per-call so two rapid captures don't replace each
+        // other in Notification Center.
+        let identifier = "capture.\(UUID().uuidString)"
+        let request = UNNotificationRequest(
+            identifier: identifier,
+            content: content,
+            // nil trigger fires immediately. The App Intent is already async,
+            // so we want the banner to land as the dialog is dismissed.
+            trigger: nil
+        )
+
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+        } catch {
+            // Best-effort. Failing to post a confirmation notification is not
+            // recoverable from inside the App Intent and should not abort the
+            // capture flow that already succeeded.
+        }
+    }
+
+    /// Build a deeplink URL for the most-relevant action in a capture batch.
+    ///
+    /// Single executed action -> deeplink to its section + UUID.
+    /// Multiple actions of the same section -> deeplink to that section, no UUID.
+    /// Mixed sections -> nil (caller posts the notification without a target;
+    /// tapping just opens the app).
+    static func deeplink(for executed: [ExecutedDraft]) -> URL? {
+        guard !executed.isEmpty else { return nil }
+
+        if executed.count == 1 {
+            let only = executed[0]
+            return url(for: only.type, id: only.id)
+        }
+
+        let sections = Set(executed.map(sectionHost(for:)))
+        guard sections.count == 1, let host = sections.first, !host.isEmpty else { return nil }
+        return url(host: host, id: nil)
+    }
+
+    private static func url(for entityType: String, id: String?) -> URL? {
+        let host = sectionHost(for: ExecutedDraft.placeholder(type: entityType))
+        guard !host.isEmpty else { return nil }
+        return url(host: host, id: id)
+    }
+
+    private static func url(host: String, id: String?) -> URL? {
+        var components = URLComponents()
+        components.scheme = "personaldashboard"
+        components.host = host
+        if let id, !id.isEmpty {
+            components.path = "/\(id)"
+        }
+        return components.url
+    }
+
+    private static func sectionHost(for draft: ExecutedDraft) -> String {
+        switch draft.type {
+        case "todo":   return "tasks"
+        case "note":   return "notes"
+        case "list":   return "lists"
+        case "folder": return "notes" // folder lives under the Notes surface
+        default:       return ""
+        }
+    }
+
+    private static func ensureAuthorization() async -> Bool {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .denied:
+            return false
+        case .notDetermined:
+            let granted = (try? await center.requestAuthorization(options: [.alert, .badge])) ?? false
+            return granted
+        @unknown default:
+            return false
+        }
+    }
+}
+
+private extension ExecutedDraft {
+    /// Build a placeholder solely so `sectionHost(for:)` can be reused with a
+    /// type string and no real outcome. Avoids exposing the section-mapping
+    /// switch as a public surface.
+    static func placeholder(type: String) -> ExecutedDraft {
+        ExecutedDraft(type: type, action: "", id: "", title: nil, dueDate: nil, addedNames: nil)
+    }
+}

--- a/mobile/PersonalDashboard/Services/CaptureNotificationDelegate.swift
+++ b/mobile/PersonalDashboard/Services/CaptureNotificationDelegate.swift
@@ -1,0 +1,41 @@
+import Foundation
+import UserNotifications
+
+/// Bridges `UNUserNotificationCenter` taps into `AppRouter` deeplinks.
+///
+/// Without this delegate, tapping a capture-confirmation notification would
+/// just open the app at its last screen. With it, the userInfo's
+/// `CaptureNotification.deeplinkKey` is parsed and `AppRouter.shared.handle`
+/// drops the user on the right surface.
+final class CaptureNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+    static let shared = CaptureNotificationDelegate()
+
+    /// Show capture banners even when the app is in the foreground; otherwise
+    /// the user gets the dialog from the App Intent and nothing else, which
+    /// makes the deeplink invisible.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .list])
+    }
+
+    /// Tap handler. Parses the deeplink from userInfo and routes via the
+    /// shared `AppRouter`.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        defer { completionHandler() }
+        let info = response.notification.request.content.userInfo
+        guard let raw = info[CaptureNotification.deeplinkKey] as? String,
+              let url = URL(string: raw) else {
+            return
+        }
+        Task { @MainActor in
+            AppRouter.shared.handle(url: url)
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var router = AppRouter()
+    // Use the shared instance so .onOpenURL and the notification delegate can
+    // route into the same router the views observe (issue #13).
+    @State private var router = AppRouter.shared
     @AppStorage("colorSchemePref") private var schemePrefRaw: String = ColorSchemePref.system.rawValue
 
     private var schemePref: Binding<ColorSchemePref> {

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -54,6 +54,13 @@ targets:
           - Inter-Medium.ttf
           - Inter-SemiBold.ttf
           - JetBrainsMono-Regular.ttf
+        # Custom URL scheme for capture-confirmation notification taps and any
+        # future deeplinks. Format: personaldashboard://<section>[/<uuid>]
+        # e.g. personaldashboard://tasks/A1B2C3D4-... opens the Tasks surface.
+        CFBundleURLTypes:
+          - CFBundleURLName: com.akshaysharma.personaldashboard
+            CFBundleURLSchemes:
+              - personaldashboard
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.akshaysharma.personaldashboard


### PR DESCRIPTION
## Summary
- Side-button capture confirmation is no longer dead-ended. After a capture executes, `CaptureToDashboardIntent` posts a `UNUserNotificationCenter` notification alongside the existing dialog; tapping it deeplinks into the owning surface.
- New URL scheme: `personaldashboard://<section>[/<uuid>]` (e.g. `personaldashboard://tasks/<UUID>`). `AppRouter.handle(url:)` is the single entry point used by both `.onOpenURL` and the notification delegate.
- `AppRouter` becomes a process-wide singleton (`AppRouter.shared`) so `.onOpenURL` and `CaptureNotificationDelegate` both route into the same instance the views observe.
- Deeplink target rules:
  - Single executed action → section + UUID (lands at the row in the list).
  - Multiple actions of the same kind → section only.
  - Mixed-section batches → no target (banner still shows; tap opens the app at its last screen).
- Notification authorization is requested on first capture; if denied, the dialog still shows.

Closes #13.

## Why option (b)
Two paths were possible per the ticket — Shortcut-side `Open App` step (lowest effort, pushes UX to the user) vs. `UNUserNotificationCenter` with a deeplink + router. Went with the latter: it's a small amount of code, the deeplink scheme can be reused for future intents (snooze, mark-done), and it keeps the experience entirely inside the app surface rather than relying on Shortcut authoring.

## On 'highlight the new row'
Acceptance says the new item should be 'top of list, scrolled into view, or a brief highlight'. Newly created entities sort to the top of every surface (`createdAt DESC`), so 'top of list' is satisfied without additional code. Scroll-into-view + accent pulse is a separate improvement and tracked as a follow-up.

## Stacked on #25
This PR is opened against \`fix/25-activity-timeline-on-device\` because it inherits the \`ActivityFocus.id: UUID\` change. Will rebase to \`main\` once #27 merges.

## Static checks (passed)
- \`xcodegen generate\` clean.
- \`xcodebuild build\` for \`generic/platform=iOS\` Debug clean.

## Device verification (pending — needs to run on your iPhone)
\`\`\`bash
cd mobile && bash ota/ship-lan.sh
xcrun devicectl device install app --device <UDID> /tmp/ota/app.ipa
\`\`\`

First time you run the side-button capture, iOS will prompt for notification permission. Allow it.

## Test plan
- [ ] Run capture via Action Button / Shortcut for a single todo: 'remind me to call John tomorrow'. Banner appears with title 'Captured to Dashboard'.
- [ ] Tap the banner. App opens on the Tasks surface; the new task is at the top of the list.
- [ ] Same for note: 'note: book ideas'. Banner taps land on Notes.
- [ ] Same for list: 'add eggs and bread to my groceries list'. Banner taps land on Lists.
- [ ] Multi-action capture: 'add milk to groceries and remind me to buy bread'. Banner appears; tap behaviour matches whether the actions share a section.
- [ ] needs_clarification (e.g. ambiguous prompt) — only the dialog shows, no notification.
- [ ] error path — only the dialog shows, no notification.