### PR TITLE
fix(ios): hide chat wizard while keyboard is visible

### DIFF
--- a/mobile/PersonalDashboard/Views/Shell/ChatFAB.swift
+++ b/mobile/PersonalDashboard/Views/Shell/ChatFAB.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import UIKit
 
 /// Floating Sparkles chip pinned bottom-right of every non-chat surface.
-/// Tapping it pops back to the chat root.
+/// Tapping it pops back to the chat root. Hides itself while the keyboard
+/// is visible so it never covers an in-row submit affordance.
 struct ChatFAB: View {
     var action: () -> Void
+    @State private var keyboardVisible = false
 
     var body: some View {
         Button(action: action) {
@@ -17,5 +20,14 @@ struct ChatFAB: View {
         .accessibilityLabel("Open chat")
         .padding(.trailing, Space.lg)
         .padding(.bottom, Space.lg)
+        .opacity(keyboardVisible ? 0 : 1)
+        .allowsHitTesting(!keyboardVisible)
+        .animation(.easeOut(duration: 0.18), value: keyboardVisible)
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+            keyboardVisible = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            keyboardVisible = false
+        }
     }
 }

--- a/mobile/PersonalDashboard/Views/Shell/ChatFAB.swift
+++ b/mobile/PersonalDashboard/Views/Shell/ChatFAB.swift
@@ -9,25 +9,27 @@ struct ChatFAB: View {
     @State private var keyboardVisible = false
 
     var body: some View {
-        Button(action: action) {
-            Image(systemName: "sparkles")
-                .font(.system(size: 18, weight: .regular))
-                .foregroundStyle(Tokens.paper)
-                .frame(width: 52, height: 52)
-                .background(Tokens.ink, in: Circle())
-                .shadowMd()
+        ZStack {
+            if !keyboardVisible {
+                Button(action: action) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 18, weight: .regular))
+                        .foregroundStyle(Tokens.paper)
+                        .frame(width: 52, height: 52)
+                        .background(Tokens.ink, in: Circle())
+                        .shadowMd()
+                }
+                .accessibilityLabel("Open chat")
+                .padding(.trailing, Space.lg)
+                .padding(.bottom, Space.lg)
+                .transition(.opacity.combined(with: .scale(scale: 0.85)))
+            }
         }
-        .accessibilityLabel("Open chat")
-        .padding(.trailing, Space.lg)
-        .padding(.bottom, Space.lg)
-        .opacity(keyboardVisible ? 0 : 1)
-        .allowsHitTesting(!keyboardVisible)
-        .animation(.easeOut(duration: 0.18), value: keyboardVisible)
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
-            keyboardVisible = true
+            withAnimation(.easeOut(duration: 0.18)) { keyboardVisible = true }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
-            keyboardVisible = false
+            withAnimation(.easeOut(duration: 0.18)) { keyboardVisible = false }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Hide the floating sparkle FAB while the keyboard is up so it never covers the in-row submit button on `Add an item`, inline task add, etc.
- One-place fix on `ChatFAB` itself: listens to `UIResponder.keyboardWillShow/Hide` and fades via opacity (no layout jump).
- Behaviour applies on every surface that mounts `ChatFAB` (Tasks, Lists, Notes root, Today, Activity, Dashboard, Settings).

Closes #29

## Test plan
Static (done):
- [x] `xcodegen generate` then `xcodebuild build` for iOS Simulator -> BUILD SUCCEEDED.

Visual QA (device-pending — run `bash mobile/ota/ship-lan.sh` + `xcrun devicectl device install app` to verify):
- [ ] Lists -> open a list -> tap `Add an item`. Wizard fades out. In-row + button reachable. Dismiss keyboard -> wizard fades back in. No layout jump.
- [ ] Tasks -> tap `Add a new task`. Same behaviour.
- [ ] Notes root list -> nothing else has a focused field on this screen, but verify the FAB returns when leaving Note detail.
- [ ] Sanity: chat root unchanged (it does not mount `ChatFAB`).