### PR TITLE
feat(ios): swipe-left to delete on tasks, lists, list items, notes, folders

### DIFF
--- a/mobile/PersonalDashboard/Design/Haptics.swift
+++ b/mobile/PersonalDashboard/Design/Haptics.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+/// Lightweight haptic helpers used by row-level destructive actions
+/// (swipe-to-delete) so the same feel is reused across surfaces.
+///
+/// Generators are short-lived intentionally: iOS does not require us to
+/// hold onto them for one-shot fires, and creating one per call keeps
+/// the call sites local.
+enum Haptics {
+    /// A medium-warning thump suitable for a destructive commit
+    /// (delete row, drop row). Mirrors the Mail / Reminders feel.
+    static func destructive() {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(.warning)
+    }
+}

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -65,8 +65,11 @@ struct ListsView: View {
     }
 
     private var rootList: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: Space.md) {
+        // `List` (not `ScrollView { LazyVStack }`) so each list row can opt
+        // into native `.swipeActions`. Paper aesthetic preserved via clear
+        // row backgrounds, hidden separators, and `.scrollContentBackground`.
+        List {
+            Section {
                 HStack {
                     Spacer()
                     Button {
@@ -76,27 +79,50 @@ struct ListsView: View {
                     }
                     .buttonStyle(EdButtonStyle(kind: .primary, size: .sm))
                 }
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets(top: Space.lg, leading: Space.lg, bottom: Space.sm, trailing: Space.lg))
+            }
 
-                if viewModel.lists.isEmpty && !viewModel.isLoading {
-                    Text("No lists yet. Tap “New list” to start.")
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.muted)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, Space.xxxl)
-                } else {
-                    ForEach(viewModel.lists) { list in
-                        ListSummaryRow(list: list) {
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                selectedListId = list.id
-                            }
+            if viewModel.lists.isEmpty && !viewModel.isLoading {
+                Text("No lists yet. Tap “New list” to start.")
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.muted)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, Space.xxxl)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: 0, leading: Space.lg, bottom: 0, trailing: Space.lg))
+            } else {
+                ForEach(viewModel.lists) { list in
+                    ListSummaryRow(list: list) {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            selectedListId = list.id
+                        }
+                    }
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            Haptics.destructive()
+                            Task { await viewModel.delete(list) }
+                        } label: {
+                            Label("Delete", systemImage: "trash")
                         }
                     }
                 }
             }
-            .padding(.horizontal, Space.lg)
-            .padding(.top, Space.lg)
-            .padding(.bottom, 96)
+
+            Color.clear
+                .frame(height: 96)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Tokens.paper)
         .refreshable { await viewModel.load() }
     }
 }
@@ -238,17 +264,27 @@ private struct ListDetailContent: View {
                             ItemRow(item: item) {
                                 Task { await viewModel.toggleItem(in: list, at: index) }
                             } onDelete: {
+                                Haptics.destructive()
                                 Task { await viewModel.removeItem(from: list, at: index) }
                             }
                             .listRowBackground(Tokens.paper)
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) {
+                                    Haptics.destructive()
+                                    Task { await viewModel.removeItem(from: list, at: index) }
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
                         }
                         .onMove { source, destination in
                             Task { await viewModel.reorderItems(in: list, from: source, to: destination) }
                         }
                         .onDelete { offsets in
                             for index in offsets {
+                                Haptics.destructive()
                                 Task { await viewModel.removeItem(from: list, at: index) }
                             }
                         }

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -117,8 +117,11 @@ struct NotesView: View {
     // MARK: - Root list (folders + unfiled)
 
     private var rootList: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: Space.xl) {
+        // `List` (not `ScrollView { LazyVStack }`) so each folder/note row can
+        // opt into native `.swipeActions`. Paper aesthetic preserved with
+        // clear row backgrounds and hidden separators.
+        List {
+            Section {
                 HStack {
                     Spacer()
                     Button {
@@ -134,77 +137,133 @@ struct NotesView: View {
                     }
                     .buttonStyle(EdButtonStyle(kind: .primary, size: .sm))
                 }
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets(top: Space.lg, leading: Space.lg, bottom: Space.sm, trailing: Space.lg))
+            }
 
-                if !viewModel.folders.isEmpty {
-                    section("Folders") {
-                        VStack(spacing: Space.xs) {
-                            ForEach(viewModel.folders) { folder in
-                                FolderRow(
-                                    folder: folder,
-                                    count: viewModel.notes(in: folder).count,
-                                    onTap: {
-                                        withAnimation(.easeOut(duration: 0.2)) { selectedFolder = folder }
-                                    }
-                                )
+            if !viewModel.folders.isEmpty {
+                Section {
+                    ForEach(viewModel.folders) { folder in
+                        FolderRow(
+                            folder: folder,
+                            count: viewModel.notes(in: folder).count,
+                            onTap: {
+                                withAnimation(.easeOut(duration: 0.2)) { selectedFolder = folder }
+                            }
+                        )
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
+                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                            Button(role: .destructive) {
+                                Haptics.destructive()
+                                Task { await viewModel.deleteFolder(folder) }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
                             }
                         }
                     }
-                }
-
-                let unfiled = viewModel.notes(in: nil)
-                if !unfiled.isEmpty {
-                    section("Unfiled") {
-                        VStack(spacing: Space.xs) {
-                            ForEach(unfiled) { note in
-                                NoteRow(note: note) { open(note: note) }
-                            }
-                        }
-                    }
-                }
-
-                if viewModel.folders.isEmpty && viewModel.notes.isEmpty && !viewModel.isLoading {
-                    Text("No notes yet. Tap “New note” to start.")
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.muted)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, Space.xxxl)
+                } header: {
+                    sectionEyebrow("Folders")
                 }
             }
-            .padding(.horizontal, Space.lg)
-            .padding(.top, Space.lg)
-            .padding(.bottom, 96)
+
+            let unfiled = viewModel.notes(in: nil)
+            if !unfiled.isEmpty {
+                Section {
+                    ForEach(unfiled) { note in
+                        NoteRow(note: note) { open(note: note) }
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
+                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                Button(role: .destructive) {
+                                    Haptics.destructive()
+                                    Task { await viewModel.deleteNote(note) }
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                    }
+                } header: {
+                    sectionEyebrow("Unfiled")
+                }
+            }
+
+            if viewModel.folders.isEmpty && viewModel.notes.isEmpty && !viewModel.isLoading {
+                Text("No notes yet. Tap “New note” to start.")
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.muted)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, Space.xxxl)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: 0, leading: Space.lg, bottom: 0, trailing: Space.lg))
+            }
+
+            Color.clear
+                .frame(height: 96)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Tokens.paper)
         .refreshable { await viewModel.load() }
     }
 
     private func folderNotesList(_ folder: NoteFolder) -> some View {
         let inFolder = viewModel.notes(in: folder)
-        return ScrollView {
-            LazyVStack(spacing: Space.xs) {
-                if inFolder.isEmpty {
-                    Text("No notes in \(folder.name) yet.")
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.muted)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, Space.xxxl)
-                } else {
-                    ForEach(inFolder) { note in
-                        NoteRow(note: note) { open(note: note) }
-                    }
+        return List {
+            if inFolder.isEmpty {
+                Text("No notes in \(folder.name) yet.")
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.muted)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, Space.xxxl)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: Space.lg, leading: Space.lg, bottom: 0, trailing: Space.lg))
+            } else {
+                ForEach(inFolder) { note in
+                    NoteRow(note: note) { open(note: note) }
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
+                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                            Button(role: .destructive) {
+                                Haptics.destructive()
+                                Task { await viewModel.deleteNote(note) }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
                 }
             }
-            .padding(.horizontal, Space.lg)
-            .padding(.top, Space.lg)
-            .padding(.bottom, 96)
+
+            Color.clear
+                .frame(height: 96)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Tokens.paper)
         .refreshable { await viewModel.load() }
     }
 
-    private func section<Content: View>(_ title: String, @ViewBuilder _ body: () -> Content) -> some View {
-        VStack(alignment: .leading, spacing: Space.sm) {
-            Text(title).eyebrow()
-            body()
-        }
+    private func sectionEyebrow(_ title: String) -> some View {
+        Text(title)
+            .eyebrow()
+            .textCase(nil)
+            .padding(.horizontal, Space.lg)
+            .padding(.top, Space.lg)
+            .padding(.bottom, Space.xs)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Tokens.paper)
     }
 
     // MARK: - Note actions

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -23,22 +23,37 @@ struct TasksView: View {
                     onToggleTheme: { schemePref = schemePref.next }
                 )
 
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: Space.lg) {
+                // Using `List` (not `ScrollView { LazyVStack }`) so each row
+                // can opt into native `.swipeActions`. The list is dressed
+                // down to keep the editorial paper styling: clear row
+                // backgrounds, hidden separators, and `.scrollContentBackground`
+                // hidden so `Tokens.paper` shows through.
+                List {
+                    Section {
                         addRow
-
-                        if viewModel.isLoading && viewModel.todos.isEmpty {
-                            placeholder("Loading…")
-                        } else if viewModel.todos.isEmpty {
-                            placeholder("No tasks yet. Add one above.")
-                        } else {
-                            taskGroups
-                        }
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets(top: Space.lg, leading: Space.lg, bottom: 0, trailing: Space.lg))
                     }
-                    .padding(.horizontal, Space.lg)
-                    .padding(.top, Space.lg)
-                    .padding(.bottom, 96) // FAB clearance
+
+                    if viewModel.isLoading && viewModel.todos.isEmpty {
+                        placeholderRow("Loading…")
+                    } else if viewModel.todos.isEmpty {
+                        placeholderRow("No tasks yet. Add one above.")
+                    } else {
+                        taskGroups
+                    }
+
+                    // FAB clearance — keeps the last row scrollable above the chat FAB.
+                    Color.clear
+                        .frame(height: 96)
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets())
                 }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .background(Tokens.paper)
                 .refreshable { await viewModel.load() }
             }
 
@@ -123,80 +138,108 @@ struct TasksView: View {
 
     // MARK: - Grouped tasks
 
+    @ViewBuilder
     private var taskGroups: some View {
+        let buckets = computeBuckets()
+        if !buckets.overdue.isEmpty {
+            taskSection(title: "Overdue", count: buckets.overdue.count, accent: Tokens.danger, soft: Tokens.dangerSoft, todos: buckets.overdue)
+        }
+        if !buckets.today.isEmpty {
+            taskSection(title: "Today", count: buckets.today.count, accent: Tokens.warning, soft: Tokens.warningSoft, todos: buckets.today)
+        }
+        if !buckets.thisWeek.isEmpty {
+            taskSection(title: "This Week", count: buckets.thisWeek.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: buckets.thisWeek)
+        }
+        if !buckets.later.isEmpty {
+            taskSection(title: "Later", count: buckets.later.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: buckets.later)
+        }
+        if !buckets.noDate.isEmpty {
+            taskSection(title: "No Date", count: buckets.noDate.count, accent: Tokens.muted, soft: Tokens.paper2, todos: buckets.noDate)
+        }
+        if !buckets.completed.isEmpty {
+            completedSection(buckets.completed)
+        }
+    }
+
+    private struct TaskBuckets {
+        var overdue: [Todo] = []
+        var today: [Todo] = []
+        var thisWeek: [Todo] = []
+        var later: [Todo] = []
+        var noDate: [Todo] = []
+        var completed: [Todo] = []
+    }
+
+    private func computeBuckets() -> TaskBuckets {
         let now = Date()
         let cal = Calendar.current
         let today = cal.startOfDay(for: now)
         let tomorrow = cal.date(byAdding: .day, value: 1, to: today)!
         let weekEnd = cal.date(byAdding: .day, value: 7, to: today)!
 
+        var b = TaskBuckets()
+        b.completed = viewModel.todos.filter { $0.completed }
         let open = viewModel.todos.filter { !$0.completed }
-        let completed = viewModel.todos.filter { $0.completed }
-
-        var overdue: [Todo] = []
-        var todayList: [Todo] = []
-        var thisWeek: [Todo] = []
-        var later: [Todo] = []
-        var noDate: [Todo] = []
-
         for todo in open {
-            guard let due = todo.dueDate else { noDate.append(todo); continue }
-            if due < today { overdue.append(todo) }
-            else if due < tomorrow { todayList.append(todo) }
-            else if due < weekEnd { thisWeek.append(todo) }
-            else { later.append(todo) }
+            guard let due = todo.dueDate else { b.noDate.append(todo); continue }
+            if due < today { b.overdue.append(todo) }
+            else if due < tomorrow { b.today.append(todo) }
+            else if due < weekEnd { b.thisWeek.append(todo) }
+            else { b.later.append(todo) }
         }
+        return b
+    }
 
-        return VStack(alignment: .leading, spacing: Space.xl) {
-            if !overdue.isEmpty {
-                taskSection(title: "Overdue", count: overdue.count, accent: Tokens.danger, soft: Tokens.dangerSoft, todos: overdue)
+    @ViewBuilder
+    private func taskSection(title: String, count: Int, accent: Color, soft: Color, todos: [Todo]) -> some View {
+        Section {
+            ForEach(todos) { todo in
+                TaskRow(todo: todo) {
+                    Task { await viewModel.toggleCompleted(todo) }
+                } onTap: {
+                    editingTodo = todo
+                }
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                    Button(role: .destructive) {
+                        Haptics.destructive()
+                        Task { await viewModel.delete(todo) }
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
             }
-            if !todayList.isEmpty {
-                taskSection(title: "Today", count: todayList.count, accent: Tokens.warning, soft: Tokens.warningSoft, todos: todayList)
-            }
-            if !thisWeek.isEmpty {
-                taskSection(title: "This Week", count: thisWeek.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: thisWeek)
-            }
-            if !later.isEmpty {
-                taskSection(title: "Later", count: later.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: later)
-            }
-            if !noDate.isEmpty {
-                taskSection(title: "No Date", count: noDate.count, accent: Tokens.muted, soft: Tokens.paper2, todos: noDate)
-            }
-            if !completed.isEmpty {
-                completedSection(completed)
-            }
+        } header: {
+            sectionHeader(title: title, count: count, accent: accent, soft: soft)
         }
     }
 
-    private func taskSection(title: String, count: Int, accent: Color, soft: Color, todos: [Todo]) -> some View {
-        VStack(alignment: .leading, spacing: Space.sm) {
-            HStack(spacing: Space.sm) {
-                Text(title)
-                    .font(.edHeading)
-                    .foregroundStyle(accent)
-                Text("\(count)")
-                    .font(.edCaption)
-                    .foregroundStyle(accent)
-                    .padding(.horizontal, Space.sm)
-                    .padding(.vertical, 2)
-                    .background(soft, in: Capsule())
-                Spacer()
-            }
-            VStack(spacing: Space.xs) {
+    @ViewBuilder
+    private func completedSection(_ todos: [Todo]) -> some View {
+        Section {
+            if completedExpanded {
                 ForEach(todos) { todo in
                     TaskRow(todo: todo) {
                         Task { await viewModel.toggleCompleted(todo) }
                     } onTap: {
                         editingTodo = todo
                     }
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            Haptics.destructive()
+                            Task { await viewModel.delete(todo) }
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
                 }
             }
-        }
-    }
-
-    private func completedSection(_ todos: [Todo]) -> some View {
-        VStack(alignment: .leading, spacing: Space.sm) {
+        } header: {
             Button {
                 withAnimation(.easeOut(duration: 0.2)) { completedExpanded.toggle() }
             } label: {
@@ -218,27 +261,45 @@ struct TasksView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-
-            if completedExpanded {
-                VStack(spacing: Space.xs) {
-                    ForEach(todos) { todo in
-                        TaskRow(todo: todo) {
-                            Task { await viewModel.toggleCompleted(todo) }
-                        } onTap: {
-                            editingTodo = todo
-                        }
-                    }
-                }
-            }
+            .textCase(nil)
+            .padding(.horizontal, Space.lg)
+            .padding(.top, Space.lg)
+            .padding(.bottom, Space.xs)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Tokens.paper)
         }
     }
 
-    private func placeholder(_ text: String) -> some View {
+    private func sectionHeader(title: String, count: Int, accent: Color, soft: Color) -> some View {
+        HStack(spacing: Space.sm) {
+            Text(title)
+                .font(.edHeading)
+                .foregroundStyle(accent)
+            Text("\(count)")
+                .font(.edCaption)
+                .foregroundStyle(accent)
+                .padding(.horizontal, Space.sm)
+                .padding(.vertical, 2)
+                .background(soft, in: Capsule())
+            Spacer()
+        }
+        .textCase(nil)
+        .padding(.horizontal, Space.lg)
+        .padding(.top, Space.lg)
+        .padding(.bottom, Space.xs)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Tokens.paper)
+    }
+
+    private func placeholderRow(_ text: String) -> some View {
         Text(text)
             .font(.edBody)
             .foregroundStyle(Tokens.muted)
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.vertical, Space.xxxl)
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets(top: 0, leading: Space.lg, bottom: 0, trailing: Space.lg))
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds native iOS swipe-from-trailing-edge delete on all five row types: tasks, lists, list items, notes, folders.
- Tap Delete soft-deletes via the existing `deletedAt` pattern (same path the trash icon uses today). Cascading folder/list deletes are unchanged.
- Haptic feedback (`UINotificationFeedbackGenerator.warning`) fires on every destructive commit for a consistent feel.
- Tap-to-open and existing trash-icon / context-menu affordances are preserved (additive change, no regressions).

## Implementation notes

- TasksView, ListsView (rootList), NotesView (rootList + folderNotesList) refactored from `ScrollView { LazyVStack }` to SwiftUI `List` so rows can opt into `.swipeActions(edge: .trailing, allowsFullSwipe: true)`. Paper styling preserved via `.listStyle(.plain)`, `.listRowBackground(.clear)`, `.listRowSeparator(.hidden)`, and `.scrollContentBackground(.hidden)`.
- ListsView's list-detail `ItemRow` was already inside a `List`; it just gains `.swipeActions` alongside the existing `.onDelete` and `contextMenu`.
- New file: `mobile/PersonalDashboard/Design/Haptics.swift` (small helper used 5 times).

Closes #31

## Test plan

Static build verified; device QA pending OTA install per `.claude/rules/dev-workflow.md`.

Manual device QA (run after OTA install):

- [ ] Tasks view: swipe a task row left, full swipe deletes it, partial swipe reveals red Delete button, tapping elsewhere snaps it back.
- [ ] Tasks view: tap-to-open still opens the task editor; checkbox tap still toggles complete.
- [ ] Lists view (root): swipe a list row left, deletes the list (and its items) via existing soft-delete cascade.
- [ ] Lists view (detail): swipe a list-item row left, deletes the item; reorder via Edit-mode handles still works.
- [ ] Notes view (root): swipe a note row left in the Unfiled section, deletes the note.
- [ ] Notes view (root): swipe a folder row left, deletes the folder and soft-deletes child notes (matches trash-icon behaviour).
- [ ] Notes view (folder detail): swipe a note row left, deletes the note.
- [ ] Haptic warning fires on each destructive commit (5 surfaces).
- [ ] Pull-to-refresh still works on every refactored screen.
- [ ] FAB clearance preserved at the bottom of every list (no row obscured).