### PR TITLE
feat(ios): hide Dashboard surface from drawer

### DIFF
--- a/mobile/PersonalDashboard/App/AppRouter.swift
+++ b/mobile/PersonalDashboard/App/AppRouter.swift
@@ -30,6 +30,9 @@ final class AppRouter {
         if let raw = ProcessInfo.processInfo.environment["LAUNCH_SECTION"]?.lowercased(),
            let s = AppSection(rawValue: raw),
            s != .chat {
+            // Dashboard is hidden (issue #30). Redirect any deep-link that
+            // targets it to Activity, the closest replacement surface.
+            if s == .dashboard { return [.activity] }
             return [s]
         }
         return []

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -53,7 +53,11 @@ struct ContentView: View {
         case .lists:
             ListsView(router: router, schemePref: schemePref)
         case .dashboard:
-            DashboardView(router: router, schemePref: schemePref)
+            // Dashboard surface is hidden (issue #30). The drawer entry has
+            // been removed and the LAUNCH_SECTION deep-link redirects to
+            // .activity, so this case is unreachable. Restore by replacing
+            // EmptyView() with `DashboardView(router: router, schemePref: schemePref)`.
+            EmptyView()
         case .activity:
             ActivityView(router: router, schemePref: schemePref)
         case .settings:

--- a/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
+++ b/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
@@ -82,10 +82,9 @@ struct SideDrawer: View {
 
             DrawerDivider()
 
-            // Dashboard
-            DrawerRow(section: .dashboard, router: router)
-
-            // Activity (read-only chronological feed of all creations)
+            // Activity (read-only chronological feed of all creations).
+            // Dashboard surface is hidden (issue #30) — files retained for a
+            // future repurpose into a forward-looking plan/focus view.
             DrawerRow(section: .activity, router: router)
 
             DrawerDivider()


### PR DESCRIPTION
## Summary
- Removes the Dashboard entry from the side drawer; Activity now sits directly under Tasks/Notes/Lists.
- `LAUNCH_SECTION=dashboard` deep-link redirects to `.activity` so any pre-existing routes don't open a dead surface.
- `ContentView`'s `.dashboard` case renders `EmptyView()` (one-line restore noted in the comment).
- `DashboardView`, `DashboardViewModel`, `DashboardService`, `DashboardStats`, the `.dashboard` enum case, and its accent token are retained — the surface can be revived later as a forward-looking plan/focus view.

Closes #30

## Test plan
- [x] `xcodegen generate` clean
- [x] `xcodebuild build` (iOS Simulator, Debug) → BUILD SUCCEEDED
- [x] On-device QA on Flightmode 2.0 (iPhone 16 Pro Max): drawer no longer shows Dashboard, app opens to Chat root, Activity reachable, Capture Shortcut still captures into SwiftData

🤖 Generated with [Claude Code](https://claude.com/claude-code)