### PR TITLE
feat(ios): unify swipe-left delete affordance across all list surfaces

### DIFF
--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+extension View {
+    /// Unified swipe-left-to-delete affordance across every list surface.
+    /// Renders an icon-only trash button on a destructive-red fill, full-swipe enabled.
+    /// Tint (without `role: .destructive`) keeps the visual flat across short and tall rows
+    /// so SwiftUI does not switch to its circular icon-bubble heuristic on short rows.
+    func swipeToDeleteTrash(perform action: @escaping () -> Void) -> some View {
+        swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button {
+                Haptics.destructive()
+                action()
+            } label: {
+                Image(systemName: "trash")
+            }
+            .tint(Tokens.danger)
+            .accessibilityLabel("Delete")
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -103,13 +103,8 @@ struct ListsView: View {
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                     .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
-                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        Button(role: .destructive) {
-                            Haptics.destructive()
-                            Task { await viewModel.delete(list) }
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
+                    .swipeToDeleteTrash {
+                        Task { await viewModel.delete(list) }
                     }
                 }
             }
@@ -270,29 +265,17 @@ private struct ListDetailContent: View {
                             .listRowBackground(Tokens.paper)
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
-                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                                Button(role: .destructive) {
-                                    Haptics.destructive()
-                                    Task { await viewModel.removeItem(from: list, at: index) }
-                                } label: {
-                                    Label("Delete", systemImage: "trash")
-                                }
+                            .swipeToDeleteTrash {
+                                Task { await viewModel.removeItem(from: list, at: index) }
                             }
                         }
                         .onMove { source, destination in
                             Task { await viewModel.reorderItems(in: list, from: source, to: destination) }
                         }
-                        .onDelete { offsets in
-                            for index in offsets {
-                                Haptics.destructive()
-                                Task { await viewModel.removeItem(from: list, at: index) }
-                            }
-                        }
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
                     .background(Tokens.paper)
-                    .environment(\.editMode, .constant(.active))
                 }
 
                 addItemBar(list: list)

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -155,13 +155,8 @@ struct NotesView: View {
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                         .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
-                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                            Button(role: .destructive) {
-                                Haptics.destructive()
-                                Task { await viewModel.deleteFolder(folder) }
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
+                        .swipeToDeleteTrash {
+                            Task { await viewModel.deleteFolder(folder) }
                         }
                     }
                 } header: {
@@ -177,13 +172,8 @@ struct NotesView: View {
                             .listRowBackground(Color.clear)
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
-                            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                                Button(role: .destructive) {
-                                    Haptics.destructive()
-                                    Task { await viewModel.deleteNote(note) }
-                                } label: {
-                                    Label("Delete", systemImage: "trash")
-                                }
+                            .swipeToDeleteTrash {
+                                Task { await viewModel.deleteNote(note) }
                             }
                     }
                 } header: {
@@ -232,13 +222,8 @@ struct NotesView: View {
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                         .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
-                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                            Button(role: .destructive) {
-                                Haptics.destructive()
-                                Task { await viewModel.deleteNote(note) }
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
+                        .swipeToDeleteTrash {
+                            Task { await viewModel.deleteNote(note) }
                         }
                 }
             }

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -202,13 +202,8 @@ struct TasksView: View {
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
                 .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
-                .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                    Button(role: .destructive) {
-                        Haptics.destructive()
-                        Task { await viewModel.delete(todo) }
-                    } label: {
-                        Label("Delete", systemImage: "trash")
-                    }
+                .swipeToDeleteTrash {
+                    Task { await viewModel.delete(todo) }
                 }
             }
         } header: {
@@ -229,13 +224,8 @@ struct TasksView: View {
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                     .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
-                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        Button(role: .destructive) {
-                            Haptics.destructive()
-                            Task { await viewModel.delete(todo) }
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
+                    .swipeToDeleteTrash {
+                        Task { await viewModel.delete(todo) }
                     }
                 }
             }
@@ -327,6 +317,9 @@ private struct TaskRow: View {
                 .frame(width: 24, height: 24)
             }
             .buttonStyle(.plain)
+            // Map the circle's center (with a 4pt body-font offset for x-height) to the
+            // firstTextBaseline so the bullet visually centers on the title's first line.
+            .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
             .accessibilityLabel(todo.completed ? "Mark incomplete" : "Mark complete")
 
             VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
## Summary
- Adds a shared `.swipeToDeleteTrash { ... }` modifier in `Design/SwipeActions.swift`
- Tasks, lists, list items, notes, folders all now show the same icon-only trash on a destructive-red pill, full-swipe enabled
- Removes the forced `editMode = .active` and the redundant `.onDelete` on list items, which was the source of the leading `-` minus
- Bonus: aligns the task row checkbox with the title's first-line x-height (was sitting too high relative to body text)

Closes #42

## Test plan
- [x] Tasks: swipe left reveals only the trash icon on red pill (no "Delete" text)
- [x] Lists: same treatment
- [x] List items: same treatment, leading `-` is gone, hold-to-reorder still works
- [x] Notes: same treatment (no circular red bubble)
- [x] Folders: same treatment (no "Delete" text)
- [x] Full-swipe-to-commit semantics still work
- [x] Tasks landing: checkbox aligns with title baseline
- [x] Installed and tested on device (Flightmode 2.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)