### PR TITLE
feat(ios): inline rename for lists, list items, and folders

### DIFF
--- a/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
@@ -55,6 +55,29 @@ final class ListsViewModel {
         }
     }
 
+    func rename(_ list: Checklist, to title: String) async {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let listIndex = lists.firstIndex(where: { $0.id == list.id }),
+              lists[listIndex].title != trimmed else { return }
+        var snapshot = lists[listIndex]
+        snapshot.title = trimmed
+        lists[listIndex] = snapshot
+        await update(snapshot)
+    }
+
+    func renameItem(in list: Checklist, at index: Int, to text: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let listIndex = lists.firstIndex(where: { $0.id == list.id }),
+              index < lists[listIndex].items.count,
+              lists[listIndex].items[index].text != trimmed else { return }
+        var snapshot = lists[listIndex]
+        snapshot.items[index].text = trimmed
+        lists[listIndex] = snapshot
+        await update(snapshot)
+    }
+
     func toggleItem(in list: Checklist, at index: Int) async {
         guard let listIndex = lists.firstIndex(where: { $0.id == list.id }),
               index < lists[listIndex].items.count else { return }

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -17,14 +17,21 @@ struct ListsView: View {
 
             VStack(spacing: 0) {
                 if let id = selectedListId, let list = viewModel.lists.first(where: { $0.id == id }) {
-                    ListDetailHeader(title: list.title, onBack: {
-                        withAnimation(.easeOut(duration: 0.2)) { selectedListId = nil }
-                    }, onDelete: {
-                        Task {
-                            await viewModel.delete(list)
-                            selectedListId = nil
+                    ListDetailHeader(
+                        title: list.title,
+                        onBack: {
+                            withAnimation(.easeOut(duration: 0.2)) { selectedListId = nil }
+                        },
+                        onRename: { newTitle in
+                            Task { await viewModel.rename(list, to: newTitle) }
+                        },
+                        onDelete: {
+                            Task {
+                                await viewModel.delete(list)
+                                selectedListId = nil
+                            }
                         }
-                    })
+                    )
                     ListDetailContent(viewModel: viewModel, listId: id)
                 } else {
                     TopBar(
@@ -124,7 +131,12 @@ struct ListsView: View {
 private struct ListDetailHeader: View {
     let title: String
     let onBack: () -> Void
+    let onRename: (String) -> Void
     let onDelete: () -> Void
+
+    @State private var isEditing = false
+    @State private var draft = ""
+    @FocusState private var focused: Bool
 
     var body: some View {
         HStack(spacing: Space.md) {
@@ -139,10 +151,31 @@ private struct ListDetailHeader: View {
                 .contentShape(Rectangle())
             }
             Spacer()
-            Text(title)
-                .font(.edTitle)
-                .foregroundStyle(Tokens.ink)
-                .lineLimit(1)
+            if isEditing {
+                TextField("", text: $draft)
+                    .font(.edTitle)
+                    .foregroundStyle(Tokens.ink)
+                    .multilineTextAlignment(.center)
+                    .submitLabel(.done)
+                    .focused($focused)
+                    .onSubmit { commit() }
+                    .onChange(of: focused) { _, nowFocused in
+                        if !nowFocused { commit() }
+                    }
+                    .accessibilityLabel("List title")
+            } else {
+                Text(title)
+                    .font(.edTitle)
+                    .foregroundStyle(Tokens.ink)
+                    .lineLimit(1)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        draft = title
+                        isEditing = true
+                        focused = true
+                    }
+                    .accessibilityLabel("List title, tap to rename")
+            }
             Spacer()
             Button(action: onDelete) {
                 Image(systemName: "trash")
@@ -156,6 +189,15 @@ private struct ListDetailHeader: View {
         .background(Tokens.paper.overlay(alignment: .bottom) {
             Rectangle().fill(Tokens.divider).frame(height: 0.5)
         })
+    }
+
+    private func commit() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty && trimmed != title {
+            onRename(trimmed)
+        }
+        isEditing = false
+        focused = false
     }
 }
 
@@ -255,12 +297,19 @@ private struct ListDetailContent: View {
                 } else {
                     List {
                         ForEach(Array(list.items.enumerated()), id: \.offset) { index, item in
-                            ItemRow(item: item) {
-                                Task { await viewModel.toggleItem(in: list, at: index) }
-                            } onDelete: {
-                                Haptics.destructive()
-                                Task { await viewModel.removeItem(from: list, at: index) }
-                            }
+                            ItemRow(
+                                item: item,
+                                onToggle: {
+                                    Task { await viewModel.toggleItem(in: list, at: index) }
+                                },
+                                onRename: { newText in
+                                    Task { await viewModel.renameItem(in: list, at: index, to: newText) }
+                                },
+                                onDelete: {
+                                    Haptics.destructive()
+                                    Task { await viewModel.removeItem(from: list, at: index) }
+                                }
+                            )
                             .listRowBackground(Tokens.paper)
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
@@ -335,7 +384,12 @@ private struct ListDetailContent: View {
 private struct ItemRow: View {
     let item: ChecklistItem
     let onToggle: () -> Void
+    let onRename: (String) -> Void
     let onDelete: () -> Void
+
+    @State private var isEditing = false
+    @State private var draft = ""
+    @FocusState private var focused: Bool
 
     var body: some View {
         HStack(spacing: Space.md) {
@@ -354,22 +408,53 @@ private struct ItemRow: View {
                 .frame(width: 24, height: 24)
             }
             .buttonStyle(.plain)
+            .disabled(isEditing)
 
-            Text(item.text)
-                .font(.edBody)
-                .strikethrough(item.checked)
-                .foregroundStyle(item.checked ? Tokens.mutedSoft : Tokens.ink)
+            if isEditing {
+                TextField("", text: $draft)
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.ink)
+                    .submitLabel(.done)
+                    .focused($focused)
+                    .onSubmit { commit() }
+                    .onChange(of: focused) { _, nowFocused in
+                        if !nowFocused { commit() }
+                    }
+                    .accessibilityLabel("Rename item")
+            } else {
+                Text(item.text)
+                    .font(.edBody)
+                    .strikethrough(item.checked)
+                    .foregroundStyle(item.checked ? Tokens.mutedSoft : Tokens.ink)
+            }
             Spacer()
         }
         .padding(.vertical, Space.sm)
         .padding(.horizontal, Space.md)
         .contentShape(Rectangle())
-        .onTapGesture { onToggle() }
+        .onTapGesture {
+            if !isEditing { beginEditing() }
+        }
         .contextMenu {
             Button(role: .destructive, action: onDelete) {
                 Label("Delete", systemImage: "trash")
             }
         }
+    }
+
+    private func beginEditing() {
+        draft = item.text
+        isEditing = true
+        DispatchQueue.main.async { focused = true }
+    }
+
+    private func commit() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty && trimmed != item.text {
+            onRename(trimmed)
+        }
+        isEditing = false
+        focused = false
     }
 }
 

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -27,7 +27,23 @@ struct NotesView: View {
                         }
                     )
                 } else if let folder = selectedFolder {
-                    folderDetailHeader(folder: folder)
+                    FolderDetailHeader(
+                        folder: folder,
+                        onBack: {
+                            withAnimation(.easeOut(duration: 0.2)) { selectedFolder = nil }
+                        },
+                        onRename: { newName in
+                            Task {
+                                await viewModel.renameFolder(folder, to: newName)
+                                if let updated = viewModel.folders.first(where: { $0.id == folder.id }) {
+                                    selectedFolder = updated
+                                }
+                            }
+                        },
+                        onAddNote: {
+                            Task { await createBlankNote(folderId: folder.id) }
+                        }
+                    )
                     folderNotesList(folder)
                 } else {
                     TopBar(
@@ -75,43 +91,6 @@ struct NotesView: View {
         } message: {
             Text(viewModel.errorMessage ?? "")
         }
-    }
-
-    // MARK: - Folder header
-
-    private func folderDetailHeader(folder: NoteFolder) -> some View {
-        HStack(spacing: Space.md) {
-            Button {
-                withAnimation(.easeOut(duration: 0.2)) { selectedFolder = nil }
-            } label: {
-                HStack(spacing: 4) {
-                    Image(systemName: "chevron.left")
-                    Text("Notes")
-                }
-                .font(.edBody)
-                .foregroundStyle(Tokens.muted)
-                .frame(height: 44)
-                .contentShape(Rectangle())
-            }
-            Spacer()
-            Text(folder.name)
-                .font(.edTitle)
-                .foregroundStyle(Tokens.ink)
-            Spacer()
-            Button {
-                Task { await createBlankNote(folderId: folder.id) }
-            } label: {
-                Image(systemName: "plus")
-                    .frame(width: 44, height: 44)
-                    .foregroundStyle(Tokens.ink)
-            }
-            .accessibilityLabel("New note")
-        }
-        .padding(.horizontal, Space.md)
-        .frame(height: 56)
-        .background(Tokens.paper.overlay(alignment: .bottom) {
-            Rectangle().fill(Tokens.divider).frame(height: 0.5)
-        })
     }
 
     // MARK: - Root list (folders + unfiled)
@@ -260,6 +239,79 @@ struct NotesView: View {
     private func createBlankNote(folderId: UUID?) async {
         guard let new = await viewModel.createNote(title: nil, content: nil, folderId: folderId) else { return }
         withAnimation(.easeOut(duration: 0.2)) { selectedNoteId = new.id }
+    }
+}
+
+private struct FolderDetailHeader: View {
+    let folder: NoteFolder
+    let onBack: () -> Void
+    let onRename: (String) -> Void
+    let onAddNote: () -> Void
+
+    @State private var isEditing = false
+    @State private var draft = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack(spacing: Space.md) {
+            Button(action: onBack) {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                    Text("Notes")
+                }
+                .font(.edBody)
+                .foregroundStyle(Tokens.muted)
+                .frame(height: 44)
+                .contentShape(Rectangle())
+            }
+            Spacer()
+            if isEditing {
+                TextField("", text: $draft)
+                    .font(.edTitle)
+                    .foregroundStyle(Tokens.ink)
+                    .multilineTextAlignment(.center)
+                    .submitLabel(.done)
+                    .focused($focused)
+                    .onSubmit { commit() }
+                    .onChange(of: focused) { _, nowFocused in
+                        if !nowFocused { commit() }
+                    }
+                    .accessibilityLabel("Folder name")
+            } else {
+                Text(folder.name)
+                    .font(.edTitle)
+                    .foregroundStyle(Tokens.ink)
+                    .lineLimit(1)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        draft = folder.name
+                        isEditing = true
+                        focused = true
+                    }
+                    .accessibilityLabel("Folder name, tap to rename")
+            }
+            Spacer()
+            Button(action: onAddNote) {
+                Image(systemName: "plus")
+                    .frame(width: 44, height: 44)
+                    .foregroundStyle(Tokens.ink)
+            }
+            .accessibilityLabel("New note")
+        }
+        .padding(.horizontal, Space.md)
+        .frame(height: 56)
+        .background(Tokens.paper.overlay(alignment: .bottom) {
+            Rectangle().fill(Tokens.divider).frame(height: 0.5)
+        })
+    }
+
+    private func commit() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty && trimmed != folder.name {
+            onRename(trimmed)
+        }
+        isEditing = false
+        focused = false
     }
 }
 


### PR DESCRIPTION
## Summary
- Tap a list title, list item row, or folder header to drop a cursor into the text and edit in place. Return saves, tap-outside / focus-loss saves, empty input silently reverts.
- Added `rename(_:to:)` and `renameItem(in:at:to:)` helpers to `ListsViewModel` so list/title/item edits route through the existing `update(_:)` write path and bump `updatedAt` via `ChecklistService`. Folder rename uses the existing `viewModel.renameFolder`.
- The list item circle stays the only toggle target so tap-to-edit on the row text never fights the check-off interaction. Lists index and Folders index keep tap-to-open (rename out of scope on index rows per the AC).

Closes #40

## Test plan
- [x] List detail title: tap puts the title into an editable field, submit saves, blank input reverts.
- [x] List item row: tap drops a cursor in the item text, return saves, the circle still toggles checked.
- [x] Notes folder header: tap puts the folder name into edit mode, submit saves.
- [x] Empty / whitespace input on every surface is a silent no-op (no entity is renamed to "").
- [x] Edits persist immediately (`updatedAt` bumped via existing service write path) and are visible across surfaces.
- [x] No regression to tap-to-open on Lists index or Folders index.
- [x] Static build clean (`xcodebuild build`); device QA passed on iPhone 16 Pro Max via `devicectl` install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)