### PR TITLE
feat(ios): swipe-to-delete with circular red trash + gray fade

### DIFF
--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -7,12 +7,11 @@ extension View {
     /// trailing edge, with a soft gray card fading in behind the
     /// row to differentiate the swiped state.
     ///
-    /// The drag uses `.simultaneousGesture` with a 10pt activation
-    /// threshold so it coexists with rows that wrap their content
-    /// in a Button (folders, list summaries, note rows) — the
-    /// Button's tap fires for short touches; the drag fires once
-    /// horizontal movement exceeds 10pt and Button's own tolerance
-    /// cancels its tap.
+    /// The drag uses `.highPriorityGesture` with a 10pt activation
+    /// threshold so it preempts the Button-wrapped rows (folders,
+    /// list summaries, note rows) — short touches stay below the
+    /// threshold and fall through to the Button's tap; deliberate
+    /// drags activate the swipe and the Button's tap is cancelled.
     ///
     /// Full-swipe-commit requires a deliberate 70%+ drag (no
     /// velocity-only commit) so a quick flick can never silently
@@ -32,7 +31,7 @@ private struct SwipeRowHeightKey: PreferenceKey {
 private struct SwipeToDeleteWithTint: ViewModifier {
     let onDelete: () -> Void
 
-    @State private var offset: CGFloat = 0
+    @State private var offset: CGFloat = 0  // change to test reveal states
     @State private var isOpen: Bool = false
     /// Measured row height — used to size the gray fade-in card so
     /// it matches the row, and to vertically center the fixed-size
@@ -68,10 +67,13 @@ private struct SwipeToDeleteWithTint: ViewModifier {
         let outerHeight: CGFloat = rowHeight > 0 ? rowHeight : 44
 
         ZStack(alignment: .trailing) {
-            // Always-rendered 52pt circle. At rest, content covers
-            // it; as content slides left it's revealed underneath,
-            // so visibility is purely a side-effect of the drag —
-            // no width animation, the circle stays a circle.
+            // 52pt circle, opacity tied to drag distance. Invisible
+            // at rest (so the circle's edges can't bleed through
+            // gaps in the row's rounded background), fades in over
+            // the first 20pt of drag, fully visible by the snap-open
+            // point. As content slides left underneath, the circle
+            // is revealed purely as a side-effect of the offset —
+            // no width animation, the shape stays a circle.
             Button(action: commit) {
                 Image(systemName: "trash")
                     .font(.system(size: 18, weight: .regular))
@@ -81,6 +83,7 @@ private struct SwipeToDeleteWithTint: ViewModifier {
             }
             .buttonStyle(.plain)
             .frame(maxHeight: outerHeight, alignment: .center)
+            .opacity(min(1.0, dragDistance / 20))
             .allowsHitTesting(dragDistance >= revealedWidth * 0.6)
             .accessibilityLabel("Delete")
 
@@ -97,14 +100,17 @@ private struct SwipeToDeleteWithTint: ViewModifier {
                 )
                 .overlay(closeOverlay)
                 .offset(x: offset)
-                // simultaneousGesture so the drag coexists with the
-                // row's tap (which fires on Button-wrapped rows like
-                // folders and list summaries). With minimumDistance:
-                // 10, brief touches stay below the threshold and
-                // pass through to the Button; deliberate horizontal
-                // drags activate the swipe and Button cancels its
-                // own tap due to movement.
-                .simultaneousGesture(dragGesture)
+                // highPriorityGesture so the drag preempts the row's
+                // Button tap (folders, list summaries, note rows
+                // wrap their content in a Button that navigates on
+                // tap). With simultaneousGesture both gestures
+                // recognised on release, so the row would snap open
+                // AND fire the Button's onTap. highPriority kills
+                // the Button's tap once the drag activates, but
+                // brief touches that stay below minimumDistance: 10
+                // never activate the drag and fall through to the
+                // Button as expected.
+                .highPriorityGesture(dragGesture)
         }
         .onPreferenceChange(SwipeRowHeightKey.self) { rowHeight = $0 }
     }

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -1,77 +1,138 @@
 import SwiftUI
+import UIKit
 
 extension View {
-    /// Unified swipe-left-to-delete affordance across every list surface.
-    /// Renders an icon-only trash button on a destructive-red fill, full-swipe enabled.
-    /// Tint (without `role: .destructive`) keeps the visual flat across short and tall rows
-    /// so SwiftUI does not switch to its circular icon-bubble heuristic on short rows.
+    /// Swipe-left-to-delete affordance: the row content slides left and
+    /// reveals an edge-to-edge red rectangle with a white trash icon on
+    /// the trailing edge — visually identical to the stock
+    /// `.swipeActions(edge: .trailing, allowsFullSwipe: true)` button.
+    /// Routed through a custom container (rather than `.swipeActions`)
+    /// so we can also fade a curved gray card in behind the row as it
+    /// slides, providing the visual separation requested in #39 without
+    /// changing row heights or the delete button's appearance.
+    ///
+    /// Native semantics are preserved:
+    ///   - Partial swipe past `revealedWidth / 2` snaps the row open.
+    ///   - Full-swipe past 45% of the row width (or fast left flick) commits.
+    ///   - Tap on the open row anywhere outside the pill closes it.
     func swipeToDeleteTrash(perform action: @escaping () -> Void) -> some View {
-        swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            Button {
-                Haptics.destructive()
-                action()
-            } label: {
+        modifier(SwipeToDeleteWithTint(onDelete: action))
+    }
+}
+
+private struct SwipeRowHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+private struct SwipeToDeleteWithTint: ViewModifier {
+    let onDelete: () -> Void
+
+    @State private var offset: CGFloat = 0
+    @State private var isOpen: Bool = false
+    /// Measured row height drives the trailing red button so it stays
+    /// edge-to-edge with the row. Without an explicit height the
+    /// inner `.frame(maxHeight: .infinity)` would propagate and force
+    /// `List` to allocate hundreds of points to each row.
+    @State private var rowHeight: CGFloat = 0
+
+    private let revealedWidth: CGFloat = 80
+    private let tintColor: Color = Tokens.borderStrong
+    private let cornerRadius: CGFloat = Radius.md
+
+    func body(content: Content) -> some View {
+        let dragDistance = -offset
+        let progress = min(1.0, max(0.0, Double(dragDistance / revealedWidth)))
+        let pillWidth = max(0, dragDistance)
+        let pillHeight: CGFloat = rowHeight > 0 ? rowHeight : 44
+
+        ZStack(alignment: .trailing) {
+            // Edge-to-edge red rectangle with a white trash icon — the
+            // stock `.swipeActions` look. Width grows with the swipe so
+            // the action is revealed live, not just on release.
+            Button(action: commit) {
                 Image(systemName: "trash")
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundStyle(.white)
+                    .frame(width: pillWidth, height: pillHeight)
+                    .background(Tokens.danger)
             }
-            .tint(Tokens.danger)
+            .buttonStyle(.plain)
+            .opacity(pillWidth > 0.5 ? 1 : 0)
+            .allowsHitTesting(pillWidth >= revealedWidth * 0.5)
             .accessibilityLabel("Delete")
+
+            content
+                .background(
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .fill(tintColor)
+                        .opacity(progress)
+                )
+                .background(
+                    GeometryReader { geo in
+                        Color.clear.preference(key: SwipeRowHeightKey.self, value: geo.size.height)
+                    }
+                )
+                .overlay(closeOverlay)
+                .offset(x: offset)
+                .gesture(dragGesture)
+        }
+        .onPreferenceChange(SwipeRowHeightKey.self) { rowHeight = $0 }
+    }
+
+    @ViewBuilder
+    private var closeOverlay: some View {
+        if isOpen {
+            Color.clear
+                .contentShape(Rectangle())
+                .onTapGesture { close() }
         }
     }
 
-    /// Fades a rounded gray tint behind the row in proportion to how
-    /// far the stock `.swipeActions` recogniser has shifted the row to
-    /// the left. Detection is purely geometric — a GeometryReader
-    /// measures the row's global x position and we compare against the
-    /// at-rest position. No custom DragGesture is attached, so the
-    /// stock swipe (and its full-swipe-to-commit) keep working
-    /// unchanged. Row height and the trailing trash button are
-    /// untouched.
-    func swipeProgressTint(_ color: Color = Tokens.borderStrong, cornerRadius: CGFloat = Radius.md) -> some View {
-        modifier(SwipeProgressTintModifier(tint: color, cornerRadius: cornerRadius))
-    }
-}
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 12)
+            .onChanged { value in
+                guard abs(value.translation.width) > abs(value.translation.height) else { return }
+                let proposed = (isOpen ? -revealedWidth : 0) + value.translation.width
+                offset = max(min(0, proposed), -UIScreen.main.bounds.width)
+            }
+            .onEnded { value in
+                let endX = (isOpen ? -revealedWidth : 0) + value.translation.width
+                let velocity = value.predictedEndTranslation.width - value.translation.width
 
-private struct SwipeRowOffsetKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
-private struct SwipeProgressTintModifier: ViewModifier {
-    let tint: Color
-    let cornerRadius: CGFloat
-    @State private var baseX: CGFloat? = nil
-    @State private var progress: Double = 0
-
-    /// Distance over which the tint fades from 0 -> 1 opacity. Roughly
-    /// matches the width of the stock `.swipeActions` trash button so
-    /// the tint is fully present once the action is fully revealed.
-    private let revealDistance: CGFloat = 80
-
-    func body(content: Content) -> some View {
-        content
-            .background(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(tint)
-                    .opacity(progress)
-            )
-            .background(
-                GeometryReader { geo in
-                    Color.clear
-                        .preference(
-                            key: SwipeRowOffsetKey.self,
-                            value: geo.frame(in: .global).origin.x
-                        )
-                }
-            )
-            .onPreferenceChange(SwipeRowOffsetKey.self) { x in
-                if let base = baseX {
-                    let dx = base - x
-                    progress = min(1, max(0, Double(dx / revealDistance)))
+                if -endX > UIScreen.main.bounds.width * 0.45 || velocity < -1200 {
+                    commit()
+                } else if -endX > revealedWidth * 0.5 {
+                    open()
                 } else {
-                    baseX = x
+                    close()
                 }
             }
+    }
+
+    private func open() {
+        isOpen = true
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+            offset = -revealedWidth
+        }
+    }
+
+    private func close() {
+        isOpen = false
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+            offset = 0
+        }
+    }
+
+    private func commit() {
+        Haptics.destructive()
+        withAnimation(.easeOut(duration: 0.2)) {
+            offset = -UIScreen.main.bounds.width
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+            onDelete()
+        }
     }
 }

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -18,37 +18,60 @@ extension View {
         }
     }
 
-    /// Fades a subtle gray tint behind the row as the user swipes left,
-    /// so the row's background reads as distinct from the destructive
-    /// `.swipeActions` button on the trailing edge. Visual-only — runs
-    /// as a `simultaneousGesture` so the stock swipe-to-delete still
-    /// commits normally; row height and the delete button itself are
-    /// unchanged.
-    func swipeProgressTint(_ color: Color = Tokens.borderStrong) -> some View {
-        modifier(SwipeProgressTintModifier(tint: color))
+    /// Fades a rounded gray tint behind the row in proportion to how
+    /// far the stock `.swipeActions` recogniser has shifted the row to
+    /// the left. Detection is purely geometric — a GeometryReader
+    /// measures the row's global x position and we compare against the
+    /// at-rest position. No custom DragGesture is attached, so the
+    /// stock swipe (and its full-swipe-to-commit) keep working
+    /// unchanged. Row height and the trailing trash button are
+    /// untouched.
+    func swipeProgressTint(_ color: Color = Tokens.borderStrong, cornerRadius: CGFloat = Radius.md) -> some View {
+        modifier(SwipeProgressTintModifier(tint: color, cornerRadius: cornerRadius))
+    }
+}
+
+private struct SwipeRowOffsetKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 
 private struct SwipeProgressTintModifier: ViewModifier {
     let tint: Color
+    let cornerRadius: CGFloat
+    @State private var baseX: CGFloat? = nil
     @State private var progress: Double = 0
+
+    /// Distance over which the tint fades from 0 -> 1 opacity. Roughly
+    /// matches the width of the stock `.swipeActions` trash button so
+    /// the tint is fully present once the action is fully revealed.
+    private let revealDistance: CGFloat = 80
 
     func body(content: Content) -> some View {
         content
-            .background(tint.opacity(progress))
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 8)
-                    .onChanged { value in
-                        let dx = -value.translation.width
-                        guard dx > 0,
-                              abs(value.translation.width) > abs(value.translation.height) else { return }
-                        progress = min(1, Double(dx / 80))
-                    }
-                    .onEnded { _ in
-                        withAnimation(.easeOut(duration: 0.25)) {
-                            progress = 0
-                        }
-                    }
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(tint)
+                    .opacity(progress)
             )
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .preference(
+                            key: SwipeRowOffsetKey.self,
+                            value: geo.frame(in: .global).origin.x
+                        )
+                }
+            )
+            .onPreferenceChange(SwipeRowOffsetKey.self) { x in
+                if let base = baseX {
+                    let dx = base - x
+                    progress = min(1, max(0, Double(dx / revealDistance)))
+                } else {
+                    baseX = x
+                }
+            }
     }
 }

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -3,15 +3,20 @@ import UIKit
 
 extension View {
     /// Swipe-left-to-delete affordance: the row content slides left
-    /// and reveals a fixed-size red square trash button on the
-    /// trailing edge, with a curved gray card fading in behind the
+    /// and reveals a fixed-size circular red trash button on the
+    /// trailing edge, with a soft gray card fading in behind the
     /// row to differentiate the swiped state.
     ///
-    /// Designed to coexist with row tap navigation — the drag has a
-    /// 10pt activation threshold so brief touches always pass
-    /// through to the underlying button. Full-swipe-commit requires
-    /// a deliberate 70%+ drag (no velocity-only commit) so a quick
-    /// flick can never silently delete the row.
+    /// The drag uses `.simultaneousGesture` with a 10pt activation
+    /// threshold so it coexists with rows that wrap their content
+    /// in a Button (folders, list summaries, note rows) — the
+    /// Button's tap fires for short touches; the drag fires once
+    /// horizontal movement exceeds 10pt and Button's own tolerance
+    /// cancels its tap.
+    ///
+    /// Full-swipe-commit requires a deliberate 70%+ drag (no
+    /// velocity-only commit) so a quick flick can never silently
+    /// delete a row.
     func swipeToDeleteTrash(perform action: @escaping () -> Void) -> some View {
         modifier(SwipeToDeleteWithTint(onDelete: action))
     }
@@ -31,24 +36,23 @@ private struct SwipeToDeleteWithTint: ViewModifier {
     @State private var isOpen: Bool = false
     /// Measured row height — used to size the gray fade-in card so
     /// it matches the row, and to vertically center the fixed-size
-    /// trash square inside taller rows like notes with body preview.
+    /// trash circle inside taller rows like notes with body preview.
     @State private var rowHeight: CGFloat = 0
 
-    /// Fixed square trash button. Same size on every row regardless
-    /// of row height, so tasks / lists / notes all reveal an
-    /// identical-looking action.
+    /// Fixed circle diameter. Same on every row regardless of row
+    /// height, so tasks / lists / notes all reveal an identical
+    /// circular action.
     private let buttonSize: CGFloat = 52
     /// Distance the row must travel for the trash to be fully revealed.
     /// Equals buttonSize plus the trailing gap, so at full reveal the
-    /// button sits exactly `pillGap` from the row's right edge.
+    /// circle sits exactly `pillGap` from the row's right edge.
     private let revealedWidth: CGFloat = 60
-    /// Spacing between the row's right edge and the trash square's
+    /// Spacing between the row's right edge and the trash circle's
     /// left edge — reads as two distinct objects.
     private let pillGap: CGFloat = Space.sm
-    /// Soft-square corner radius. Small enough that the trash always
-    /// looks like a rounded square (never a pill); large enough that
-    /// the gray card behind tall rows reads as soft, not sharp.
-    private let cornerRadius: CGFloat = 14
+    /// Soft corner radius for the gray fade-in card. The trash itself
+    /// is a Circle (corner radius doesn't apply).
+    private let cardCornerRadius: CGFloat = 14
     private let tintColor: Color = Tokens.borderStrong
     /// Vivid iOS-system red used by Reminders / Mail for destructive
     /// swipe actions.
@@ -61,37 +65,28 @@ private struct SwipeToDeleteWithTint: ViewModifier {
         // point.
         let linear = min(1.0, max(0.0, Double(dragDistance / revealedWidth)))
         let progress = 0.5 - 0.5 * cos(.pi * linear)
-        // Trash button width grows with drag but caps at buttonSize.
-        // Past the snap-open point the row keeps moving (rubber-band
-        // in dragGesture) but the button stops growing, so it stays
-        // a square.
-        let buttonWidth = max(0, min(dragDistance - pillGap, buttonSize))
         let outerHeight: CGFloat = rowHeight > 0 ? rowHeight : 44
 
         ZStack(alignment: .trailing) {
-            // Trash square — `.frame(maxHeight:)` set to the measured
-            // row height with center alignment, so the button sits
-            // vertically centered inside taller rows. ZStack alignment
-            // .trailing pins it to the right edge.
+            // Always-rendered 52pt circle. At rest, content covers
+            // it; as content slides left it's revealed underneath,
+            // so visibility is purely a side-effect of the drag —
+            // no width animation, the circle stays a circle.
             Button(action: commit) {
                 Image(systemName: "trash")
                     .font(.system(size: 18, weight: .regular))
                     .foregroundStyle(.white)
-                    .frame(width: buttonWidth, height: buttonSize)
-                    .background(
-                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .fill(trashColor)
-                    )
+                    .frame(width: buttonSize, height: buttonSize)
+                    .background(Circle().fill(trashColor))
             }
             .buttonStyle(.plain)
             .frame(maxHeight: outerHeight, alignment: .center)
-            .opacity(buttonWidth > 0.5 ? 1 : 0)
-            .allowsHitTesting(buttonWidth >= buttonSize * 0.6)
+            .allowsHitTesting(dragDistance >= revealedWidth * 0.6)
             .accessibilityLabel("Delete")
 
             content
                 .background(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
                         .fill(tintColor)
                         .opacity(progress)
                 )
@@ -102,7 +97,14 @@ private struct SwipeToDeleteWithTint: ViewModifier {
                 )
                 .overlay(closeOverlay)
                 .offset(x: offset)
-                .gesture(dragGesture)
+                // simultaneousGesture so the drag coexists with the
+                // row's tap (which fires on Button-wrapped rows like
+                // folders and list summaries). With minimumDistance:
+                // 10, brief touches stay below the threshold and
+                // pass through to the Button; deliberate horizontal
+                // drags activate the swipe and Button cancels its
+                // own tap due to movement.
+                .simultaneousGesture(dragGesture)
         }
         .onPreferenceChange(SwipeRowHeightKey.self) { rowHeight = $0 }
     }
@@ -117,12 +119,9 @@ private struct SwipeToDeleteWithTint: ViewModifier {
     }
 
     private var dragGesture: some Gesture {
-        // 10pt activation threshold so brief touches pass through to
-        // the row's underlying tap (folder/list rows navigate on tap;
-        // a 4pt threshold was hijacking those taps).
         DragGesture(minimumDistance: 10)
             .onChanged { value in
-                // Vertical drags (scroll) shouldn't move the row.
+                // Vertical drags (List scroll) shouldn't move the row.
                 guard abs(value.translation.width) > abs(value.translation.height) else { return }
                 let raw = (isOpen ? -revealedWidth : 0) + value.translation.width
                 offset = applyRubberBand(to: raw)
@@ -131,14 +130,10 @@ private struct SwipeToDeleteWithTint: ViewModifier {
                 let endRaw = (isOpen ? -revealedWidth : 0) + value.translation.width
                 // Commit only on a deliberate full-swipe past 70% of
                 // the screen width. No velocity-based commit — a
-                // quick flick must never silently delete a row, the
-                // user has to drag the row almost off the screen to
-                // confirm.
+                // quick flick must never silently delete a row.
                 if -endRaw > UIScreen.main.bounds.width * 0.7 {
                     commit()
                 } else if -endRaw > revealedWidth * 0.4 {
-                    // Snap open: relatively low threshold so a short
-                    // deliberate swipe reliably reveals the trash.
                     open()
                 } else {
                     close()
@@ -157,8 +152,6 @@ private struct SwipeToDeleteWithTint: ViewModifier {
 
     private func open() {
         isOpen = true
-        // Softer spring than before so the snap-open settles rather
-        // than hard-clicks into place.
         withAnimation(.spring(response: 0.5, dampingFraction: 0.86)) {
             offset = -revealedWidth
         }

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -2,19 +2,16 @@ import SwiftUI
 import UIKit
 
 extension View {
-    /// Swipe-left-to-delete affordance: the row content slides left and
-    /// reveals an edge-to-edge red rectangle with a white trash icon on
-    /// the trailing edge — visually identical to the stock
-    /// `.swipeActions(edge: .trailing, allowsFullSwipe: true)` button.
-    /// Routed through a custom container (rather than `.swipeActions`)
-    /// so we can also fade a curved gray card in behind the row as it
-    /// slides, providing the visual separation requested in #39 without
-    /// changing row heights or the delete button's appearance.
+    /// Swipe-left-to-delete affordance: the row content slides left
+    /// and reveals a fixed-size red square trash button on the
+    /// trailing edge, with a curved gray card fading in behind the
+    /// row to differentiate the swiped state.
     ///
-    /// Native semantics are preserved:
-    ///   - Partial swipe past `revealedWidth / 2` snaps the row open.
-    ///   - Full-swipe past 45% of the row width (or fast left flick) commits.
-    ///   - Tap on the open row anywhere outside the pill closes it.
+    /// Designed to coexist with row tap navigation — the drag has a
+    /// 10pt activation threshold so brief touches always pass
+    /// through to the underlying button. Full-swipe-commit requires
+    /// a deliberate 70%+ drag (no velocity-only commit) so a quick
+    /// flick can never silently delete the row.
     func swipeToDeleteTrash(perform action: @escaping () -> Void) -> some View {
         modifier(SwipeToDeleteWithTint(onDelete: action))
     }
@@ -32,57 +29,64 @@ private struct SwipeToDeleteWithTint: ViewModifier {
 
     @State private var offset: CGFloat = 0
     @State private var isOpen: Bool = false
-    /// Measured row height drives the trailing trash pill so it
-    /// stays the same height as the row. Without an explicit height
-    /// the inner `.frame(maxHeight: .infinity)` would propagate and
-    /// force `List` to allocate hundreds of points to each row.
+    /// Measured row height — used to size the gray fade-in card so
+    /// it matches the row, and to vertically center the fixed-size
+    /// trash square inside taller rows like notes with body preview.
     @State private var rowHeight: CGFloat = 0
 
-    private let revealedWidth: CGFloat = 80
-    private let tintColor: Color = Tokens.borderStrong
-    /// Cap for the corner radius. For short rows (~50pt — tasks,
-    /// folders, list summaries) the pill clamps to half-height
-    /// (~25pt) so it terminates in semicircles like Reminders.
-    /// For tall rows (notes with body preview) the cap holds at
-    /// 28pt so the shape stays a nicely rounded rectangle instead
-    /// of stretching into a vertical pill.
-    private let maxCornerRadius: CGFloat = 28
-    /// Spacing between the row's right edge and the trash pill's
-    /// left edge, so they read as two distinct objects.
+    /// Fixed square trash button. Same size on every row regardless
+    /// of row height, so tasks / lists / notes all reveal an
+    /// identical-looking action.
+    private let buttonSize: CGFloat = 52
+    /// Distance the row must travel for the trash to be fully revealed.
+    /// Equals buttonSize plus the trailing gap, so at full reveal the
+    /// button sits exactly `pillGap` from the row's right edge.
+    private let revealedWidth: CGFloat = 60
+    /// Spacing between the row's right edge and the trash square's
+    /// left edge — reads as two distinct objects.
     private let pillGap: CGFloat = Space.sm
+    /// Soft-square corner radius. Small enough that the trash always
+    /// looks like a rounded square (never a pill); large enough that
+    /// the gray card behind tall rows reads as soft, not sharp.
+    private let cornerRadius: CGFloat = 14
+    private let tintColor: Color = Tokens.borderStrong
     /// Vivid iOS-system red used by Reminders / Mail for destructive
-    /// swipe actions. Brighter and more saturated than `Tokens.danger`.
+    /// swipe actions.
     private let trashColor: Color = Color(.sRGB, red: 1.0, green: 0.231, blue: 0.188, opacity: 1.0)
 
     func body(content: Content) -> some View {
         let dragDistance = -offset
-        // Smooth ease-in-out so the gray doesn't pop in. Linear ramp
-        // feels jumpy because the eye sees a step from 0% to ~15%
-        // opacity in the first few points of drag; cosine starts
-        // imperceptibly and accelerates toward the snap-open point.
+        // Cosine ease so the gray doesn't pop in — barely visible at
+        // the start of the swipe, accelerating toward the snap-open
+        // point.
         let linear = min(1.0, max(0.0, Double(dragDistance / revealedWidth)))
         let progress = 0.5 - 0.5 * cos(.pi * linear)
-        let pillWidth = max(0, dragDistance - pillGap)
-        let pillHeight: CGFloat = rowHeight > 0 ? rowHeight : 44
-        let cornerRadius = min(pillHeight / 2, maxCornerRadius)
+        // Trash button width grows with drag but caps at buttonSize.
+        // Past the snap-open point the row keeps moving (rubber-band
+        // in dragGesture) but the button stops growing, so it stays
+        // a square.
+        let buttonWidth = max(0, min(dragDistance - pillGap, buttonSize))
+        let outerHeight: CGFloat = rowHeight > 0 ? rowHeight : 44
 
         ZStack(alignment: .trailing) {
-            // Standalone pill-shaped red button on the trailing edge
-            // with a white trash icon. Width grows with the swipe so
-            // the action is revealed live, not just on release.
+            // Trash square — `.frame(maxHeight:)` set to the measured
+            // row height with center alignment, so the button sits
+            // vertically centered inside taller rows. ZStack alignment
+            // .trailing pins it to the right edge.
             Button(action: commit) {
                 Image(systemName: "trash")
                     .font(.system(size: 18, weight: .regular))
                     .foregroundStyle(.white)
-                    .frame(width: pillWidth, height: pillHeight)
+                    .frame(width: buttonWidth, height: buttonSize)
                     .background(
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                             .fill(trashColor)
                     )
             }
             .buttonStyle(.plain)
-            .opacity(pillWidth > 0.5 ? 1 : 0)
-            .allowsHitTesting(pillWidth >= revealedWidth * 0.5)
+            .frame(maxHeight: outerHeight, alignment: .center)
+            .opacity(buttonWidth > 0.5 ? 1 : 0)
+            .allowsHitTesting(buttonWidth >= buttonSize * 0.6)
             .accessibilityLabel("Delete")
 
             content
@@ -113,23 +117,28 @@ private struct SwipeToDeleteWithTint: ViewModifier {
     }
 
     private var dragGesture: some Gesture {
-        // Small minimumDistance so the row starts tracking the
-        // finger immediately. 12pt felt laggy because the row sat
-        // still for the first 12pt of finger travel before
-        // suddenly catching up.
-        DragGesture(minimumDistance: 4)
+        // 10pt activation threshold so brief touches pass through to
+        // the row's underlying tap (folder/list rows navigate on tap;
+        // a 4pt threshold was hijacking those taps).
+        DragGesture(minimumDistance: 10)
             .onChanged { value in
+                // Vertical drags (scroll) shouldn't move the row.
                 guard abs(value.translation.width) > abs(value.translation.height) else { return }
-                let proposed = (isOpen ? -revealedWidth : 0) + value.translation.width
-                offset = max(min(0, proposed), -UIScreen.main.bounds.width)
+                let raw = (isOpen ? -revealedWidth : 0) + value.translation.width
+                offset = applyRubberBand(to: raw)
             }
             .onEnded { value in
-                let endX = (isOpen ? -revealedWidth : 0) + value.translation.width
-                let velocity = value.predictedEndTranslation.width - value.translation.width
-
-                if -endX > UIScreen.main.bounds.width * 0.45 || velocity < -1200 {
+                let endRaw = (isOpen ? -revealedWidth : 0) + value.translation.width
+                // Commit only on a deliberate full-swipe past 70% of
+                // the screen width. No velocity-based commit — a
+                // quick flick must never silently delete a row, the
+                // user has to drag the row almost off the screen to
+                // confirm.
+                if -endRaw > UIScreen.main.bounds.width * 0.7 {
                     commit()
-                } else if -endX > revealedWidth * 0.5 {
+                } else if -endRaw > revealedWidth * 0.4 {
+                    // Snap open: relatively low threshold so a short
+                    // deliberate swipe reliably reveals the trash.
                     open()
                 } else {
                     close()
@@ -137,29 +146,37 @@ private struct SwipeToDeleteWithTint: ViewModifier {
             }
     }
 
+    /// Drag freely up to the snap-open point, then add resistance so
+    /// over-drag feels weighted instead of just sliding to the edge.
+    private func applyRubberBand(to raw: CGFloat) -> CGFloat {
+        if raw >= 0 { return 0 }
+        if -raw <= revealedWidth { return raw }
+        let overshoot = -raw - revealedWidth
+        return -(revealedWidth + overshoot * 0.4)
+    }
+
     private func open() {
         isOpen = true
-        // Slightly softer spring than before — 0.38 response with
-        // 0.82 damping reads as "settles into place" rather than
-        // "hard snap", matching Reminders' open-close feel.
-        withAnimation(.spring(response: 0.38, dampingFraction: 0.82)) {
+        // Softer spring than before so the snap-open settles rather
+        // than hard-clicks into place.
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.86)) {
             offset = -revealedWidth
         }
     }
 
     private func close() {
         isOpen = false
-        withAnimation(.spring(response: 0.38, dampingFraction: 0.82)) {
+        withAnimation(.spring(response: 0.5, dampingFraction: 0.86)) {
             offset = 0
         }
     }
 
     private func commit() {
         Haptics.destructive()
-        withAnimation(.easeOut(duration: 0.2)) {
+        withAnimation(.easeOut(duration: 0.22)) {
             offset = -UIScreen.main.bounds.width
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             onDelete()
         }
     }

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -40,10 +40,13 @@ private struct SwipeToDeleteWithTint: ViewModifier {
 
     private let revealedWidth: CGFloat = 80
     private let tintColor: Color = Tokens.borderStrong
-    /// Pill-shaped corners (like iOS Reminders / Mail). 999pt clips to
-    /// half the height so the row card and the trash button both
-    /// terminate in perfect semicircles.
-    private let cornerRadius: CGFloat = Radius.pill
+    /// Cap for the corner radius. For short rows (~50pt — tasks,
+    /// folders, list summaries) the pill clamps to half-height
+    /// (~25pt) so it terminates in semicircles like Reminders.
+    /// For tall rows (notes with body preview) the cap holds at
+    /// 28pt so the shape stays a nicely rounded rectangle instead
+    /// of stretching into a vertical pill.
+    private let maxCornerRadius: CGFloat = 28
     /// Spacing between the row's right edge and the trash pill's
     /// left edge, so they read as two distinct objects.
     private let pillGap: CGFloat = Space.sm
@@ -61,6 +64,7 @@ private struct SwipeToDeleteWithTint: ViewModifier {
         let progress = 0.5 - 0.5 * cos(.pi * linear)
         let pillWidth = max(0, dragDistance - pillGap)
         let pillHeight: CGFloat = rowHeight > 0 ? rowHeight : 44
+        let cornerRadius = min(pillHeight / 2, maxCornerRadius)
 
         ZStack(alignment: .trailing) {
             // Standalone pill-shaped red button on the trailing edge

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -40,23 +40,32 @@ private struct SwipeToDeleteWithTint: ViewModifier {
 
     private let revealedWidth: CGFloat = 80
     private let tintColor: Color = Tokens.borderStrong
-    /// Curved corner radius used for both the row's gray fade-in
-    /// and the trailing trash pill so they read as a matched pair.
-    private let cornerRadius: CGFloat = Radius.lg
+    /// Pill-shaped corners (like iOS Reminders / Mail). 999pt clips to
+    /// half the height so the row card and the trash button both
+    /// terminate in perfect semicircles.
+    private let cornerRadius: CGFloat = Radius.pill
     /// Spacing between the row's right edge and the trash pill's
     /// left edge, so they read as two distinct objects.
     private let pillGap: CGFloat = Space.sm
+    /// Vivid iOS-system red used by Reminders / Mail for destructive
+    /// swipe actions. Brighter and more saturated than `Tokens.danger`.
+    private let trashColor: Color = Color(.sRGB, red: 1.0, green: 0.231, blue: 0.188, opacity: 1.0)
 
     func body(content: Content) -> some View {
         let dragDistance = -offset
-        let progress = min(1.0, max(0.0, Double(dragDistance / revealedWidth)))
+        // Smooth ease-in-out so the gray doesn't pop in. Linear ramp
+        // feels jumpy because the eye sees a step from 0% to ~15%
+        // opacity in the first few points of drag; cosine starts
+        // imperceptibly and accelerates toward the snap-open point.
+        let linear = min(1.0, max(0.0, Double(dragDistance / revealedWidth)))
+        let progress = 0.5 - 0.5 * cos(.pi * linear)
         let pillWidth = max(0, dragDistance - pillGap)
         let pillHeight: CGFloat = rowHeight > 0 ? rowHeight : 44
 
         ZStack(alignment: .trailing) {
-            // Standalone rounded red pill on the trailing edge with a
-            // white trash icon. Width grows with the swipe so the
-            // action is revealed live, not just on release.
+            // Standalone pill-shaped red button on the trailing edge
+            // with a white trash icon. Width grows with the swipe so
+            // the action is revealed live, not just on release.
             Button(action: commit) {
                 Image(systemName: "trash")
                     .font(.system(size: 18, weight: .regular))
@@ -64,7 +73,7 @@ private struct SwipeToDeleteWithTint: ViewModifier {
                     .frame(width: pillWidth, height: pillHeight)
                     .background(
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                            .fill(Tokens.danger)
+                            .fill(trashColor)
                     )
             }
             .buttonStyle(.plain)
@@ -100,7 +109,11 @@ private struct SwipeToDeleteWithTint: ViewModifier {
     }
 
     private var dragGesture: some Gesture {
-        DragGesture(minimumDistance: 12)
+        // Small minimumDistance so the row starts tracking the
+        // finger immediately. 12pt felt laggy because the row sat
+        // still for the first 12pt of finger travel before
+        // suddenly catching up.
+        DragGesture(minimumDistance: 4)
             .onChanged { value in
                 guard abs(value.translation.width) > abs(value.translation.height) else { return }
                 let proposed = (isOpen ? -revealedWidth : 0) + value.translation.width
@@ -122,14 +135,17 @@ private struct SwipeToDeleteWithTint: ViewModifier {
 
     private func open() {
         isOpen = true
-        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+        // Slightly softer spring than before — 0.38 response with
+        // 0.82 damping reads as "settles into place" rather than
+        // "hard snap", matching Reminders' open-close feel.
+        withAnimation(.spring(response: 0.38, dampingFraction: 0.82)) {
             offset = -revealedWidth
         }
     }
 
     private func close() {
         isOpen = false
-        withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
+        withAnimation(.spring(response: 0.38, dampingFraction: 0.82)) {
             offset = 0
         }
     }

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -17,4 +17,38 @@ extension View {
             .accessibilityLabel("Delete")
         }
     }
+
+    /// Fades a subtle gray tint behind the row as the user swipes left,
+    /// so the row's background reads as distinct from the destructive
+    /// `.swipeActions` button on the trailing edge. Visual-only — runs
+    /// as a `simultaneousGesture` so the stock swipe-to-delete still
+    /// commits normally; row height and the delete button itself are
+    /// unchanged.
+    func swipeProgressTint(_ color: Color = Tokens.borderStrong) -> some View {
+        modifier(SwipeProgressTintModifier(tint: color))
+    }
+}
+
+private struct SwipeProgressTintModifier: ViewModifier {
+    let tint: Color
+    @State private var progress: Double = 0
+
+    func body(content: Content) -> some View {
+        content
+            .background(tint.opacity(progress))
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 8)
+                    .onChanged { value in
+                        let dx = -value.translation.width
+                        guard dx > 0,
+                              abs(value.translation.width) > abs(value.translation.height) else { return }
+                        progress = min(1, Double(dx / 80))
+                    }
+                    .onEnded { _ in
+                        withAnimation(.easeOut(duration: 0.25)) {
+                            progress = 0
+                        }
+                    }
+            )
+    }
 }

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -32,32 +32,40 @@ private struct SwipeToDeleteWithTint: ViewModifier {
 
     @State private var offset: CGFloat = 0
     @State private var isOpen: Bool = false
-    /// Measured row height drives the trailing red button so it stays
-    /// edge-to-edge with the row. Without an explicit height the
-    /// inner `.frame(maxHeight: .infinity)` would propagate and force
-    /// `List` to allocate hundreds of points to each row.
+    /// Measured row height drives the trailing trash pill so it
+    /// stays the same height as the row. Without an explicit height
+    /// the inner `.frame(maxHeight: .infinity)` would propagate and
+    /// force `List` to allocate hundreds of points to each row.
     @State private var rowHeight: CGFloat = 0
 
     private let revealedWidth: CGFloat = 80
     private let tintColor: Color = Tokens.borderStrong
-    private let cornerRadius: CGFloat = Radius.md
+    /// Curved corner radius used for both the row's gray fade-in
+    /// and the trailing trash pill so they read as a matched pair.
+    private let cornerRadius: CGFloat = Radius.lg
+    /// Spacing between the row's right edge and the trash pill's
+    /// left edge, so they read as two distinct objects.
+    private let pillGap: CGFloat = Space.sm
 
     func body(content: Content) -> some View {
         let dragDistance = -offset
         let progress = min(1.0, max(0.0, Double(dragDistance / revealedWidth)))
-        let pillWidth = max(0, dragDistance)
+        let pillWidth = max(0, dragDistance - pillGap)
         let pillHeight: CGFloat = rowHeight > 0 ? rowHeight : 44
 
         ZStack(alignment: .trailing) {
-            // Edge-to-edge red rectangle with a white trash icon — the
-            // stock `.swipeActions` look. Width grows with the swipe so
-            // the action is revealed live, not just on release.
+            // Standalone rounded red pill on the trailing edge with a
+            // white trash icon. Width grows with the swipe so the
+            // action is revealed live, not just on release.
             Button(action: commit) {
                 Image(systemName: "trash")
                     .font(.system(size: 18, weight: .regular))
                     .foregroundStyle(.white)
                     .frame(width: pillWidth, height: pillHeight)
-                    .background(Tokens.danger)
+                    .background(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .fill(Tokens.danger)
+                    )
             }
             .buttonStyle(.plain)
             .opacity(pillWidth > 0.5 ? 1 : 0)

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -106,12 +106,12 @@ struct ListsView: View {
                             selectedListId = list.id
                         }
                     }
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                     .swipeToDeleteTrash {
                         Task { await viewModel.delete(list) }
                     }
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                 }
             }
 
@@ -310,12 +310,12 @@ private struct ListDetailContent: View {
                                     Task { await viewModel.removeItem(from: list, at: index) }
                                 }
                             )
-                            .listRowBackground(Tokens.paper)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
                             .swipeToDeleteTrash {
                                 Task { await viewModel.removeItem(from: list, at: index) }
                             }
+                            .listRowBackground(Tokens.paper)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
                         }
                         .onMove { source, destination in
                             Task { await viewModel.reorderItems(in: list, from: source, to: destination) }

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -131,12 +131,12 @@ struct NotesView: View {
                                 withAnimation(.easeOut(duration: 0.2)) { selectedFolder = folder }
                             }
                         )
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                         .swipeToDeleteTrash {
                             Task { await viewModel.deleteFolder(folder) }
                         }
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                     }
                 } header: {
                     sectionEyebrow("Folders")
@@ -148,12 +148,12 @@ struct NotesView: View {
                 Section {
                     ForEach(unfiled) { note in
                         NoteRow(note: note) { open(note: note) }
-                            .listRowBackground(Color.clear)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                             .swipeToDeleteTrash {
                                 Task { await viewModel.deleteNote(note) }
                             }
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                     }
                 } header: {
                     sectionEyebrow("Unfiled")
@@ -198,12 +198,12 @@ struct NotesView: View {
             } else {
                 ForEach(inFolder) { note in
                     NoteRow(note: note) { open(note: note) }
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                         .swipeToDeleteTrash {
                             Task { await viewModel.deleteNote(note) }
                         }
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                 }
             }
 

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -197,6 +197,7 @@ struct TasksView: View {
                 } onTap: {
                     editingTodo = todo
                 }
+                .swipeProgressTint()
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
                 .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
@@ -219,6 +220,7 @@ struct TasksView: View {
                     } onTap: {
                         editingTodo = todo
                     }
+                    .swipeProgressTint()
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                     .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -197,13 +197,12 @@ struct TasksView: View {
                 } onTap: {
                     editingTodo = todo
                 }
-                .swipeProgressTint()
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-                .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
                 .swipeToDeleteTrash {
                     Task { await viewModel.delete(todo) }
                 }
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
             }
         } header: {
             sectionHeader(title: title, count: count, accent: accent, soft: soft)
@@ -220,13 +219,12 @@ struct TasksView: View {
                     } onTap: {
                         editingTodo = todo
                     }
-                    .swipeProgressTint()
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
                     .swipeToDeleteTrash {
                         Task { await viewModel.delete(todo) }
                     }
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
                 }
             }
         } header: {


### PR DESCRIPTION
## Summary

Replaces the stock `.swipeActions` on every row surface with a custom container that matches the design called out in #39:

- 52pt **red Circle** trash button on the trailing edge — same shape on every surface (tasks, lists, list items, note folders, orphaned notes, in-folder notes), regardless of row height.
- Soft **gray card fades in behind the row** as you swipe — cosine ease so it doesn't pop, just gently differentiates the swiped state.
- 8pt **gap** between the row's right edge and the trash circle so they read as two distinct objects.
- **Rubber-band** past the snap-open point so over-drag feels weighted.
- **Deliberate commit** — no velocity-based auto-delete. Full-swipe-commit requires a 70%+ drag of the screen width, so a quick flick can never silently delete a row.
- **`.highPriorityGesture` with 10pt activation** so the drag coexists with rows that wrap their content in a Button (folders, lists, notes navigate on tap). Short touches fall through to the Button's tap; deliberate drags preempt it.
- Trash is **invisible at rest** (opacity tied to drag distance), so the circle's edges can't bleed through gaps in the row's rounded background.

Closes #39

## Test plan

- [x] Swipe a task — circle reveals, snap-open works, tap-trash deletes
- [x] Swipe a list — circle reveals, navigation tap is suppressed during/after swipe
- [x] Swipe a list item inside a list — circle reveals, snap-open works
- [x] Swipe a note folder — circle reveals, navigation tap is suppressed, no red bleed at rest
- [x] Swipe an unfiled note — circle reveals, navigation tap is suppressed
- [x] Swipe a note inside a folder — circle reveals, navigation tap is suppressed
- [x] Vertical scroll on each surface still works (drag has horizontal-priority guard)
- [x] Quick flick doesn't auto-delete (70% screen distance required)
- [x] Trash is fully hidden at rest on all row heights

🤖 Generated with [Claude Code](https://claude.com/claude-code)