### PR TITLE
fix(ios): dismiss keyboard when opening side drawer

### DIFF
--- a/mobile/PersonalDashboard/App/AppRouter.swift
+++ b/mobile/PersonalDashboard/App/AppRouter.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import Observation
 
 /// Activity timeline deep-link payload. The Activity surface sets this when
@@ -50,6 +51,22 @@ final class AppRouter {
     /// this on `task` / `onAppear`, applies the scroll + pulse, then sets it
     /// back to nil so it doesn't fire again on the next appearance.
     var focus: ActivityFocus?
+
+    /// Open the side drawer and dismiss any active keyboard so the drawer
+    /// renders cleanly above the chat input (issue #54). Both the top-bar
+    /// menu tap and the edge-swipe gesture route through here so the
+    /// keyboard-dismiss behaviour is consistent.
+    func openDrawer() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+        withAnimation(.easeOut(duration: 0.2)) {
+            drawerOpen = true
+        }
+    }
 
     /// Push a section into the chat-rooted stack and close the drawer.
     func go(to section: AppSection) {

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -47,9 +47,7 @@ struct ChatView: View {
                     TopBar(
                         title: viewModel.turns.isEmpty ? nil : "Chat",
                         onMenu: {
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                router.drawerOpen = true
-                            }
+                            router.openDrawer()
                         },
                         onToggleTheme: {
                             schemePref = schemePref.next

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -105,9 +105,12 @@ struct ContentView: View {
                 let shouldOpen = translation > drawerWidth * 0.4 || velocity > 500
                 withAnimation(.easeOut(duration: 0.2)) {
                     router.drawerDragOffset = 0
-                    if shouldOpen {
-                        router.drawerOpen = true
-                    }
+                }
+                if shouldOpen {
+                    // openDrawer() resigns first responder before flipping the
+                    // flag so the keyboard goes away before the drawer slides
+                    // in over the chat input (issue #54).
+                    router.openDrawer()
                 }
             }
     }


### PR DESCRIPTION
## Summary
- Centralize drawer-open in `AppRouter.openDrawer()` which resigns first responder before flipping `drawerOpen`, so the keyboard always goes away before the drawer slides in.
- Route both entry points (top-bar menu tap in `ChatView`, edge-swipe in `ContentView`) through it.
- Move the `if shouldOpen { ... }` branch out of the `withAnimation` closure on the edge-swipe so the keyboard-dismiss + drawer-animation pair stays consistent with the menu-tap path.

Closes #54

## Test plan
- [x] xcodegen + xcodebuild build (Debug, iOS device) — green.
- [x] Patched IPA installed on iPhone via `devicectl` (commit `e1b44d8`).
- [ ] Device walkthrough: open chat, tap input to bring up keyboard, then (a) tap the menu icon, (b) edge-swipe right from the left edge. In both cases the keyboard dismisses and the drawer is fully visible (footer reaches the bottom safe area). Evidence to be added on issue #54.