### PR TITLE
feat(ios): remove dark/light theme toggle from chrome

### DIFF
--- a/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
+++ b/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
@@ -44,7 +44,6 @@ struct ActivityView: View {
     }
 
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     @Query(filter: #Predicate<LocalTodo> { $0.deletedAt == nil })
     private var todos: [LocalTodo]
@@ -74,8 +73,7 @@ struct ActivityView: View {
                     title: "Activity",
                     onMenu: {
                         withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true }
-                    },
-                    onToggleTheme: { schemePref = schemePref.next }
+                    }
                 )
 
                 Text("Everything you have captured, newest first.")

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -13,7 +13,6 @@ struct ChatView: View {
     @FocusState private var inputFocused: Bool
 
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     private let examples = [
         "Remind me to call John tomorrow at 3",
@@ -48,9 +47,6 @@ struct ChatView: View {
                         title: viewModel.turns.isEmpty ? nil : "Chat",
                         onMenu: {
                             router.openDrawer()
-                        },
-                        onToggleTheme: {
-                            schemePref = schemePref.next
                         }
                     )
 

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -68,7 +68,7 @@ struct ContentView: View {
             .zIndex(3)
 
             // Drawer on top of everything.
-            SideDrawer(router: router, schemePref: schemePref)
+            SideDrawer(router: router)
                 .zIndex(4)
         }
         .preferredColorScheme((ColorSchemePref(rawValue: schemePrefRaw) ?? .system).resolved)
@@ -117,7 +117,7 @@ struct ContentView: View {
 
     @ViewBuilder
     private var chatRoot: some View {
-        ChatView(router: router, schemePref: schemePref)
+        ChatView(router: router)
             .activeSection(.chat)
     }
 
@@ -128,25 +128,25 @@ struct ContentView: View {
             // shouldn't render — chat is the root, not an overlay.
             EmptyView()
         case .tasks:
-            TasksView(router: router, schemePref: schemePref)
+            TasksView(router: router)
         case .notes:
-            NotesView(router: router, schemePref: schemePref)
+            NotesView(router: router)
         case .lists:
-            ListsView(router: router, schemePref: schemePref)
+            ListsView(router: router)
         case .dashboard:
             // Dashboard surface is hidden (issue #30). The drawer entry has
             // been removed and the LAUNCH_SECTION deep-link redirects to
             // .activity, so this case is unreachable. Restore by replacing
-            // EmptyView() with `DashboardView(router: router, schemePref: schemePref)`.
+            // EmptyView() with `DashboardView(router: router)`.
             EmptyView()
         case .activity:
-            ActivityView(router: router, schemePref: schemePref)
+            ActivityView(router: router)
         case .settings:
             SettingsView(router: router, schemePref: schemePref)
         case .today:
-            TodayView(router: router, schemePref: schemePref)
+            TodayView(router: router)
         case .helpCenter:
-            HelpCenterView(router: router, schemePref: schemePref)
+            HelpCenterView(router: router)
         }
     }
 }
@@ -154,7 +154,6 @@ struct ContentView: View {
 private struct PlaceholderView: View {
     let section: AppSection
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     var body: some View {
         ZStack {
@@ -162,8 +161,7 @@ private struct PlaceholderView: View {
             VStack(spacing: 0) {
                 TopBar(
                     title: section.displayName,
-                    onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } },
-                    onToggleTheme: { schemePref = schemePref.next }
+                    onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                 )
                 Spacer()
                 VStack(spacing: Space.md) {

--- a/mobile/PersonalDashboard/Views/Dashboard/DashboardView.swift
+++ b/mobile/PersonalDashboard/Views/Dashboard/DashboardView.swift
@@ -4,7 +4,6 @@ struct DashboardView: View {
     @State private var viewModel = DashboardViewModel()
 
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     var body: some View {
         ZStack {
@@ -13,8 +12,7 @@ struct DashboardView: View {
             VStack(spacing: 0) {
                 TopBar(
                     title: "Dashboard",
-                    onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } },
-                    onToggleTheme: { schemePref = schemePref.next }
+                    onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                 )
 
                 ScrollView {

--- a/mobile/PersonalDashboard/Views/HelpCenter/HelpCenterView.swift
+++ b/mobile/PersonalDashboard/Views/HelpCenter/HelpCenterView.swift
@@ -6,7 +6,6 @@ import SwiftUI
 /// release notes) lands here later.
 struct HelpCenterView: View {
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     var body: some View {
         ZStack {
@@ -17,8 +16,7 @@ struct HelpCenterView: View {
                     title: "Help center",
                     onMenu: {
                         withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true }
-                    },
-                    onToggleTheme: { schemePref = schemePref.next }
+                    }
                 )
 
                 Spacer()

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -9,7 +9,6 @@ struct ListsView: View {
     }()
 
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     var body: some View {
         ZStack {
@@ -36,8 +35,7 @@ struct ListsView: View {
                 } else {
                     TopBar(
                         title: "Lists",
-                        onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } },
-                        onToggleTheme: { schemePref = schemePref.next }
+                        onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                     )
                     rootList
                 }

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -11,7 +11,6 @@ struct NotesView: View {
     }()
 
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     var body: some View {
         ZStack {
@@ -48,8 +47,7 @@ struct NotesView: View {
                 } else {
                     TopBar(
                         title: "Notes",
-                        onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } },
-                        onToggleTheme: { schemePref = schemePref.next }
+                        onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                     )
                     rootList
                 }

--- a/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
@@ -13,8 +13,7 @@ struct SettingsView: View {
             VStack(spacing: 0) {
                 TopBar(
                     title: "Settings",
-                    onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } },
-                    onToggleTheme: { schemePref = schemePref.next }
+                    onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                 )
 
                 ScrollView {

--- a/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
+++ b/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
@@ -8,7 +8,6 @@ import SwiftUI
 /// - Closing: a finger-tracking pan on the panel (and a tap on the scrim).
 struct SideDrawer: View {
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     /// Velocity threshold for "fling" snaps (pt/s). Above this, the drawer
     /// snaps to the direction of motion regardless of distance.
@@ -129,18 +128,6 @@ struct SideDrawer: View {
                     .accessibilityLabel("App version \(Self.shortVersion) build \(Self.buildNumber)")
 
                 HStack(spacing: Space.md) {
-                    Button {
-                        schemePref = schemePref.next
-                    } label: {
-                        Image(systemName: schemeIcon)
-                            .font(.system(size: 16, weight: .regular))
-                            .foregroundStyle(Tokens.muted)
-                            .frame(width: 36, height: 36)
-                            .background(Tokens.paper2, in: Circle())
-                            .overlay(Circle().stroke(Tokens.border, lineWidth: 0.5))
-                    }
-                    .accessibilityLabel("Theme: \(schemePref.rawValue)")
-
                     Text("AS")
                         .font(.edFootnote)
                         .foregroundStyle(Tokens.ink)
@@ -162,14 +149,6 @@ struct SideDrawer: View {
                     .fill(Tokens.divider)
                     .frame(height: 0.5)
             }
-        }
-    }
-
-    private var schemeIcon: String {
-        switch schemePref {
-        case .system: return "circle.lefthalf.filled"
-        case .light:  return "sun.max"
-        case .dark:   return "moon"
         }
     }
 

--- a/mobile/PersonalDashboard/Views/Shell/TopBar.swift
+++ b/mobile/PersonalDashboard/Views/Shell/TopBar.swift
@@ -1,11 +1,10 @@
 import SwiftUI
 
 /// 56pt top bar matching `TopBar.jsx`. Leading hamburger,
-/// title in Calistoga 22, theme toggle + AS pip trailing.
+/// title in Calistoga 22, AS pip trailing.
 struct TopBar: View {
     var title: String?
     var onMenu: () -> Void
-    var onToggleTheme: () -> Void
 
     var body: some View {
         HStack(spacing: Space.md) {
@@ -26,15 +25,6 @@ struct TopBar: View {
             }
 
             Spacer()
-
-            Button(action: onToggleTheme) {
-                Image(systemName: "sun.max")
-                    .font(.system(size: 18, weight: .regular))
-                    .foregroundStyle(Tokens.ink)
-                    .frame(width: 44, height: 44)
-                    .contentShape(Rectangle())
-            }
-            .accessibilityLabel("Toggle theme")
 
             // Profile pip — paper coin, not a colored badge.
             Text("AS")

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -8,7 +8,6 @@ struct TasksView: View {
     @State private var completedExpanded: Bool = false
 
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     var body: some View {
         ZStack {
@@ -19,8 +18,7 @@ struct TasksView: View {
                     title: "Tasks",
                     onMenu: {
                         withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true }
-                    },
-                    onToggleTheme: { schemePref = schemePref.next }
+                    }
                 )
 
                 // Using `List` (not `ScrollView { LazyVStack }`) so each row

--- a/mobile/PersonalDashboard/Views/Today/TodayView.swift
+++ b/mobile/PersonalDashboard/Views/Today/TodayView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct TodayView: View {
     @Bindable var router: AppRouter
-    @Binding var schemePref: ColorSchemePref
 
     @State private var todosVM = TodosViewModel()
     @State private var notesVM = NotesViewModel()
@@ -15,8 +14,7 @@ struct TodayView: View {
             VStack(spacing: 0) {
                 TopBar(
                     title: nil,
-                    onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } },
-                    onToggleTheme: { schemePref = schemePref.next }
+                    onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                 )
 
                 ScrollView {


### PR DESCRIPTION
## Summary
- Removes the sun.max button from the iOS `TopBar` (top-right) and the theme cycle button from the `SideDrawer` footer (left nav).
- Drops the `onToggleTheme` prop from `TopBar` and the `schemePref` binding from `SideDrawer`, then cleans up every section view that was only forwarding those for the toggle (Today / Tasks / Notes / Lists / Activity / Chat / HelpCenter / Dashboard, plus the inner `PlaceholderView` in `ContentView`).
- Settings keeps the in-app `ThemePicker` (out of scope), and `ContentView` keeps the `@AppStorage("colorSchemePref")` + `.preferredColorScheme` rails so the system / Settings preference still drives the app's appearance.

Closes #57

## Test plan
- [x] `xcodegen generate` succeeds.
- [x] `xcodebuild -scheme PersonalDashboard -destination 'generic/platform=iOS Simulator' build` -> `** BUILD SUCCEEDED **`.
- [x] `grep -rn "schemePref\|onToggleTheme" mobile/PersonalDashboard --include="*.swift"` returns only intentional rails (`ContentView` `@AppStorage` + `.preferredColorScheme`, `SettingsView` `ThemePicker`).
- [ ] Visual on device: top-right of header has no sun icon on every surface (Today, Tasks, Notes, Lists, Activity, Chat, Settings, Help center).
- [ ] Visual on device: left side drawer footer has no theme cycle button — just the AS pip + "Akshay" text + version.
- [ ] System dark/light still flips the app via Settings -> Display & Brightness.
- [ ] Settings -> Appearance -> Theme picker still works as the alternate way to flip the app theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)