### PR TITLE
fix(ios): drop chat input flush against floating tab pill

### DIFF
--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -83,8 +83,10 @@ struct ChatView: View {
                 .padding(.top, Space.sm)
                 // Reserve room for the bottom tab bar so the input bar
                 // doesn't hide behind it. When the keyboard is up, the bar
-                // hides and the keyboard pushes the input up directly.
-                .padding(.bottom, keyboardVisible ? Space.md : (Space.md + BottomTabBarMetrics.height))
+                // hides and the keyboard pushes the input up directly. The
+                // gap above the tab bar is intentionally small so the input
+                // sits visually close to the floating pill.
+                .padding(.bottom, keyboardVisible ? Space.md : BottomTabBarMetrics.height)
             }
         }
         .background(Tokens.paper)


### PR DESCRIPTION
## Summary
- Removes the `Space.md` gap above the floating bottom-tab pill so the chat input bar sits flush against it.
- Keyboard-up behaviour preserved (still uses `Space.md` padding when the keyboard is visible).

Closes #59

## Test plan
- [x] Installed dev build on Flightmode 2.0 (iPhone 16 Pro Max) via `devicectl`.
- [x] Empty-state Chat: input bar visually anchored to the tab pill, tab pill position unchanged.
- [x] With keyboard up: input bar lifts with the keyboard, tab pill hides as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)