### PR TITLE
fix(ios): render Activity timeline contiguously, no blank gaps

### DIFF
--- a/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
+++ b/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
@@ -61,7 +61,8 @@ struct ActivityView: View {
     @State private var visibleCount: Int = pageSize
 
     /// First page size and the increment per "load more" tap. Generous because
-    /// SwiftData fetches are cheap and LazyVStack only renders what's on screen.
+    /// SwiftData fetches are cheap and the dataset is small (single-device,
+    /// personal scope).
     private static let pageSize = 100
 
     var body: some View {
@@ -101,24 +102,29 @@ struct ActivityView: View {
                 let total = totalAfterFilter
 
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0, pinnedViews: [.sectionHeaders]) {
+                    // Plain VStack (not LazyVStack) because the dataset is small
+                    // (single-device personal scope, hundreds of items at most).
+                    // LazyVStack + `pinnedViews: [.sectionHeaders]` triggered a
+                    // SwiftUI layout bug where sections with varying row counts
+                    // left reserved blank space until a gesture forced a layout
+                    // pass. Issue #63.
+                    VStack(alignment: .leading, spacing: 0) {
                         if pageItems.isEmpty {
                             EmptyStateView(filter: filter)
                                 .frame(maxWidth: .infinity)
                                 .padding(.top, Space.xxxl)
                         } else {
                             ForEach(groups(for: pageItems), id: \.key) { group in
-                                Section(header: dayHeader(for: group)) {
-                                    ForEach(Array(group.items.enumerated()), id: \.element.rowKey) { idx, item in
-                                        ActivityRow(item: item) {
-                                            handleTap(item: item)
-                                        }
-                                        if idx < group.items.count - 1 {
-                                            Rectangle()
-                                                .fill(Tokens.divider)
-                                                .frame(height: 0.5)
-                                                .padding(.leading, Space.lg)
-                                        }
+                                dayHeader(for: group)
+                                ForEach(Array(group.items.enumerated()), id: \.element.rowKey) { idx, item in
+                                    ActivityRow(item: item) {
+                                        handleTap(item: item)
+                                    }
+                                    if idx < group.items.count - 1 {
+                                        Rectangle()
+                                            .fill(Tokens.divider)
+                                            .frame(height: 0.5)
+                                            .padding(.leading, Space.lg)
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

- Replace `LazyVStack` with `pinnedViews: [.sectionHeaders]` in the Activity timeline with a plain `VStack` and inline date headers.
- Eliminates the blank vertical band between sections that only filled in after a swipe gesture forced a re-layout.
- Dataset is single-device personal scope, so eager layout is the right call.

## Trade-off

Section headers no longer pin while scrolling. The bug fix is the priority; sticky headers can come back as a separate enhancement if needed.

## Closes

Closes #63

## Test plan

- [x] `xcodebuild` Debug + iphonesimulator SDK builds cleanly
- [x] OTA archive + sign produces a working IPA
- [x] `xcrun devicectl device install` succeeds on Flightmode 2.0 (iPhone 16 Pro Max)
- [x] Manual scroll on device shows sections rendering back-to-back, no swipe needed

QA evidence on #63.