### PR TITLE
fix(ios): dismiss keyboard mid-edge-swipe so drawer tracks finger smoothly

### DIFF
--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -1,8 +1,16 @@
 import SwiftUI
+import UIKit
 
 struct ContentView: View {
     @State private var router = AppRouter()
     @AppStorage("colorSchemePref") private var schemePrefRaw: String = ColorSchemePref.system.rawValue
+
+    /// Tracks whether we've already resigned first responder for the active
+    /// edge-swipe. Without this, every `onChanged` tick would fire another
+    /// `resignFirstResponder` send-action — once the keyboard is down, the
+    /// repeated calls are a no-op but still wasted work. Reset on `onEnded`
+    /// so the next swipe gets a fresh dismiss.
+    @State private var didDismissKeyboardForEdgeSwipe: Bool = false
 
     private var schemePref: Binding<ColorSchemePref> {
         Binding(
@@ -87,10 +95,23 @@ struct ContentView: View {
                 guard !router.drawerOpen else { return }
                 guard value.startLocation.x <= edgeSwipeWidth else { return }
                 guard value.translation.width > 0 else { return }
+                // Drop the keyboard the moment the drag qualifies as an
+                // edge-open — keyboard slide-down and drawer slide-in then
+                // happen simultaneously, finger-tracked (issue #54).
+                if !didDismissKeyboardForEdgeSwipe {
+                    didDismissKeyboardForEdgeSwipe = true
+                    UIApplication.shared.sendAction(
+                        #selector(UIResponder.resignFirstResponder),
+                        to: nil,
+                        from: nil,
+                        for: nil
+                    )
+                }
                 let drawerWidth = min(280, UIScreen.main.bounds.width * 0.8)
                 router.drawerDragOffset = min(drawerWidth, value.translation.width)
             }
             .onEnded { value in
+                defer { didDismissKeyboardForEdgeSwipe = false }
                 guard !router.drawerOpen else {
                     router.drawerDragOffset = 0
                     return
@@ -105,12 +126,13 @@ struct ContentView: View {
                 let shouldOpen = translation > drawerWidth * 0.4 || velocity > 500
                 withAnimation(.easeOut(duration: 0.2)) {
                     router.drawerDragOffset = 0
-                }
-                if shouldOpen {
-                    // openDrawer() resigns first responder before flipping the
-                    // flag so the keyboard goes away before the drawer slides
-                    // in over the chat input (issue #54).
-                    router.openDrawer()
+                    if shouldOpen {
+                        // Keyboard was already dismissed in onChanged; flip
+                        // the flag inside the same animation block as the
+                        // drag-offset reset so the panel snaps to its open
+                        // position smoothly.
+                        router.drawerOpen = true
+                    }
                 }
             }
     }


### PR DESCRIPTION
## Summary

- Re-applies the orphaned local commit `e415898` from the original #54 work that was dropped from PR #56's squash-merge (it was committed but never pushed).
- `resignFirstResponder` moves into the gesture's `onChanged` handler, gated by a one-shot `@State` flag so it fires once per swipe rather than on every drag tick.
- Keyboard slide-down and drawer slide-in now track the finger together. Top-bar menu tap path is unchanged.

## Closes

Closes #67

## Test plan

- [x] `xcodegen generate` + `xcodebuild` Debug + iphonesimulator SDK builds cleanly
- [x] OTA archive + sign produced a working IPA (build 1.0.4 (1))
- [x] `xcrun devicectl device install` succeeded on Flightmode 2.0
- [ ] Manual: open chat with keyboard up, edge-swipe right -> keyboard collapses as the drag begins (not at gesture-end), drawer slides in over empty space

QA evidence on #67.