### PR TITLE
feat(ios): icon-square action buttons on Notes & Lists

### DIFF
--- a/mobile/PersonalDashboard/Design/Buttons.swift
+++ b/mobile/PersonalDashboard/Design/Buttons.swift
@@ -87,9 +87,9 @@ struct EdIconButtonStyle: ButtonStyle {
     }
 }
 
-// MARK: - Icon-square button (36×36 filled, for list-header actions)
+// MARK: - Icon-circle button (48pt floating FAB, for Notes / Lists overlay actions)
 
-struct EdIconSquareButtonStyle: ButtonStyle {
+struct EdIconCircleButtonStyle: ButtonStyle {
     var kind: ButtonKind = .primary
 
     func makeBody(configuration: Configuration) -> some View {
@@ -102,14 +102,12 @@ struct EdIconSquareButtonStyle: ButtonStyle {
         }()
 
         return configuration.label
-            .font(.system(size: 15, weight: .regular))
+            .font(.system(size: 17, weight: .regular))
             .foregroundStyle(fg)
-            .frame(width: 36, height: 36)
-            .background(bg, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-                    .stroke(stroke ?? .clear, lineWidth: stroke == nil ? 0 : 0.5)
-            )
+            .frame(width: 48, height: 48)
+            .background(bg, in: Circle())
+            .overlay(Circle().stroke(stroke ?? .clear, lineWidth: stroke == nil ? 0 : 0.5))
+            .shadow(color: .black.opacity(0.18), radius: 12, x: 0, y: 6)
             .opacity(configuration.isPressed ? 0.7 : 1.0)
             .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
     }

--- a/mobile/PersonalDashboard/Design/Buttons.swift
+++ b/mobile/PersonalDashboard/Design/Buttons.swift
@@ -87,6 +87,34 @@ struct EdIconButtonStyle: ButtonStyle {
     }
 }
 
+// MARK: - Icon-square button (36×36 filled, for list-header actions)
+
+struct EdIconSquareButtonStyle: ButtonStyle {
+    var kind: ButtonKind = .primary
+
+    func makeBody(configuration: Configuration) -> some View {
+        let (fg, bg, stroke): (Color, Color, Color?) = {
+            switch kind {
+            case .primary:   return (Tokens.paper, Tokens.ink, nil)
+            case .secondary: return (Tokens.ink, Tokens.surface, Tokens.border)
+            case .ghost:     return (Tokens.muted, .clear, nil)
+            }
+        }()
+
+        return configuration.label
+            .font(.system(size: 15, weight: .regular))
+            .foregroundStyle(fg)
+            .frame(width: 36, height: 36)
+            .background(bg, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                    .stroke(stroke ?? .clear, lineWidth: stroke == nil ? 0 : 0.5)
+            )
+            .opacity(configuration.isPressed ? 0.7 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
 // MARK: - Send button (filled accent square)
 
 struct EdSendButtonStyle: ButtonStyle {

--- a/mobile/PersonalDashboard/Views/Components/SectionEyebrow.swift
+++ b/mobile/PersonalDashboard/Views/Components/SectionEyebrow.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+func sectionEyebrow(_ title: String) -> some View {
+    Text(title)
+        .eyebrow()
+        .textCase(nil)
+        .padding(.horizontal, Space.lg)
+        .padding(.top, Space.lg)
+        .padding(.bottom, Space.xs)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Tokens.paper)
+}

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -83,29 +83,33 @@ struct ListsView: View {
         // into native `.swipeActions`. Paper aesthetic preserved via clear
         // row backgrounds, hidden separators, and `.scrollContentBackground`.
         List {
-            if viewModel.lists.isEmpty && !viewModel.isLoading {
-                Text("No lists yet. Tap + to start.")
-                    .font(.edBody)
-                    .foregroundStyle(Tokens.muted)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.vertical, Space.xxxl)
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets(top: 0, leading: Space.lg, bottom: 0, trailing: Space.lg))
-            } else {
-                ForEach(viewModel.lists) { list in
-                    ListSummaryRow(list: list) {
-                        withAnimation(.easeOut(duration: 0.2)) {
-                            selectedListId = list.id
+            Section {
+                if viewModel.lists.isEmpty && !viewModel.isLoading {
+                    Text("No lists yet. Tap + to start.")
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.muted)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, Space.xxxl)
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: 0, leading: Space.lg, bottom: 0, trailing: Space.lg))
+                } else {
+                    ForEach(viewModel.lists) { list in
+                        ListSummaryRow(list: list) {
+                            withAnimation(.easeOut(duration: 0.2)) {
+                                selectedListId = list.id
+                            }
                         }
+                        .swipeToDeleteTrash {
+                            Task { await viewModel.delete(list) }
+                        }
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                     }
-                    .swipeToDeleteTrash {
-                        Task { await viewModel.delete(list) }
-                    }
-                    .listRowBackground(Color.clear)
-                    .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                 }
+            } header: {
+                sectionEyebrow("All Lists")
             }
 
             Color.clear

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -40,6 +40,18 @@ struct ListsView: View {
                     rootList
                 }
             }
+
+            if selectedListId == nil {
+                Button {
+                    showingNewList = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .buttonStyle(EdIconSquareButtonStyle(kind: .primary))
+                .padding(.trailing, 22)
+                .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+            }
         }
         .activeSection(.lists)
         .task { await viewModel.load() }
@@ -71,23 +83,8 @@ struct ListsView: View {
         // into native `.swipeActions`. Paper aesthetic preserved via clear
         // row backgrounds, hidden separators, and `.scrollContentBackground`.
         List {
-            Section {
-                HStack {
-                    Spacer()
-                    Button {
-                        showingNewList = true
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .buttonStyle(EdIconSquareButtonStyle(kind: .primary))
-                }
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-                .listRowInsets(EdgeInsets(top: Space.lg, leading: Space.lg, bottom: Space.sm, trailing: Space.lg))
-            }
-
             if viewModel.lists.isEmpty && !viewModel.isLoading {
-                Text("No lists yet. Tap “New list” to start.")
+                Text("No lists yet. Tap + to start.")
                     .font(.edBody)
                     .foregroundStyle(Tokens.muted)
                     .frame(maxWidth: .infinity, alignment: .center)

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -47,7 +47,7 @@ struct ListsView: View {
                 } label: {
                     Image(systemName: "plus")
                 }
-                .buttonStyle(EdIconSquareButtonStyle(kind: .primary))
+                .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
                 .padding(.trailing, 22)
                 .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -77,9 +77,9 @@ struct ListsView: View {
                     Button {
                         showingNewList = true
                     } label: {
-                        Label("New list", systemImage: "plus")
+                        Image(systemName: "plus")
                     }
-                    .buttonStyle(EdButtonStyle(kind: .primary, size: .sm))
+                    .buttonStyle(EdIconSquareButtonStyle(kind: .primary))
                 }
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -52,6 +52,26 @@ struct NotesView: View {
                     rootList
                 }
             }
+
+            if selectedNoteId == nil && selectedFolder == nil {
+                HStack(spacing: Space.sm) {
+                    Button {
+                        showingNewFolder = true
+                    } label: {
+                        Image(systemName: "folder.badge.plus")
+                    }
+                    .buttonStyle(EdIconSquareButtonStyle(kind: .secondary))
+                    Button {
+                        Task { await createBlankNote(folderId: nil) }
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .buttonStyle(EdIconSquareButtonStyle(kind: .primary))
+                }
+                .padding(.trailing, 22)
+                .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+            }
         }
         .activeSection(.notes)
         .task {
@@ -93,27 +113,6 @@ struct NotesView: View {
         // opt into native `.swipeActions`. Paper aesthetic preserved with
         // clear row backgrounds and hidden separators.
         List {
-            Section {
-                HStack {
-                    Spacer()
-                    Button {
-                        showingNewFolder = true
-                    } label: {
-                        Image(systemName: "folder.badge.plus")
-                    }
-                    .buttonStyle(EdIconSquareButtonStyle(kind: .secondary))
-                    Button {
-                        Task { await createBlankNote(folderId: selectedFolder?.id) }
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .buttonStyle(EdIconSquareButtonStyle(kind: .primary))
-                }
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-                .listRowInsets(EdgeInsets(top: Space.lg, leading: Space.lg, bottom: Space.sm, trailing: Space.lg))
-            }
-
             if !viewModel.folders.isEmpty {
                 Section {
                     ForEach(viewModel.folders) { folder in
@@ -154,7 +153,7 @@ struct NotesView: View {
             }
 
             if viewModel.folders.isEmpty && viewModel.notes.isEmpty && !viewModel.isLoading {
-                Text("No notes yet. Tap “New note” to start.")
+                Text("No notes yet. Tap + to start.")
                     .font(.edBody)
                     .foregroundStyle(Tokens.muted)
                     .frame(maxWidth: .infinity, alignment: .center)

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -211,17 +211,6 @@ struct NotesView: View {
         .refreshable { await viewModel.load() }
     }
 
-    private func sectionEyebrow(_ title: String) -> some View {
-        Text(title)
-            .eyebrow()
-            .textCase(nil)
-            .padding(.horizontal, Space.lg)
-            .padding(.top, Space.lg)
-            .padding(.bottom, Space.xs)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Tokens.paper)
-    }
-
     // MARK: - Note actions
 
     private func open(note: Note) {

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -60,13 +60,13 @@ struct NotesView: View {
                     } label: {
                         Image(systemName: "folder.badge.plus")
                     }
-                    .buttonStyle(EdIconSquareButtonStyle(kind: .secondary))
+                    .buttonStyle(EdIconCircleButtonStyle(kind: .secondary))
                     Button {
                         Task { await createBlankNote(folderId: nil) }
                     } label: {
                         Image(systemName: "plus")
                     }
-                    .buttonStyle(EdIconSquareButtonStyle(kind: .primary))
+                    .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
                 }
                 .padding(.trailing, 22)
                 .padding(.bottom, BottomTabBarMetrics.height + Space.sm)

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -99,15 +99,15 @@ struct NotesView: View {
                     Button {
                         showingNewFolder = true
                     } label: {
-                        Label("New folder", systemImage: "folder.badge.plus")
+                        Image(systemName: "folder.badge.plus")
                     }
-                    .buttonStyle(EdButtonStyle(kind: .secondary, size: .sm))
+                    .buttonStyle(EdIconSquareButtonStyle(kind: .secondary))
                     Button {
                         Task { await createBlankNote(folderId: selectedFolder?.id) }
                     } label: {
-                        Label("New note", systemImage: "plus")
+                        Image(systemName: "plus")
                     }
-                    .buttonStyle(EdButtonStyle(kind: .primary, size: .sm))
+                    .buttonStyle(EdIconSquareButtonStyle(kind: .primary))
                 }
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -1,13 +1,10 @@
 import SwiftUI
-import UIKit
 
 struct TasksView: View {
     @State private var viewModel = TodosViewModel()
     @State private var showingEditor = false
     @State private var editingTodo: Todo?
-    @State private var newTaskText: String = ""
     @State private var completedExpanded: Bool = false
-    @State private var keyboardVisible = false
 
     @Bindable var router: AppRouter
 
@@ -32,12 +29,12 @@ struct TasksView: View {
                     if viewModel.isLoading && viewModel.todos.isEmpty {
                         placeholderRow("Loading…")
                     } else if viewModel.todos.isEmpty {
-                        placeholderRow("No tasks yet. Add one below.")
+                        placeholderRow("No tasks yet. Tap + to start.")
                     } else {
                         taskGroups
                     }
 
-                    // FAB clearance — keeps the last row scrollable above the docked add row.
+                    // FAB clearance — keeps the last row scrollable above the floating + button.
                     Color.clear
                         .frame(height: 96)
                         .listRowBackground(Color.clear)
@@ -47,31 +44,20 @@ struct TasksView: View {
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)
                 .background(Tokens.paper)
-                .scrollDismissesKeyboard(.interactively)
                 .refreshable { await viewModel.load() }
-                .simultaneousGesture(TapGesture().onEnded {
-                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-                })
-                .safeAreaInset(edge: .bottom, spacing: 0) {
-                    addRow
-                        .padding(.horizontal, Space.lg)
-                        .padding(.vertical, Space.md)
-                        .padding(.bottom, keyboardVisible ? 0 : BottomTabBarMetrics.height)
-                        .background(
-                            Tokens.paper.overlay(alignment: .top) {
-                                Rectangle().fill(Tokens.border).frame(height: 0.5)
-                            }
-                        )
-                }
             }
+
+            Button {
+                showingEditor = true
+            } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
+            .padding(.trailing, 22)
+            .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
         }
         .activeSection(.tasks)
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
-            withAnimation(.easeOut(duration: 0.18)) { keyboardVisible = true }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
-            withAnimation(.easeOut(duration: 0.18)) { keyboardVisible = false }
-        }
         .task { await viewModel.load() }
         .onAppear {
             // Activity timeline deep-link consumption. The Activity surface
@@ -99,51 +85,6 @@ struct TasksView: View {
         } message: {
             Text(viewModel.errorMessage ?? "")
         }
-    }
-
-    // MARK: - Add row
-
-    private var addRow: some View {
-        HStack(spacing: Space.sm) {
-            ZStack(alignment: .leading) {
-                if newTaskText.isEmpty {
-                    Text("Add a new task…")
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.mutedSoft)
-                        .padding(.horizontal, Space.md)
-                        .allowsHitTesting(false)
-                }
-                TextField("", text: $newTaskText)
-                    .font(.edBody)
-                    .foregroundStyle(Tokens.ink)
-                    .padding(.horizontal, Space.md)
-                    .padding(.vertical, 10)
-                    .submitLabel(.done)
-                    .onSubmit(addTaskInline)
-            }
-            .frame(minHeight: 40)
-            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
-            .paperBorder(Tokens.border, radius: Radius.md)
-
-            Button {
-                if !newTaskText.trimmingCharacters(in: .whitespaces).isEmpty {
-                    addTaskInline()
-                } else {
-                    showingEditor = true
-                }
-            } label: {
-                Image(systemName: "plus")
-            }
-            .buttonStyle(EdSendButtonStyle(enabled: true))
-            .accessibilityLabel("Add task")
-        }
-    }
-
-    private func addTaskInline() {
-        let trimmed = newTaskText.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        newTaskText = ""
-        Task { await viewModel.create(title: trimmed, description: nil, dueDate: nil, tag: nil) }
     }
 
     // MARK: - Grouped tasks

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct TasksView: View {
     @State private var viewModel = TodosViewModel()
@@ -6,6 +7,7 @@ struct TasksView: View {
     @State private var editingTodo: Todo?
     @State private var newTaskText: String = ""
     @State private var completedExpanded: Bool = false
+    @State private var keyboardVisible = false
 
     @Bindable var router: AppRouter
 
@@ -47,11 +49,14 @@ struct TasksView: View {
                 .background(Tokens.paper)
                 .scrollDismissesKeyboard(.interactively)
                 .refreshable { await viewModel.load() }
+                .simultaneousGesture(TapGesture().onEnded {
+                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                })
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     addRow
                         .padding(.horizontal, Space.lg)
                         .padding(.vertical, Space.md)
-                        .padding(.bottom, BottomTabBarMetrics.height)
+                        .padding(.bottom, keyboardVisible ? 0 : BottomTabBarMetrics.height)
                         .background(
                             Tokens.paper.overlay(alignment: .top) {
                                 Rectangle().fill(Tokens.border).frame(height: 0.5)
@@ -61,6 +66,12 @@ struct TasksView: View {
             }
         }
         .activeSection(.tasks)
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
+            withAnimation(.easeOut(duration: 0.18)) { keyboardVisible = true }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
+            withAnimation(.easeOut(duration: 0.18)) { keyboardVisible = false }
+        }
         .task { await viewModel.load() }
         .onAppear {
             // Activity timeline deep-link consumption. The Activity surface

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -27,22 +27,15 @@ struct TasksView: View {
                 // backgrounds, hidden separators, and `.scrollContentBackground`
                 // hidden so `Tokens.paper` shows through.
                 List {
-                    Section {
-                        addRow
-                            .listRowBackground(Color.clear)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets(top: Space.lg, leading: Space.lg, bottom: 0, trailing: Space.lg))
-                    }
-
                     if viewModel.isLoading && viewModel.todos.isEmpty {
                         placeholderRow("Loading…")
                     } else if viewModel.todos.isEmpty {
-                        placeholderRow("No tasks yet. Add one above.")
+                        placeholderRow("No tasks yet. Add one below.")
                     } else {
                         taskGroups
                     }
 
-                    // FAB clearance — keeps the last row scrollable above the chat FAB.
+                    // FAB clearance — keeps the last row scrollable above the docked add row.
                     Color.clear
                         .frame(height: 96)
                         .listRowBackground(Color.clear)
@@ -54,6 +47,17 @@ struct TasksView: View {
                 .background(Tokens.paper)
                 .scrollDismissesKeyboard(.interactively)
                 .refreshable { await viewModel.load() }
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    addRow
+                        .padding(.horizontal, Space.lg)
+                        .padding(.vertical, Space.md)
+                        .padding(.bottom, BottomTabBarMetrics.height)
+                        .background(
+                            Tokens.paper.overlay(alignment: .top) {
+                                Rectangle().fill(Tokens.border).frame(height: 0.5)
+                            }
+                        )
+                }
             }
         }
         .activeSection(.tasks)


### PR DESCRIPTION
## Summary

Five iterative changes to the Notes / Lists / Tasks add affordances on a single branch, driven by on-device feedback:

1. **#69** — adds an icon-square button style and converts the Notes top-right (`New folder`, `New note`) and Lists top-right (`New list`) buttons from label-pills to icon-only.
2. **#71** — relocates those add affordances to the bottom for thumb reach: Notes & Lists float at the bottom-right; Tasks docks its inline `addRow` (TextField + plus) at the bottom via `safeAreaInset`.
3. **#72** — converts the floating Notes & Lists add buttons from squares to circles with a drop shadow so they read as elevated above scrolling content. Dead `EdIconSquareButtonStyle` removed; `EdIconCircleButtonStyle` is the canonical floating-action style.
4. **#73** — first content row is vertically aligned across Notes / Lists / Tasks (shared `sectionEyebrow(_:)` helper, `All Lists` eyebrow on Lists). Tasks keyboard fixes: dead-space gap collapsed, tap-outside dismiss added.
5. **#74** — Tasks now matches Notes / Lists: docked input row removed, single floating + circle at bottom-right opens the existing `TaskEditorSheet`. All inline-add plumbing stripped (state, keyboard observers, simultaneous gesture, `import UIKit`, `.scrollDismissesKeyboard`, `.safeAreaInset`). Empty-state copy unified to `"Tap + to start."`.

Closes #69
Closes #71
Closes #72
Closes #73
Closes #74

## Test plan

- [x] `xcodegen generate` regenerates cleanly.
- [x] `xcodebuild ... -sdk iphonesimulator build` -> **BUILD SUCCEEDED**.
- [ ] Device QA after `bash mobile/ota/ship-lan.sh` + `devicectl device install`:
  - All three surfaces show the same floating-circle pattern at bottom-right (Notes has two, Lists and Tasks have one).
  - Tasks: tap + opens the full `TaskEditorSheet`. No inline TextField anywhere on the page.
  - Switching between Notes / Lists / Tasks: first folder / list / task row sits at the same Y below the TopBar.
  - Lists shows the `All Lists` eyebrow above its first row.
  - Empty-state copy on all three reads `"Tap + to start."` (or equivalent unified phrasing).
  - Scrolling list content visibly passes behind the floating circles.
  - All add affordances hide when the keyboard occludes the bottom nav (only relevant inside the editor sheet now).