### PR TITLE
feat(ios): tap below to insert inline new row on Lists & Tasks

### DIFF
--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -261,8 +261,13 @@ private struct ListDetailContent: View {
     @Bindable var viewModel: ListsViewModel
     let listId: UUID
     @State private var newItemText: String = ""
-    // Tap-below inline draft state. nil = no draft active; "" = draft active (empty field).
-    @State private var draftText: String? = nil
+    // Tap-below inline draft state. Modelled the same way as TasksView:
+    // a boolean flag for "draft active" plus a non-optional String for the
+    // text. The earlier optional-binding pattern (`Binding($draftText)` from
+    // a `String?`) crashed when commitDraft set draftText = nil while the
+    // TextField was still mid-edit.
+    @State private var draftActive: Bool = false
+    @State private var draftText: String = ""
     @FocusState private var draftFocused: Bool
 
     var body: some View {
@@ -285,7 +290,7 @@ private struct ListDetailContent: View {
                 .padding(.top, Space.lg)
                 .padding(.bottom, Space.sm)
                 .contentShape(Rectangle())
-                .onTapGesture { if draftText != nil { draftFocused = false } }
+                .onTapGesture { if draftActive { draftFocused = false } }
 
                 Rectangle().fill(Tokens.divider).frame(height: 0.5)
                     .padding(.horizontal, Space.lg)
@@ -296,7 +301,7 @@ private struct ListDetailContent: View {
                     // Existing items live in their own section so .onMove stays scoped to them.
                     Section {
                         // Empty state row — only when no items and no draft is active.
-                        if list.items.isEmpty && draftText == nil {
+                        if list.items.isEmpty && !draftActive {
                             Text("No items yet. Add one below.")
                                 .font(.edBody)
                                 .foregroundStyle(Tokens.muted)
@@ -320,7 +325,7 @@ private struct ListDetailContent: View {
                                     Haptics.destructive()
                                     Task { await viewModel.removeItem(from: list, at: index) }
                                 },
-                                isDraftActive: draftText != nil,
+                                isDraftActive: draftActive,
                                 onTapWhileDraftActive: { draftFocused = false }
                             )
                             .swipeToDeleteTrash {
@@ -337,10 +342,10 @@ private struct ListDetailContent: View {
 
                     // Tap-below section — lives after items, before addItemBar.
                     Section {
-                        if let text = Binding($draftText) {
+                        if draftActive {
                             // Draft is active: show an inline editable row mirroring ItemRow.
                             DraftItemRow(
-                                text: text,
+                                text: $draftText,
                                 isFocused: $draftFocused,
                                 onSubmit: { commitDraft(in: list, keepFocus: true) },
                                 onFocusLost: { commitDraft(in: list, keepFocus: false) }
@@ -348,16 +353,23 @@ private struct ListDetailContent: View {
                             .listRowBackground(Tokens.paper)
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
-                        } else {
-                            // No draft: clear tap target below the last row.
-                            Color.clear
-                                .frame(minHeight: 200)
-                                .contentShape(Rectangle())
-                                .onTapGesture { startDraft() }
-                                .listRowBackground(Tokens.paper)
-                                .listRowSeparator(.hidden)
-                                .listRowInsets(EdgeInsets())
                         }
+                        // Tap-below zone, always rendered:
+                        // - no draft → tap to start a draft.
+                        // - draft active → tap to dismiss the draft (resigns focus → commitDraft via onChange).
+                        Color.clear
+                            .frame(minHeight: 200)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                if draftActive {
+                                    draftFocused = false
+                                } else {
+                                    startDraft()
+                                }
+                            }
+                            .listRowBackground(Tokens.paper)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets())
                     }
                 }
                 .listStyle(.plain)
@@ -369,7 +381,7 @@ private struct ListDetailContent: View {
                     // Tapping the addItemBar while a draft is active dismisses the draft.
                     // simultaneousGesture fires alongside the inner TextField tap so the
                     // bar's own text field can still receive focus normally.
-                    .simultaneousGesture(TapGesture().onEnded { if draftText != nil { draftFocused = false } })
+                    .simultaneousGesture(TapGesture().onEnded { if draftActive { draftFocused = false } })
             }
         } else {
             Spacer()
@@ -383,6 +395,7 @@ private struct ListDetailContent: View {
     // MARK: - Tap-below helpers
 
     private func startDraft() {
+        draftActive = true
         draftText = ""
         // Give the List time to insert the DraftItemRow into the hierarchy before focusing.
         DispatchQueue.main.async { draftFocused = true }
@@ -391,11 +404,11 @@ private struct ListDetailContent: View {
     /// Commits whatever is in draftText.
     /// - keepFocus: true = chain creation (Return key path); false = dismiss (focus-loss path).
     private func commitDraft(in list: Checklist, keepFocus: Bool) {
-        let text = draftText ?? ""
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
             // Empty draft: silently dismiss.
-            draftText = nil
+            draftActive = false
+            draftText = ""
             draftFocused = false
             return
         }
@@ -408,7 +421,8 @@ private struct ListDetailContent: View {
             // Re-assert focus after the text clears (SwiftUI may drop it briefly).
             DispatchQueue.main.async { draftFocused = true }
         } else {
-            draftText = nil
+            draftActive = false
+            draftText = ""
             draftFocused = false
         }
     }

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct ListsView: View {
     @State private var viewModel = ListsViewModel()
@@ -316,7 +317,8 @@ private struct ListDetailContent: View {
                                 onDelete: {
                                     Haptics.destructive()
                                     Task { await viewModel.removeItem(from: list, at: index) }
-                                }
+                                },
+                                isDraftActive: draftText != nil
                             )
                             .swipeToDeleteTrash {
                                 Task { await viewModel.removeItem(from: list, at: index) }
@@ -388,6 +390,9 @@ private struct ListDetailContent: View {
             // Empty draft: silently dismiss.
             draftText = nil
             draftFocused = false
+            // Belt-and-braces: ensure keyboard collapses even if something else
+            // would try to steal first responder (e.g. an ItemRow tap).
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             return
         }
         // Non-empty: commit and optionally chain.
@@ -401,6 +406,7 @@ private struct ListDetailContent: View {
         } else {
             draftText = nil
             draftFocused = false
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
     }
 
@@ -488,6 +494,9 @@ private struct ItemRow: View {
     let onToggle: () -> Void
     let onRename: (String) -> Void
     let onDelete: () -> Void
+    /// When a tap-below draft is active in the parent, suppress beginEditing so the
+    /// tap only dismisses the draft keyboard — nothing re-steals first responder.
+    var isDraftActive: Bool = false
 
     @State private var isEditing = false
     @State private var draft = ""
@@ -535,6 +544,10 @@ private struct ItemRow: View {
         .padding(.horizontal, Space.md)
         .contentShape(Rectangle())
         .onTapGesture {
+            // When a tap-below draft is active, ignore the tap entirely.
+            // The draft's TextField loses focus naturally, commitDraft fires,
+            // and the keyboard collapses without anything re-stealing focus.
+            guard !isDraftActive else { return }
             if !isEditing { beginEditing() }
         }
         .contextMenu {

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 struct ListsView: View {
     @State private var viewModel = ListsViewModel()
@@ -270,6 +269,7 @@ private struct ListDetailContent: View {
         if let list = viewModel.lists.first(where: { $0.id == listId }) {
             VStack(spacing: 0) {
                 // Header strip — count + "Edit" affordance is implicit via long-press.
+                // Tapping the strip while a draft is active dismisses the draft.
                 HStack(spacing: Space.sm) {
                     Text("\(list.items.filter(\.checked).count) of \(list.items.count) items")
                         .font(.edCaption)
@@ -284,6 +284,8 @@ private struct ListDetailContent: View {
                 .padding(.horizontal, Space.lg)
                 .padding(.top, Space.lg)
                 .padding(.bottom, Space.sm)
+                .contentShape(Rectangle())
+                .onTapGesture { if draftText != nil { draftFocused = false } }
 
                 Rectangle().fill(Tokens.divider).frame(height: 0.5)
                     .padding(.horizontal, Space.lg)
@@ -318,7 +320,8 @@ private struct ListDetailContent: View {
                                     Haptics.destructive()
                                     Task { await viewModel.removeItem(from: list, at: index) }
                                 },
-                                isDraftActive: draftText != nil
+                                isDraftActive: draftText != nil,
+                                onTapWhileDraftActive: { draftFocused = false }
                             )
                             .swipeToDeleteTrash {
                                 Task { await viewModel.removeItem(from: list, at: index) }
@@ -363,6 +366,10 @@ private struct ListDetailContent: View {
                 .scrollDismissesKeyboard(.interactively)
 
                 addItemBar(list: list)
+                    // Tapping the addItemBar while a draft is active dismisses the draft.
+                    // simultaneousGesture fires alongside the inner TextField tap so the
+                    // bar's own text field can still receive focus normally.
+                    .simultaneousGesture(TapGesture().onEnded { if draftText != nil { draftFocused = false } })
             }
         } else {
             Spacer()
@@ -390,9 +397,6 @@ private struct ListDetailContent: View {
             // Empty draft: silently dismiss.
             draftText = nil
             draftFocused = false
-            // Belt-and-braces: ensure keyboard collapses even if something else
-            // would try to steal first responder (e.g. an ItemRow tap).
-            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             return
         }
         // Non-empty: commit and optionally chain.
@@ -406,7 +410,6 @@ private struct ListDetailContent: View {
         } else {
             draftText = nil
             draftFocused = false
-            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
     }
 
@@ -497,6 +500,9 @@ private struct ItemRow: View {
     /// When a tap-below draft is active in the parent, suppress beginEditing so the
     /// tap only dismisses the draft keyboard — nothing re-steals first responder.
     var isDraftActive: Bool = false
+    /// Called back to the parent when this row is tapped while a draft is active,
+    /// so the parent can flip draftFocused = false and trigger the focus-loss → commitDraft cycle.
+    var onTapWhileDraftActive: () -> Void = {}
 
     @State private var isEditing = false
     @State private var draft = ""
@@ -544,10 +550,13 @@ private struct ItemRow: View {
         .padding(.horizontal, Space.md)
         .contentShape(Rectangle())
         .onTapGesture {
-            // When a tap-below draft is active, ignore the tap entirely.
-            // The draft's TextField loses focus naturally, commitDraft fires,
-            // and the keyboard collapses without anything re-stealing focus.
-            guard !isDraftActive else { return }
+            // When a tap-below draft is active, actively flip draftFocused in the parent
+            // so the focus-loss → commitDraft → dismiss cycle fires immediately.
+            // We still return early so this row does not enter its own edit flow.
+            if isDraftActive {
+                onTapWhileDraftActive()
+                return
+            }
             if !isEditing { beginEditing() }
         }
         .contextMenu {

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -261,6 +261,9 @@ private struct ListDetailContent: View {
     @Bindable var viewModel: ListsViewModel
     let listId: UUID
     @State private var newItemText: String = ""
+    // Tap-below inline draft state. nil = no draft active; "" = draft active (empty field).
+    @State private var draftText: String? = nil
+    @FocusState private var draftFocused: Bool
 
     var body: some View {
         if let list = viewModel.lists.first(where: { $0.id == listId }) {
@@ -284,16 +287,23 @@ private struct ListDetailContent: View {
                 Rectangle().fill(Tokens.divider).frame(height: 0.5)
                     .padding(.horizontal, Space.lg)
 
-                // Items list — using SwiftUI List so `.onMove` works.
+                // Items list — always rendered so tap-below works even when empty.
                 // Chrome stripped to keep the editorial calm look.
-                if list.items.isEmpty {
-                    Text("No items yet. Add one below.")
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.muted)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-                        .padding(.vertical, Space.xxxl)
-                } else {
-                    List {
+                List {
+                    // Existing items live in their own section so .onMove stays scoped to them.
+                    Section {
+                        // Empty state row — only when no items and no draft is active.
+                        if list.items.isEmpty && draftText == nil {
+                            Text("No items yet. Add one below.")
+                                .font(.edBody)
+                                .foregroundStyle(Tokens.muted)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.vertical, Space.lg)
+                                .listRowBackground(Tokens.paper)
+                                .listRowSeparator(.hidden)
+                                .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+                        }
+
                         ForEach(Array(list.items.enumerated()), id: \.offset) { index, item in
                             ItemRow(
                                 item: item,
@@ -319,11 +329,36 @@ private struct ListDetailContent: View {
                             Task { await viewModel.reorderItems(in: list, from: source, to: destination) }
                         }
                     }
-                    .listStyle(.plain)
-                    .scrollContentBackground(.hidden)
-                    .background(Tokens.paper)
-                    .scrollDismissesKeyboard(.interactively)
+
+                    // Tap-below section — lives after items, before addItemBar.
+                    Section {
+                        if let text = Binding($draftText) {
+                            // Draft is active: show an inline editable row mirroring ItemRow.
+                            DraftItemRow(
+                                text: text,
+                                isFocused: $draftFocused,
+                                onSubmit: { commitDraft(in: list, keepFocus: true) },
+                                onFocusLost: { commitDraft(in: list, keepFocus: false) }
+                            )
+                            .listRowBackground(Tokens.paper)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+                        } else {
+                            // No draft: clear tap target below the last row.
+                            Color.clear
+                                .frame(minHeight: 200)
+                                .contentShape(Rectangle())
+                                .onTapGesture { startDraft() }
+                                .listRowBackground(Tokens.paper)
+                                .listRowSeparator(.hidden)
+                                .listRowInsets(EdgeInsets())
+                        }
+                    }
                 }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .background(Tokens.paper)
+                .scrollDismissesKeyboard(.interactively)
 
                 addItemBar(list: list)
             }
@@ -333,6 +368,39 @@ private struct ListDetailContent: View {
                 .font(.edBody)
                 .foregroundStyle(Tokens.muted)
             Spacer()
+        }
+    }
+
+    // MARK: - Tap-below helpers
+
+    private func startDraft() {
+        draftText = ""
+        // Give the List time to insert the DraftItemRow into the hierarchy before focusing.
+        DispatchQueue.main.async { draftFocused = true }
+    }
+
+    /// Commits whatever is in draftText.
+    /// - keepFocus: true = chain creation (Return key path); false = dismiss (focus-loss path).
+    private func commitDraft(in list: Checklist, keepFocus: Bool) {
+        let text = draftText ?? ""
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            // Empty draft: silently dismiss.
+            draftText = nil
+            draftFocused = false
+            return
+        }
+        // Non-empty: commit and optionally chain.
+        let snapshot = list
+        Task { await viewModel.addItem(to: snapshot, text: trimmed) }
+        if keepFocus {
+            // Chain: clear text, keep focus for next entry.
+            draftText = ""
+            // Re-assert focus after the text clears (SwiftUI may drop it briefly).
+            DispatchQueue.main.async { draftFocused = true }
+        } else {
+            draftText = nil
+            draftFocused = false
         }
     }
 
@@ -377,6 +445,41 @@ private struct ListDetailContent: View {
         let snapshot = list
         newItemText = ""
         Task { await viewModel.addItem(to: snapshot, text: trimmed) }
+    }
+}
+
+/// Inline draft row that appears when the user taps below the last item.
+/// Mirrors the visual shape of ItemRow: stroked circle bullet + text field.
+private struct DraftItemRow: View {
+    @Binding var text: String
+    var isFocused: FocusState<Bool>.Binding
+    let onSubmit: () -> Void
+    let onFocusLost: () -> Void
+
+    var body: some View {
+        HStack(spacing: Space.md) {
+            // Empty stroked circle — identical to ItemRow's unchecked bullet.
+            Circle()
+                .stroke(Tokens.borderStrong, lineWidth: 2)
+                .frame(width: 22, height: 22)
+                .frame(width: 24, height: 24)
+
+            TextField("New item", text: $text)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .submitLabel(.return)
+                .focused(isFocused)
+                .onSubmit { onSubmit() }
+                .onChange(of: isFocused.wrappedValue) { _, nowFocused in
+                    if !nowFocused { onFocusLost() }
+                }
+                .accessibilityLabel("New item")
+
+            Spacer()
+        }
+        .padding(.vertical, Space.sm)
+        .padding(.horizontal, Space.md)
+        .contentShape(Rectangle())
     }
 }
 

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -53,6 +53,7 @@ struct TasksView: View {
                         .listRowInsets(EdgeInsets())
                 }
                 .listStyle(.plain)
+                .listSectionSpacing(0)
                 .scrollContentBackground(.hidden)
                 .background(Tokens.paper)
                 .refreshable { await viewModel.load() }
@@ -334,7 +335,7 @@ struct TasksView: View {
             .buttonStyle(.plain)
             .textCase(nil)
             .padding(.horizontal, Space.lg)
-            .padding(.top, Space.lg)
+            .padding(.top, Space.sm)
             .padding(.bottom, Space.xs)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Tokens.paper)
@@ -359,7 +360,7 @@ struct TasksView: View {
         }
         .textCase(nil)
         .padding(.horizontal, Space.lg)
-        .padding(.top, Space.lg)
+        .padding(.top, Space.sm)
         .padding(.bottom, Space.xs)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Tokens.paper)

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -160,9 +160,13 @@ struct TasksView: View {
                 onSubmit: { commitDraft(keepFocus: true) },
                 onFocusLost: { commitDraft(keepFocus: false) }
             )
+            // Same height-stabilisation as the per-section draft rows: lock to 60pt
+            // so swapping the empty-state tap-zone for the draft row doesn't jump.
+            .frame(minHeight: 60)
+            .padding(.horizontal, Space.lg)
             .listRowBackground(Color.clear)
             .listRowSeparator(.hidden)
-            .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+            .listRowInsets(EdgeInsets())
         } else {
             Color.clear
                 .frame(minHeight: 120)
@@ -259,9 +263,17 @@ struct TasksView: View {
                         onSubmit: { commitDraft(keepFocus: true) },
                         onFocusLost: { commitDraft(keepFocus: false) }
                     )
+                    // Match the tap-zone's 60pt height exactly so swapping clear→draft
+                    // doesn't shift the "No Date" header (and everything below) by ~16pt
+                    // as the keyboard appears. EdgeInsets() + .padding(.horizontal, Space.lg)
+                    // at the call site reproduces the same leading/trailing gutter as
+                    // the existing TaskRow rows (.listRowInsets leading/trailing Space.lg
+                    // + internal .padding(.horizontal, Space.md)).
+                    .frame(minHeight: 60)
+                    .padding(.horizontal, Space.lg)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
-                    .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+                    .listRowInsets(EdgeInsets())
                 } else {
                     // Clear tap target — 60pt is enough per section without bloating the list.
                     Color.clear

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 struct TasksView: View {
     @State private var viewModel = TodosViewModel()
@@ -44,8 +43,11 @@ struct TasksView: View {
                     }
 
                     // FAB clearance — keeps the last row scrollable above the floating + button.
+                    // Also acts as a tap-to-dismiss zone for any active inline draft.
                     Color.clear
                         .frame(height: 96)
+                        .contentShape(Rectangle())
+                        .onTapGesture { if draftBucket != nil { draftFocused = false } }
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                         .listRowInsets(EdgeInsets())
@@ -65,6 +67,11 @@ struct TasksView: View {
             .padding(.trailing, 22)
             .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+            // Hide the FAB while an inline draft is active — the user is already
+            // adding a task inline, so the FAB is redundant and visually distracting.
+            .opacity(draftBucket == nil ? 1 : 0)
+            .allowsHitTesting(draftBucket == nil)
+            .animation(.easeOut(duration: 0.15), value: draftBucket)
         }
         .activeSection(.tasks)
         .task { await viewModel.load() }
@@ -113,7 +120,6 @@ struct TasksView: View {
         if trimmed.isEmpty {
             draftBucket = nil
             draftFocused = false
-            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             return
         }
         let due = suggestedDueDate(for: bucket)
@@ -124,7 +130,6 @@ struct TasksView: View {
         } else {
             draftBucket = nil
             draftFocused = false
-            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
     }
 
@@ -234,7 +239,8 @@ struct TasksView: View {
                     todo: todo,
                     isDraftActive: draftBucket != nil,
                     onToggle: { Task { await viewModel.toggleCompleted(todo) } },
-                    onTap: { editingTodo = todo }
+                    onTap: { editingTodo = todo },
+                    onTapWhileDraftActive: { draftFocused = false }
                 )
                 .swipeToDeleteTrash {
                     Task { await viewModel.delete(todo) }
@@ -281,7 +287,8 @@ struct TasksView: View {
                         todo: todo,
                         isDraftActive: draftBucket != nil,
                         onToggle: { Task { await viewModel.toggleCompleted(todo) } },
-                        onTap: { editingTodo = todo }
+                        onTap: { editingTodo = todo },
+                        onTapWhileDraftActive: { draftFocused = false }
                     )
                     .swipeToDeleteTrash {
                         Task { await viewModel.delete(todo) }
@@ -319,6 +326,9 @@ struct TasksView: View {
             .padding(.bottom, Space.xs)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Tokens.paper)
+            // Dismiss draft alongside the expand/collapse toggle so keyboard
+            // collapses when the user taps the Completed header.
+            .simultaneousGesture(TapGesture().onEnded { if draftBucket != nil { draftFocused = false } })
         }
     }
 
@@ -341,6 +351,9 @@ struct TasksView: View {
         .padding(.bottom, Space.xs)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Tokens.paper)
+        // Tapping a section header while a draft is active dismisses the draft.
+        .contentShape(Rectangle())
+        .onTapGesture { if draftBucket != nil { draftFocused = false } }
     }
 
     private func placeholderRow(_ text: String) -> some View {
@@ -403,6 +416,9 @@ private struct TaskRow: View {
     var isDraftActive: Bool = false
     let onToggle: () -> Void
     let onTap: () -> Void
+    /// Called back to the parent when this row is tapped while a draft is active,
+    /// so the parent can flip draftFocused = false and trigger the focus-loss → commitDraft cycle.
+    var onTapWhileDraftActive: () -> Void = {}
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Space.md) {
@@ -470,9 +486,13 @@ private struct TaskRow: View {
         .background(Color.clear)
         .contentShape(Rectangle())
         .onTapGesture {
-            // When a tap-below draft is active, ignore the tap so the editor sheet
-            // doesn't open over the dismissing keyboard.
-            guard !isDraftActive else { return }
+            // When a tap-below draft is active, actively flip draftFocused in the parent
+            // so the focus-loss → commitDraft → dismiss cycle fires immediately.
+            // We still return early so the editor sheet does not open over the keyboard.
+            if isDraftActive {
+                onTapWhileDraftActive()
+                return
+            }
             onTap()
         }
     }

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -5,6 +5,9 @@ struct TasksView: View {
     @State private var showingEditor = false
     @State private var editingTodo: Todo?
     @State private var completedExpanded: Bool = false
+    // Tap-below inline draft state. nil = no draft active; "" = draft active (empty field).
+    @State private var draftText: String? = nil
+    @FocusState private var draftFocused: Bool
 
     @Bindable var router: AppRouter
 
@@ -32,6 +35,30 @@ struct TasksView: View {
                         placeholderRow("No tasks yet. Tap + to start.")
                     } else {
                         taskGroups
+                    }
+
+                    // Tap-below affordance — sits above FAB clearance so the empty
+                    // visual gap above the FAB is tappable to start a quick inline task.
+                    if let text = Binding($draftText) {
+                        // Draft active: show inline editable row.
+                        DraftTaskRow(
+                            text: text,
+                            isFocused: $draftFocused,
+                            onSubmit: { commitDraft(keepFocus: true) },
+                            onFocusLost: { commitDraft(keepFocus: false) }
+                        )
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+                    } else {
+                        // No draft: clear tap target — gives a meaty ~120pt tap zone.
+                        Color.clear
+                            .frame(minHeight: 120)
+                            .contentShape(Rectangle())
+                            .onTapGesture { startDraft() }
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets())
                     }
 
                     // FAB clearance — keeps the last row scrollable above the floating + button.
@@ -84,6 +111,36 @@ struct TasksView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(viewModel.errorMessage ?? "")
+        }
+    }
+
+    // MARK: - Tap-below helpers
+
+    private func startDraft() {
+        draftText = ""
+        // Give the List time to insert DraftTaskRow into the hierarchy before focusing.
+        DispatchQueue.main.async { draftFocused = true }
+    }
+
+    /// Commits the current draftText as a new no-date task.
+    /// - keepFocus: true = chain creation (Return key); false = dismiss (focus-loss path).
+    private func commitDraft(keepFocus: Bool) {
+        let text = draftText ?? ""
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            // Empty draft: silently dismiss.
+            draftText = nil
+            draftFocused = false
+            return
+        }
+        // Non-empty: create a no-date task and optionally chain.
+        Task { await viewModel.create(title: trimmed) }
+        if keepFocus {
+            draftText = ""
+            DispatchQueue.main.async { draftFocused = true }
+        } else {
+            draftText = nil
+            draftFocused = false
         }
     }
 
@@ -241,6 +298,45 @@ struct TasksView: View {
             .listRowBackground(Color.clear)
             .listRowSeparator(.hidden)
             .listRowInsets(EdgeInsets(top: 0, leading: Space.lg, bottom: 0, trailing: Space.lg))
+    }
+}
+
+// MARK: - Inline draft row
+
+/// Inline draft row that appears when the user taps below the last task.
+/// Mirrors the visual shape of TaskRow: stroked circle bullet + text field.
+private struct DraftTaskRow: View {
+    @Binding var text: String
+    var isFocused: FocusState<Bool>.Binding
+    let onSubmit: () -> Void
+    let onFocusLost: () -> Void
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Space.md) {
+            // Empty stroked circle — identical to TaskRow's unchecked bullet.
+            Circle()
+                .stroke(Tokens.borderStrong, lineWidth: 2)
+                .frame(width: 22, height: 22)
+                .frame(width: 24, height: 24)
+                // Align circle center to firstTextBaseline as TaskRow does.
+                .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
+
+            TextField("New task", text: $text)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .submitLabel(.return)
+                .focused(isFocused)
+                .onSubmit { onSubmit() }
+                .onChange(of: isFocused.wrappedValue) { _, nowFocused in
+                    if !nowFocused { onFocusLost() }
+                }
+                .accessibilityLabel("New task")
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, Space.sm)
+        .padding(.horizontal, Space.md)
+        .contentShape(Rectangle())
     }
 }
 

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -1,12 +1,16 @@
 import SwiftUI
+import UIKit
 
 struct TasksView: View {
     @State private var viewModel = TodosViewModel()
     @State private var showingEditor = false
     @State private var editingTodo: Todo?
     @State private var completedExpanded: Bool = false
-    // Tap-below inline draft state. nil = no draft active; "" = draft active (empty field).
-    @State private var draftText: String? = nil
+    // Per-section tap-below inline draft state.
+    // draftBucket == nil → no draft active; non-nil → draft in that section.
+    private enum DraftBucket: String { case today, thisWeek, later, noDate }
+    @State private var draftBucket: DraftBucket? = nil
+    @State private var draftText: String = ""
     @FocusState private var draftFocused: Bool
 
     @Bindable var router: AppRouter
@@ -32,33 +36,11 @@ struct TasksView: View {
                     if viewModel.isLoading && viewModel.todos.isEmpty {
                         placeholderRow("Loading…")
                     } else if viewModel.todos.isEmpty {
-                        placeholderRow("No tasks yet. Tap + to start.")
+                        // Empty-state: single tap-below that seeds a No Date task.
+                        placeholderRow("No tasks yet. Tap below to start.")
+                        emptyStateDraftRow
                     } else {
                         taskGroups
-                    }
-
-                    // Tap-below affordance — sits above FAB clearance so the empty
-                    // visual gap above the FAB is tappable to start a quick inline task.
-                    if let text = Binding($draftText) {
-                        // Draft active: show inline editable row.
-                        DraftTaskRow(
-                            text: text,
-                            isFocused: $draftFocused,
-                            onSubmit: { commitDraft(keepFocus: true) },
-                            onFocusLost: { commitDraft(keepFocus: false) }
-                        )
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
-                    } else {
-                        // No draft: clear tap target — gives a meaty ~120pt tap zone.
-                        Color.clear
-                            .frame(minHeight: 120)
-                            .contentShape(Rectangle())
-                            .onTapGesture { startDraft() }
-                            .listRowBackground(Color.clear)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets())
                     }
 
                     // FAB clearance — keeps the last row scrollable above the floating + button.
@@ -116,31 +98,74 @@ struct TasksView: View {
 
     // MARK: - Tap-below helpers
 
-    private func startDraft() {
+    private func startDraft(in bucket: DraftBucket) {
+        draftBucket = bucket
         draftText = ""
-        // Give the List time to insert DraftTaskRow into the hierarchy before focusing.
+        // Give the List time to insert DraftTaskRow before focusing.
         DispatchQueue.main.async { draftFocused = true }
     }
 
-    /// Commits the current draftText as a new no-date task.
+    /// Commits the current draftText as a new task in the active bucket.
     /// - keepFocus: true = chain creation (Return key); false = dismiss (focus-loss path).
     private func commitDraft(keepFocus: Bool) {
-        let text = draftText ?? ""
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let bucket = draftBucket else { return }
+        let trimmed = draftText.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
-            // Empty draft: silently dismiss.
-            draftText = nil
+            draftBucket = nil
             draftFocused = false
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             return
         }
-        // Non-empty: create a no-date task and optionally chain.
-        Task { await viewModel.create(title: trimmed) }
+        let due = suggestedDueDate(for: bucket)
+        Task { await viewModel.create(title: trimmed, dueDate: due) }
         if keepFocus {
             draftText = ""
             DispatchQueue.main.async { draftFocused = true }
         } else {
-            draftText = nil
+            draftBucket = nil
             draftFocused = false
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+    }
+
+    private func suggestedDueDate(for bucket: DraftBucket) -> Date? {
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: Date())
+        switch bucket {
+        case .today:
+            return cal.date(bySettingHour: 23, minute: 0, second: 0, of: today)
+        case .thisWeek:
+            let eod = cal.date(bySettingHour: 23, minute: 0, second: 0, of: today)!
+            return cal.date(byAdding: .day, value: 3, to: eod)
+        case .later:
+            let eod = cal.date(bySettingHour: 23, minute: 0, second: 0, of: today)!
+            return cal.date(byAdding: .day, value: 14, to: eod)
+        case .noDate:
+            return nil
+        }
+    }
+
+    // Empty-state fallback: single tap-below seeding a No Date task.
+    @ViewBuilder
+    private var emptyStateDraftRow: some View {
+        if draftBucket == .noDate {
+            DraftTaskRow(
+                text: $draftText,
+                isFocused: $draftFocused,
+                onSubmit: { commitDraft(keepFocus: true) },
+                onFocusLost: { commitDraft(keepFocus: false) }
+            )
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+        } else {
+            Color.clear
+                .frame(minHeight: 120)
+                .contentShape(Rectangle())
+                .onTapGesture { startDraft(in: .noDate) }
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
         }
     }
 
@@ -149,20 +174,21 @@ struct TasksView: View {
     @ViewBuilder
     private var taskGroups: some View {
         let buckets = computeBuckets()
+        // Overdue: no tap-below (adding a new overdue task is incoherent).
         if !buckets.overdue.isEmpty {
-            taskSection(title: "Overdue", count: buckets.overdue.count, accent: Tokens.danger, soft: Tokens.dangerSoft, todos: buckets.overdue)
+            taskSection(title: "Overdue", count: buckets.overdue.count, accent: Tokens.danger, soft: Tokens.dangerSoft, todos: buckets.overdue, bucket: nil)
         }
-        if !buckets.today.isEmpty {
-            taskSection(title: "Today", count: buckets.today.count, accent: Tokens.warning, soft: Tokens.warningSoft, todos: buckets.today)
+        if !buckets.today.isEmpty || draftBucket == .today {
+            taskSection(title: "Today", count: buckets.today.count, accent: Tokens.warning, soft: Tokens.warningSoft, todos: buckets.today, bucket: .today)
         }
-        if !buckets.thisWeek.isEmpty {
-            taskSection(title: "This Week", count: buckets.thisWeek.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: buckets.thisWeek)
+        if !buckets.thisWeek.isEmpty || draftBucket == .thisWeek {
+            taskSection(title: "This Week", count: buckets.thisWeek.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: buckets.thisWeek, bucket: .thisWeek)
         }
-        if !buckets.later.isEmpty {
-            taskSection(title: "Later", count: buckets.later.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: buckets.later)
+        if !buckets.later.isEmpty || draftBucket == .later {
+            taskSection(title: "Later", count: buckets.later.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: buckets.later, bucket: .later)
         }
-        if !buckets.noDate.isEmpty {
-            taskSection(title: "No Date", count: buckets.noDate.count, accent: Tokens.muted, soft: Tokens.paper2, todos: buckets.noDate)
+        if !buckets.noDate.isEmpty || draftBucket == .noDate {
+            taskSection(title: "No Date", count: buckets.noDate.count, accent: Tokens.muted, soft: Tokens.paper2, todos: buckets.noDate, bucket: .noDate)
         }
         if !buckets.completed.isEmpty {
             completedSection(buckets.completed)
@@ -198,21 +224,48 @@ struct TasksView: View {
         return b
     }
 
+    /// Renders a task section with an optional per-section tap-below affordance.
+    /// Pass `bucket: nil` for sections that should not have tap-below (e.g. Overdue).
     @ViewBuilder
-    private func taskSection(title: String, count: Int, accent: Color, soft: Color, todos: [Todo]) -> some View {
+    private func taskSection(title: String, count: Int, accent: Color, soft: Color, todos: [Todo], bucket: DraftBucket?) -> some View {
         Section {
             ForEach(todos) { todo in
-                TaskRow(todo: todo) {
-                    Task { await viewModel.toggleCompleted(todo) }
-                } onTap: {
-                    editingTodo = todo
-                }
+                TaskRow(
+                    todo: todo,
+                    isDraftActive: draftBucket != nil,
+                    onToggle: { Task { await viewModel.toggleCompleted(todo) } },
+                    onTap: { editingTodo = todo }
+                )
                 .swipeToDeleteTrash {
                     Task { await viewModel.delete(todo) }
                 }
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
                 .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+            }
+
+            // Tap-below affordance for this section (skipped for Overdue).
+            if let bucket {
+                if draftBucket == bucket {
+                    DraftTaskRow(
+                        text: $draftText,
+                        isFocused: $draftFocused,
+                        onSubmit: { commitDraft(keepFocus: true) },
+                        onFocusLost: { commitDraft(keepFocus: false) }
+                    )
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
+                } else {
+                    // Clear tap target — 60pt is enough per section without bloating the list.
+                    Color.clear
+                        .frame(minHeight: 60)
+                        .contentShape(Rectangle())
+                        .onTapGesture { startDraft(in: bucket) }
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets())
+                }
             }
         } header: {
             sectionHeader(title: title, count: count, accent: accent, soft: soft)
@@ -224,11 +277,12 @@ struct TasksView: View {
         Section {
             if completedExpanded {
                 ForEach(todos) { todo in
-                    TaskRow(todo: todo) {
-                        Task { await viewModel.toggleCompleted(todo) }
-                    } onTap: {
-                        editingTodo = todo
-                    }
+                    TaskRow(
+                        todo: todo,
+                        isDraftActive: draftBucket != nil,
+                        onToggle: { Task { await viewModel.toggleCompleted(todo) } },
+                        onTap: { editingTodo = todo }
+                    )
                     .swipeToDeleteTrash {
                         Task { await viewModel.delete(todo) }
                     }
@@ -344,6 +398,9 @@ private struct DraftTaskRow: View {
 
 private struct TaskRow: View {
     let todo: Todo
+    /// When a tap-below draft is active, suppress opening the editor sheet so the tap
+    /// only dismisses the draft keyboard — nothing re-steals first responder.
+    var isDraftActive: Bool = false
     let onToggle: () -> Void
     let onTap: () -> Void
 
@@ -412,7 +469,12 @@ private struct TaskRow: View {
         .padding(.horizontal, Space.md)
         .background(Color.clear)
         .contentShape(Rectangle())
-        .onTapGesture(perform: onTap)
+        .onTapGesture {
+            // When a tap-below draft is active, ignore the tap so the editor sheet
+            // doesn't open over the dismissing keyboard.
+            guard !isDraftActive else { return }
+            onTap()
+        }
     }
 
     private func dueColor(for date: Date) -> Color {

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -263,21 +263,21 @@ struct TasksView: View {
                         onSubmit: { commitDraft(keepFocus: true) },
                         onFocusLost: { commitDraft(keepFocus: false) }
                     )
-                    // Match the tap-zone's 60pt height exactly so swapping clear→draft
+                    // Match the tap-zone's 40pt height exactly so swapping clear→draft
                     // doesn't shift the "No Date" header (and everything below) by ~16pt
                     // as the keyboard appears. EdgeInsets() + .padding(.horizontal, Space.lg)
                     // at the call site reproduces the same leading/trailing gutter as
                     // the existing TaskRow rows (.listRowInsets leading/trailing Space.lg
                     // + internal .padding(.horizontal, Space.md)).
-                    .frame(minHeight: 60)
+                    .frame(minHeight: 40)
                     .padding(.horizontal, Space.lg)
                     .listRowBackground(Color.clear)
                     .listRowSeparator(.hidden)
                     .listRowInsets(EdgeInsets())
                 } else {
-                    // Clear tap target — 60pt is enough per section without bloating the list.
+                    // Clear tap target — 40pt keeps sections tight while staying tappable.
                     Color.clear
-                        .frame(minHeight: 60)
+                        .frame(minHeight: 40)
                         .contentShape(Rectangle())
                         .onTapGesture { startDraft(in: bucket) }
                         .listRowBackground(Color.clear)


### PR DESCRIPTION
## Summary

- iOS Reminders style tap-below: empty area below the last row spawns an inline editable draft.
- Return commits and chains (cursor stays focused for the next entry); empty Return dismisses.
- Tap outside with text commits; tap outside empty silently dismisses.
- Lists detail keeps its existing bottom add bar; Tasks keeps its + FAB. Both new affordances are additive.

Closes #75.

## Test plan

- [ ] Lists detail (empty list): tap below the empty state, type, Return, see chained creation.
- [ ] Lists detail (with items): tap below last row, draft appears focused, Return commits + clears for next.
- [ ] Lists detail: type some text, tap outside the keyboard, row commits.
- [ ] Lists detail: open draft, type nothing, tap outside, draft silently disappears.
- [ ] Lists detail: existing bottom Add bar still works; existing tap-to-rename on rows still works; swipe-to-delete and reorder still work.
- [ ] Tasks page (empty): tap below empty state, type, Return → no-date task appears in No Date bucket.
- [ ] Tasks page (with tasks): tap below last bucket above the FAB, draft appears focused, Return commits.
- [ ] Tasks page: existing + FAB editor sheet still works for full-metadata tasks.

Device verification + screenshots posted on #75 once walked through on the iPhone.