### PR TITLE
fix(ios): unblock vertical scroll over swipeable rows

### DIFF
--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -1,79 +1,50 @@
 import SwiftUI
 import UIKit
 
+/// Swipe-left-to-delete with circular red trash + gray fade card,
+/// keyed to a UIKit-bridged horizontal-only pan recognizer so the
+/// parent List's vertical scroll is never starved.
+///
+/// SwiftUI gesture arbitration cannot filter by direction at the
+/// recognizer level — `DragGesture(minimumDistance: 10)` claims the
+/// touch as soon as movement crosses 10pt regardless of direction,
+/// even with an `abs(width) > abs(height)` early-return inside
+/// `onChanged`. The early-return suppresses visual changes but does
+/// not release the gesture, so vertical drags over rows never reach
+/// the List's UIScrollView pan and scroll dies.
+///
+/// UIKit's UIPanGestureRecognizer fixes this via
+/// `gestureRecognizerShouldBegin`: returning false for
+/// vertical-dominant velocity transitions the recognizer to
+/// `.failed`, freeing the parent List's pan to begin. Tap
+/// arbitration is preserved by `cancelsTouchesInView = false` plus
+/// `shouldRecognizeSimultaneouslyWith` returning true — short
+/// touches never reach the pan threshold, so the underlying SwiftUI
+/// Button's tap fires normally.
 extension View {
-    /// Swipe-left-to-delete affordance: the row content slides left
-    /// and reveals a fixed-size circular red trash button on the
-    /// trailing edge, with a soft gray card fading in behind the
-    /// row to differentiate the swiped state.
-    ///
-    /// The drag uses `.highPriorityGesture` with a 10pt activation
-    /// threshold so it preempts the Button-wrapped rows (folders,
-    /// list summaries, note rows) — short touches stay below the
-    /// threshold and fall through to the Button's tap; deliberate
-    /// drags activate the swipe and the Button's tap is cancelled.
-    ///
-    /// Full-swipe-commit requires a deliberate 70%+ drag (no
-    /// velocity-only commit) so a quick flick can never silently
-    /// delete a row.
     func swipeToDeleteTrash(perform action: @escaping () -> Void) -> some View {
         modifier(SwipeToDeleteWithTint(onDelete: action))
-    }
-}
-
-private struct SwipeRowHeightKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
     }
 }
 
 private struct SwipeToDeleteWithTint: ViewModifier {
     let onDelete: () -> Void
 
-    @State private var offset: CGFloat = 0  // change to test reveal states
+    @State private var offset: CGFloat = 0
     @State private var isOpen: Bool = false
-    /// Measured row height — used to size the gray fade-in card so
-    /// it matches the row, and to vertically center the fixed-size
-    /// trash circle inside taller rows like notes with body preview.
-    @State private var rowHeight: CGFloat = 0
 
-    /// Fixed circle diameter. Same on every row regardless of row
-    /// height, so tasks / lists / notes all reveal an identical
-    /// circular action.
     private let buttonSize: CGFloat = 52
-    /// Distance the row must travel for the trash to be fully revealed.
-    /// Equals buttonSize plus the trailing gap, so at full reveal the
-    /// circle sits exactly `pillGap` from the row's right edge.
     private let revealedWidth: CGFloat = 60
-    /// Spacing between the row's right edge and the trash circle's
-    /// left edge — reads as two distinct objects.
-    private let pillGap: CGFloat = Space.sm
-    /// Soft corner radius for the gray fade-in card. The trash itself
-    /// is a Circle (corner radius doesn't apply).
     private let cardCornerRadius: CGFloat = 14
     private let tintColor: Color = Tokens.borderStrong
-    /// Vivid iOS-system red used by Reminders / Mail for destructive
-    /// swipe actions.
     private let trashColor: Color = Color(.sRGB, red: 1.0, green: 0.231, blue: 0.188, opacity: 1.0)
 
     func body(content: Content) -> some View {
         let dragDistance = -offset
-        // Cosine ease so the gray doesn't pop in — barely visible at
-        // the start of the swipe, accelerating toward the snap-open
-        // point.
         let linear = min(1.0, max(0.0, Double(dragDistance / revealedWidth)))
         let progress = 0.5 - 0.5 * cos(.pi * linear)
-        let outerHeight: CGFloat = rowHeight > 0 ? rowHeight : 44
 
         ZStack(alignment: .trailing) {
-            // 52pt circle, opacity tied to drag distance. Invisible
-            // at rest (so the circle's edges can't bleed through
-            // gaps in the row's rounded background), fades in over
-            // the first 20pt of drag, fully visible by the snap-open
-            // point. As content slides left underneath, the circle
-            // is revealed purely as a side-effect of the offset —
-            // no width animation, the shape stays a circle.
             Button(action: commit) {
                 Image(systemName: "trash")
                     .font(.system(size: 18, weight: .regular))
@@ -82,37 +53,36 @@ private struct SwipeToDeleteWithTint: ViewModifier {
                     .background(Circle().fill(trashColor))
             }
             .buttonStyle(.plain)
-            .frame(maxHeight: outerHeight, alignment: .center)
             .opacity(min(1.0, dragDistance / 20))
             .allowsHitTesting(dragDistance >= revealedWidth * 0.6)
             .accessibilityLabel("Delete")
 
-            content
-                .background(
-                    RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
-                        .fill(tintColor)
-                        .opacity(progress)
-                )
-                .background(
-                    GeometryReader { geo in
-                        Color.clear.preference(key: SwipeRowHeightKey.self, value: geo.size.height)
+            HorizontalPanCapture(
+                onChanged: { dx in
+                    let raw = (isOpen ? -revealedWidth : 0) + dx
+                    offset = applyRubberBand(to: raw)
+                },
+                onEnded: { dx in
+                    let endRaw = (isOpen ? -revealedWidth : 0) + dx
+                    if -endRaw > UIScreen.main.bounds.width * 0.7 {
+                        commit()
+                    } else if -endRaw > revealedWidth * 0.4 {
+                        open()
+                    } else {
+                        close()
                     }
-                )
-                .overlay(closeOverlay)
-                .offset(x: offset)
-                // highPriorityGesture so the drag preempts the row's
-                // Button tap (folders, list summaries, note rows
-                // wrap their content in a Button that navigates on
-                // tap). With simultaneousGesture both gestures
-                // recognised on release, so the row would snap open
-                // AND fire the Button's onTap. highPriority kills
-                // the Button's tap once the drag activates, but
-                // brief touches that stay below minimumDistance: 10
-                // never activate the drag and fall through to the
-                // Button as expected.
-                .highPriorityGesture(dragGesture)
+                }
+            ) {
+                content
+                    .background(
+                        RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
+                            .fill(tintColor)
+                            .opacity(progress)
+                    )
+                    .overlay(closeOverlay)
+                    .offset(x: offset)
+            }
         }
-        .onPreferenceChange(SwipeRowHeightKey.self) { rowHeight = $0 }
     }
 
     @ViewBuilder
@@ -124,31 +94,6 @@ private struct SwipeToDeleteWithTint: ViewModifier {
         }
     }
 
-    private var dragGesture: some Gesture {
-        DragGesture(minimumDistance: 10)
-            .onChanged { value in
-                // Vertical drags (List scroll) shouldn't move the row.
-                guard abs(value.translation.width) > abs(value.translation.height) else { return }
-                let raw = (isOpen ? -revealedWidth : 0) + value.translation.width
-                offset = applyRubberBand(to: raw)
-            }
-            .onEnded { value in
-                let endRaw = (isOpen ? -revealedWidth : 0) + value.translation.width
-                // Commit only on a deliberate full-swipe past 70% of
-                // the screen width. No velocity-based commit — a
-                // quick flick must never silently delete a row.
-                if -endRaw > UIScreen.main.bounds.width * 0.7 {
-                    commit()
-                } else if -endRaw > revealedWidth * 0.4 {
-                    open()
-                } else {
-                    close()
-                }
-            }
-    }
-
-    /// Drag freely up to the snap-open point, then add resistance so
-    /// over-drag feels weighted instead of just sliding to the edge.
     private func applyRubberBand(to raw: CGFloat) -> CGFloat {
         if raw >= 0 { return 0 }
         if -raw <= revealedWidth { return raw }
@@ -178,5 +123,128 @@ private struct SwipeToDeleteWithTint: ViewModifier {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             onDelete()
         }
+    }
+}
+
+/// UIKit-bridged horizontal-only pan recognizer wrapping arbitrary
+/// SwiftUI content. The hosting view is an ancestor of the SwiftUI
+/// content's hosting controller view, so the recognizer sees touches
+/// that hit anywhere in the wrapped subtree. `cancelsTouchesInView
+/// = false` plus `shouldRecognizeSimultaneouslyWith = true` keeps
+/// tap-on-Button working; `gestureRecognizerShouldBegin` filtering
+/// on velocity direction lets the parent List's vertical scroll
+/// proceed when the user drags vertically.
+private struct HorizontalPanCapture<Content: View>: UIViewRepresentable {
+    let onChanged: (CGFloat) -> Void
+    let onEnded: (CGFloat) -> Void
+    let content: Content
+
+    init(
+        onChanged: @escaping (CGFloat) -> Void,
+        onEnded: @escaping (CGFloat) -> Void,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.onChanged = onChanged
+        self.onEnded = onEnded
+        self.content = content()
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onChanged: onChanged, onEnded: onEnded)
+    }
+
+    func makeUIView(context: Context) -> ContainerView {
+        let host = UIHostingController(rootView: AnyView(content))
+        host.view.backgroundColor = .clear
+        // Do NOT use `host.sizingOptions = [.intrinsicContentSize]` —
+        // SwiftUI text-heavy content reports a wide unbounded
+        // natural width as its intrinsic size, which leaks through
+        // the wrapper and makes some rows render edge-to-edge with
+        // no pill background. We size via `sizeThatFits` instead so
+        // the host always lays out at the width SwiftUI proposes.
+
+        let container = ContainerView()
+        container.backgroundColor = .clear
+        container.addSubview(host.view)
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            host.view.topAnchor.constraint(equalTo: container.topAnchor),
+            host.view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            host.view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            host.view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+        container.host = host
+
+        let pan = UIPanGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handle(_:))
+        )
+        pan.delegate = context.coordinator
+        pan.cancelsTouchesInView = false
+        container.addGestureRecognizer(pan)
+
+        return container
+    }
+
+    func updateUIView(_ uiView: ContainerView, context: Context) {
+        uiView.host?.rootView = AnyView(content)
+        context.coordinator.onChanged = onChanged
+        context.coordinator.onEnded = onEnded
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        uiView: ContainerView,
+        context: Context
+    ) -> CGSize? {
+        guard let host = uiView.host else { return nil }
+        let proposedWidth = proposal.width ?? UIView.layoutFittingCompressedSize.width
+        let measured = host.sizeThatFits(
+            in: CGSize(width: proposedWidth, height: UIView.layoutFittingCompressedSize.height)
+        )
+        return CGSize(width: proposedWidth, height: measured.height)
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var onChanged: (CGFloat) -> Void
+        var onEnded: (CGFloat) -> Void
+
+        init(
+            onChanged: @escaping (CGFloat) -> Void,
+            onEnded: @escaping (CGFloat) -> Void
+        ) {
+            self.onChanged = onChanged
+            self.onEnded = onEnded
+        }
+
+        @objc func handle(_ g: UIPanGestureRecognizer) {
+            let t = g.translation(in: g.view).x
+            switch g.state {
+            case .changed:
+                onChanged(t)
+            case .ended, .cancelled, .failed:
+                onEnded(t)
+            default:
+                break
+            }
+        }
+
+        func gestureRecognizerShouldBegin(_ g: UIGestureRecognizer) -> Bool {
+            guard let pan = g as? UIPanGestureRecognizer else { return true }
+            let v = pan.velocity(in: pan.view)
+            return abs(v.x) > abs(v.y) * 1.5
+        }
+
+        func gestureRecognizer(
+            _ g: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer
+        ) -> Bool {
+            return true
+        }
+    }
+
+    final class ContainerView: UIView {
+        var host: UIHostingController<AnyView>?
     }
 }

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -82,11 +82,23 @@ struct ContentView: View {
         .preferredColorScheme((ColorSchemePref(rawValue: schemePrefRaw) ?? .system).resolved)
         .activeSection(router.currentSection)
         .coordinateSpace(name: edgeCoordinateSpace)
-        // Edge-swipe-to-open lives on the root so it works on every primary
-        // surface. `simultaneousGesture` keeps taps reaching the underlying
-        // views; only drags whose start lands in the leading 20pt strip
-        // hijack the gesture to drag the drawer.
-        .simultaneousGesture(edgeOpenGesture)
+        // Edge-swipe-to-open is scoped to a 20pt-wide leading strip overlay,
+        // NOT a screen-wide `.simultaneousGesture`. A root-level DragGesture
+        // with `minimumDistance: 8` claims arbitration on any 8pt drag — that
+        // starves the inner List's vertical scroll, even with the
+        // `startLocation.x <= edgeSwipeWidth` guard (the guard runs after
+        // the gesture has already won). Constraining the gesture host to a
+        // thin leading strip leaves the rest of the screen free for the
+        // List's native scroll + `.swipeActions` arbitration. (#79)
+        .overlay(alignment: .leading) {
+            Color.clear
+                .frame(width: edgeSwipeWidth)
+                .frame(maxHeight: .infinity)
+                .contentShape(Rectangle())
+                .gesture(edgeOpenGesture)
+                .ignoresSafeArea()
+                .allowsHitTesting(!router.drawerOpen)
+        }
     }
 
     private var edgeOpenGesture: some Gesture {


### PR DESCRIPTION
## Summary

- Constrain the drawer edge-swipe to a 20pt leading-edge overlay so it stops claiming any 8pt drag anywhere on screen.
- Replace the row-level SwiftUI `.highPriorityGesture(DragGesture)` with a UIKit-bridged `UIPanGestureRecognizer` that filters horizontal-dominant velocity, so vertical drags fall through to the parent List's scroll cleanly.
- Switch the bridged hosting wrapper to use `sizeThatFits` (instead of leaking the SwiftUI content's unbounded natural width as intrinsic size) so rows respect the row width SwiftUI proposes.

Closes #79

## Test plan

- [x] Build (`xcodebuild` Debug + Release archive both succeed)
- [x] Simulator: vertical drag over rows scrolls the list
- [x] Simulator: tap on row opens the note (taps not blocked by the recognizer)
- [x] Simulator: list rows render with consistent pill backgrounds at uniform width
- [ ] Real device walk: scroll over rows on Notes / Tasks / Lists
- [ ] Real device walk: swipe-left reveals 52pt circular red trash, full-swipe deletes
- [ ] Real device walk: edge-swipe-from-leading-edge still opens the drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)