### PR TITLE
feat(ios): consistent row height for notes on main page

### DIFF
--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -334,18 +334,19 @@ private struct NoteRow: View {
     let onTap: () -> Void
 
     var body: some View {
-        Button(action: onTap) {
+        let trimmedBody = (note.content ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasBody = !trimmedBody.isEmpty
+
+        return Button(action: onTap) {
             VStack(alignment: .leading, spacing: 4) {
                 Text((note.title?.isEmpty == false ? note.title! : "Untitled"))
                     .font(.edBodyMedium)
                     .foregroundStyle(Tokens.ink)
                     .lineLimit(1)
-                if let content = note.content, !content.isEmpty {
-                    Text(content)
-                        .font(.edSubheadline)
-                        .foregroundStyle(Tokens.muted)
-                        .lineLimit(1)
-                }
+                Text(hasBody ? trimmedBody : "No additional text")
+                    .font(.edSubheadline)
+                    .foregroundStyle(hasBody ? Tokens.muted : Tokens.mutedSoft)
+                    .lineLimit(1)
                 Text(note.updatedAt, style: .relative)
                     .font(.edCaption)
                     .foregroundStyle(Tokens.mutedSoft)


### PR DESCRIPTION
## Summary
- Notes rows always render three lines: title, one body line, and the relative timestamp.
- When a note has no body, the body slot now shows "No additional text" in the softer `Tokens.mutedSoft` tone so every row on the main Notes page (and inside folders) is the same height.

## Test plan
- [x] xcodebuild Debug build for iOS Simulator succeeds.
- [x] Installed via `devicectl` to the paired iPhone for on-device verification.
- [ ] Walk the Notes list: rows with body and rows without body share the same height.
- [ ] "No additional text" placeholder reads as muted (lighter than real body content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)