### PR TITLE
feat(ios): notes folder icon top-right; swipe-right pops sub-screens

### DIFF
--- a/mobile/PersonalDashboard/App/AppRouter.swift
+++ b/mobile/PersonalDashboard/App/AppRouter.swift
@@ -52,6 +52,14 @@ final class AppRouter {
     /// back to nil so it doesn't fire again on the next appearance.
     var focus: ActivityFocus?
 
+    /// When non-nil, an edge-swipe-from-leading on the active surface routes
+    /// through this handler instead of opening the side drawer. Notes and
+    /// Lists set this when the user is inside a sub-screen (folder, note,
+    /// list detail) so swipe-right pops back to the section root, mirroring
+    /// the iOS-native interactive back gesture. Cleared when the surface
+    /// returns to its root.
+    var leadingEdgeBackHandler: (() -> Void)?
+
     /// Open the side drawer and dismiss any active keyboard so the drawer
     /// renders cleanly above the chat input (issue #54). Both the top-bar
     /// menu tap and the edge-swipe gesture route through here so the

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -119,6 +119,14 @@ struct ContentView: View {
                         for: nil
                     )
                 }
+                // When the active surface owns the edge swipe (it's inside
+                // a sub-screen that should pop on right-swipe), suppress the
+                // drawer peek mid-drag — the gesture is being recognised as
+                // a back swipe, not a drawer open.
+                if router.leadingEdgeBackHandler != nil {
+                    router.drawerDragOffset = 0
+                    return
+                }
                 let drawerWidth = min(280, UIScreen.main.bounds.width * 0.8)
                 router.drawerDragOffset = min(drawerWidth, value.translation.width)
             }
@@ -135,15 +143,22 @@ struct ContentView: View {
                 let drawerWidth = min(280, UIScreen.main.bounds.width * 0.8)
                 let translation = value.translation.width
                 let velocity = value.predictedEndTranslation.width - translation
-                let shouldOpen = translation > drawerWidth * 0.4 || velocity > 500
+                let shouldCommit = translation > drawerWidth * 0.4 || velocity > 500
                 withAnimation(.easeOut(duration: 0.2)) {
                     router.drawerDragOffset = 0
-                    if shouldOpen {
-                        // Keyboard was already dismissed in onChanged; flip
-                        // the flag inside the same animation block as the
-                        // drag-offset reset so the panel snaps to its open
-                        // position smoothly.
-                        router.drawerOpen = true
+                    if shouldCommit {
+                        if let backHandler = router.leadingEdgeBackHandler {
+                            // Sub-screen active: pop back instead of opening
+                            // the drawer. The handler runs its own animation
+                            // for the screen swap.
+                            backHandler()
+                        } else {
+                            // Keyboard was already dismissed in onChanged; flip
+                            // the flag inside the same animation block as the
+                            // drag-offset reset so the panel snaps to its open
+                            // position smoothly.
+                            router.drawerOpen = true
+                        }
                     }
                 }
             }

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -62,7 +62,16 @@ struct ListsView: View {
             if router.focus?.section == .lists {
                 router.focus = nil
             }
+            syncBackHandler()
         }
+        .onDisappear {
+            // Don't strip a back handler we didn't install — another surface
+            // may have set its own when this view was off-screen.
+            if selectedListId != nil {
+                router.leadingEdgeBackHandler = nil
+            }
+        }
+        .onChange(of: selectedListId) { _, _ in syncBackHandler() }
         .sheet(isPresented: $showingNewList) {
             NewListSheet(viewModel: viewModel)
         }
@@ -75,6 +84,24 @@ struct ListsView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(viewModel.errorMessage ?? "")
+        }
+    }
+
+    // MARK: - Back-swipe wiring
+    //
+    // Captures the @State binding so the closure stored on the router can
+    // pop the list detail back to the lists root. Mirror of NotesView's
+    // syncBackHandler — see that file for the rationale.
+    private func syncBackHandler() {
+        let listBinding = $selectedListId
+        if selectedListId != nil {
+            router.leadingEdgeBackHandler = {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    listBinding.wrappedValue = nil
+                }
+            }
+        } else {
+            router.leadingEdgeBackHandler = nil
         }
     }
 

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -49,25 +49,35 @@ struct NotesView: View {
                         title: "Notes",
                         onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                     )
+                    // Create-folder affordance overlays the top-right of the
+                    // list area so it doesn't take layout space — the
+                    // Folders/Unfiled sections start at the same vertical
+                    // level as Lists/Tasks. The button sits between the top
+                    // bar (with the AS pip) and the first row of content.
                     rootList
+                        .overlay(alignment: .topTrailing) {
+                            Button {
+                                showingNewFolder = true
+                            } label: {
+                                Image(systemName: "folder.badge.plus")
+                                    .font(.system(size: 18, weight: .regular))
+                                    .foregroundStyle(Tokens.ink)
+                                    .frame(width: 44, height: 44)
+                                    .contentShape(Rectangle())
+                            }
+                            .accessibilityLabel("New folder")
+                            .padding(.trailing, Space.sm)
+                        }
                 }
             }
 
             if selectedNoteId == nil && selectedFolder == nil {
-                HStack(spacing: Space.sm) {
-                    Button {
-                        showingNewFolder = true
-                    } label: {
-                        Image(systemName: "folder.badge.plus")
-                    }
-                    .buttonStyle(EdIconCircleButtonStyle(kind: .secondary))
-                    Button {
-                        Task { await createBlankNote(folderId: nil) }
-                    } label: {
-                        Image(systemName: "plus")
-                    }
-                    .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
+                Button {
+                    Task { await createBlankNote(folderId: nil) }
+                } label: {
+                    Image(systemName: "plus")
                 }
+                .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
                 .padding(.trailing, 22)
                 .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
@@ -90,7 +100,18 @@ struct NotesView: View {
             if router.focus?.section == .notes {
                 router.focus = nil
             }
+            syncBackHandler()
         }
+        .onDisappear {
+            // Don't strip a back handler we didn't install. NotesView appears
+            // and disappears when toggled in/out of the surface stack; another
+            // surface may have set its own handler in the meantime.
+            if selectedNoteId != nil || selectedFolder != nil {
+                router.leadingEdgeBackHandler = nil
+            }
+        }
+        .onChange(of: selectedNoteId) { _, _ in syncBackHandler() }
+        .onChange(of: selectedFolder?.id) { _, _ in syncBackHandler() }
         .sheet(isPresented: $showingNewFolder) {
             NewFolderSheet(viewModel: viewModel)
         }
@@ -220,6 +241,33 @@ struct NotesView: View {
     private func createBlankNote(folderId: UUID?) async {
         guard let new = await viewModel.createNote(title: nil, content: nil, folderId: folderId) else { return }
         withAnimation(.easeOut(duration: 0.2)) { selectedNoteId = new.id }
+    }
+
+    // MARK: - Back-swipe wiring
+    //
+    // Captures @State via Bindings so the closures stored on the router can
+    // mutate this view's selection state. Setting `wrappedValue = nil` writes
+    // back through to @State storage, mirroring how SwiftUI passes bindings
+    // around. Re-runs whenever sub-state changes so the handler always pops
+    // the most-nested screen first (note before folder).
+    private func syncBackHandler() {
+        let noteBinding = $selectedNoteId
+        let folderBinding = $selectedFolder
+        if selectedNoteId != nil {
+            router.leadingEdgeBackHandler = {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    noteBinding.wrappedValue = nil
+                }
+            }
+        } else if selectedFolder != nil {
+            router.leadingEdgeBackHandler = {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    folderBinding.wrappedValue = nil
+                }
+            }
+        } else {
+            router.leadingEdgeBackHandler = nil
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Notes: create-folder icon moved off the bottom-right cluster and overlaid on the top-right of the list area, so Folders / Unfiled still start at the same vertical level as Lists / Tasks. Bottom-right now shows only the primary `+` FAB.
- Notes & Lists: edge-swipe-from-leading inside a folder, note, or list detail pops back to the section root instead of opening the side drawer. From the section root the gesture opens the drawer as before. Drawer no longer peeks mid-drag while a sub-screen owns the back gesture.

## How it works
- `AppRouter.leadingEdgeBackHandler: (() -> Void)?` is set by NotesView / ListsView whenever they push into a sub-screen, and cleared on return.
- `ContentView`'s edge-swipe gesture suppresses the drawer peek mid-drag when a back handler is registered, and on commit routes to the handler instead of `router.drawerOpen = true`.

## Test plan
- [x] iOS Debug build succeeds (xcodebuild).
- [x] Installed on iPhone 16 Pro Max via OTA.
- [x] Notes root: folder icon at top-right; FOLDERS section starts at the same Y as Lists root.
- [x] Inside a folder → swipe-right pops to Notes root.
- [x] Inside a note → swipe-right pops to Notes root.
- [x] Inside a list → swipe-right pops to Lists root.
- [x] From the Notes / Lists / Tasks roots → swipe-right still opens the drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)