### PR TITLE
chore(ota): allow provisioning updates on archive step

### DIFF
--- a/mobile/ota/ship-lan.sh
+++ b/mobile/ota/ship-lan.sh
@@ -147,6 +147,7 @@ xcodebuild \
     MARKETING_VERSION="${SHORT_VERSION}" \
     OTA_API_URL="${API_URL}" \
     ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+    -allowProvisioningUpdates \
     archive \
     2>&1 | grep -E "(error:|warning: .*\.swift:|\*\* )" || true
 


### PR DESCRIPTION
## Summary
- Add `-allowProvisioningUpdates` to the `xcodebuild archive` step in `mobile/ota/ship-lan.sh`, mirroring what the export step already does.
- Without this, free personal-team builds fail at archive once the 7-day profile expires, because xcodebuild can't regenerate the profile during archive.

## Test plan
- [x] Re-ran `bash mobile/ota/ship-lan.sh` after the change. Archive completed, IPA produced, direct install via `devicectl` succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)