### PR TITLE
feat(ios): drop All Lists header so empty state aligns with Notes/Tasks

### DIFF
--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -110,33 +110,29 @@ struct ListsView: View {
         // into native `.swipeActions`. Paper aesthetic preserved via clear
         // row backgrounds, hidden separators, and `.scrollContentBackground`.
         List {
-            Section {
-                if viewModel.lists.isEmpty && !viewModel.isLoading {
-                    Text("No lists yet. Tap + to start.")
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.muted)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, Space.xxxl)
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(top: 0, leading: Space.lg, bottom: 0, trailing: Space.lg))
-                } else {
-                    ForEach(viewModel.lists) { list in
-                        ListSummaryRow(list: list) {
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                selectedListId = list.id
-                            }
+            if viewModel.lists.isEmpty && !viewModel.isLoading {
+                Text("No lists yet. Tap + to start.")
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.muted)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, Space.xxxl)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: 0, leading: Space.lg, bottom: 0, trailing: Space.lg))
+            } else {
+                ForEach(viewModel.lists) { list in
+                    ListSummaryRow(list: list) {
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            selectedListId = list.id
                         }
-                        .swipeToDeleteTrash {
-                            Task { await viewModel.delete(list) }
-                        }
-                        .listRowBackground(Color.clear)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                     }
+                    .swipeToDeleteTrash {
+                        Task { await viewModel.delete(list) }
+                    }
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
                 }
-            } header: {
-                sectionEyebrow("All Lists")
             }
 
             Color.clear


### PR DESCRIPTION
## Summary
- Removes the "All Lists" section eyebrow from the Lists root view so it matches Notes and Tasks (which have no "All Notes" / "All Tasks" header).
- The "No lists yet. Tap + to start." empty state now sits at the same vertical offset from the TopBar as the empty states on the sibling pages.
- Populated state still renders rows with the existing styling (clear background, hidden separators, swipe-to-delete).

Closes #89

## Test plan
- [ ] On a real device, open the Lists tab while empty: confirm no "All Lists" header is visible and "No lists yet. Tap + to start." sits at the same height as the empty copy on Notes and Tasks.
- [ ] Add a list: rows render with existing styling, swipe-to-delete still works.
- [ ] Delete back to empty: empty state returns at the correct height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)