### PR TITLE
feat(ios): rename app to Dexter; tidy Settings page

### DIFF
--- a/mobile/PersonalDashboard/Info.plist
+++ b/mobile/PersonalDashboard/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Deks</string>
+	<string>Dexter</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -34,11 +34,11 @@
 		<string>_http._tcp</string>
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>Deks talks to your Mac dev server over wifi when you're on the same network.</string>
+	<string>Dexter talks to your Mac dev server over wifi when you're on the same network.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Deks listens to your voice so it can transcribe what you say into the chat.</string>
+	<string>Dexter listens to your voice so it can transcribe what you say into the chat.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>Deks transcribes your voice into chat messages on-device. Audio never leaves your phone.</string>
+	<string>Dexter transcribes your voice into chat messages on-device. Audio never leaves your phone.</string>
 	<key>OTA_API_URL</key>
 	<string>$(OTA_API_URL)</string>
 	<key>UIAppFonts</key>

--- a/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
@@ -15,9 +15,9 @@ import Foundation
 ///     persisted.
 ///   - failure -> dialog surfaces a brief error.
 struct CaptureToDashboardIntent: AppIntent {
-    static var title: LocalizedStringResource = "Capture to Deks"
+    static var title: LocalizedStringResource = "Capture to Dexter"
     static var description = IntentDescription(
-        "Add a task, note, or list to Deks from text or voice. Runs on-device against your local data, no server hop."
+        "Add a task, note, or list to Dexter from text or voice. Runs on-device against your local data, no server hop."
     )
 
     /// Stay backgrounded so the side button feels instant and the user
@@ -37,7 +37,7 @@ struct CaptureToDashboardIntent: AppIntent {
     var input: String
 
     static var parameterSummary: some ParameterSummary {
-        Summary("Capture \(\.$input) to Deks")
+        Summary("Capture \(\.$input) to Dexter")
     }
 
     func perform() async throws -> some IntentResult & ProvidesDialog {

--- a/mobile/PersonalDashboard/Intents/DashboardAppShortcuts.swift
+++ b/mobile/PersonalDashboard/Intents/DashboardAppShortcuts.swift
@@ -1,13 +1,13 @@
 import AppIntents
 
 /// Registers our App Intents with iOS so they appear automatically in:
-///   - the Shortcuts app under "Deks"
+///   - the Shortcuts app under "Dexter"
 ///   - the Action Button picker (Settings -> Action Button -> Shortcut)
 ///   - Spotlight / Siri voice triggers via the listed phrases
 ///
 /// The intended runtime path is a user-built 3-step Shortcut:
 ///   1. Dictate Text (after short pause)
-///   2. Capture to Deks (input = Dictated Text)
+///   2. Capture to Dexter (input = Dictated Text)
 ///   3. Show Notification (text = Result of the previous step)
 ///
 /// Bound to the Action Button (or back-tap, or a Lock Screen control)

--- a/mobile/PersonalDashboard/Services/SpeechTranscriber.swift
+++ b/mobile/PersonalDashboard/Services/SpeechTranscriber.swift
@@ -104,12 +104,12 @@ final class SpeechTranscriber {
         // before we touch the audio engine, otherwise `installTap` traps.
         let speechOK = await Self.requestSpeechAuthorization()
         guard speechOK else {
-            errorMessage = "Enable Speech Recognition for Deks in Settings."
+            errorMessage = "Enable Speech Recognition for Dexter in Settings."
             return
         }
         let micOK = await Self.requestMicrophonePermission()
         guard micOK else {
-            errorMessage = "Enable Microphone access for Deks in Settings."
+            errorMessage = "Enable Microphone access for Dexter in Settings."
             return
         }
 

--- a/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
@@ -4,8 +4,6 @@ struct SettingsView: View {
     @Bindable var router: AppRouter
     @Binding var schemePref: ColorSchemePref
 
-    @State private var showingCacheCleared = false
-
     var body: some View {
         ZStack {
             Tokens.paper.ignoresSafeArea()
@@ -19,8 +17,6 @@ struct SettingsView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: Space.xl) {
                         appearanceSection
-                        connectionSection
-                        cacheSection
                         aboutSection
                         footer
                     }
@@ -31,35 +27,6 @@ struct SettingsView: View {
             }
         }
         .activeSection(.settings)
-        .alert("Cache cleared",
-               isPresented: $showingCacheCleared) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text("Cached tasks, notes, lists, and dashboard stats removed. Pull to refresh on each surface to repopulate.")
-        }
-    }
-
-    private var cacheSection: some View {
-        SettingsSection(title: "Offline cache") {
-            Button {
-                CacheStore.clearAll()
-                showingCacheCleared = true
-            } label: {
-                HStack {
-                    Text("Clear cached data")
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.danger)
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 12, weight: .regular))
-                        .foregroundStyle(Tokens.muted)
-                }
-                .padding(.horizontal, Space.lg)
-                .padding(.vertical, Space.md)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-        }
     }
 
     // MARK: - Sections
@@ -77,40 +44,19 @@ struct SettingsView: View {
         }
     }
 
-    private var connectionSection: some View {
-        SettingsSection(title: "Connection") {
-            VStack(spacing: 0) {
-                SettingsRow(
-                    label: "API base",
-                    value: AppConfig.apiBaseURL.host ?? "—",
-                    detail: AppConfig.apiBaseURL.absoluteString
-                )
-
-                SettingsDivider()
-
-                SettingsRow(
-                    label: "Source",
-                    value: ProcessInfo.processInfo.environment["API_URL"] != nil ? "env override" : "default"
-                )
-            }
-        }
-    }
-
     private var aboutSection: some View {
         SettingsSection(title: "About") {
             VStack(spacing: 0) {
                 SettingsRow(label: "Version", value: shortVersion)
                 SettingsDivider()
                 SettingsRow(label: "Build", value: buildNumber)
-                SettingsDivider()
-                SettingsRow(label: "Bundle", value: Bundle.main.bundleIdentifier ?? "—")
             }
         }
     }
 
     private var footer: some View {
         VStack(spacing: Space.xs) {
-            Text("Dashy")
+            Text("Dexter")
                 .font(.edTitle)
                 .foregroundStyle(Tokens.ink)
             Text("A small place to think and do.")

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -24,7 +24,7 @@ targets:
     info:
       path: PersonalDashboard/Info.plist
       properties:
-        CFBundleDisplayName: Deks
+        CFBundleDisplayName: Dexter
         # Versioning scheme: "a.b.c (d)" — see mobile/ota/ship-lan.sh for the
         # derivation. a.b come from mobile/VERSION; c is auto-derived from
         # git history (commits since VERSION last changed); d is a local
@@ -46,7 +46,7 @@ targets:
           NSAllowsArbitraryLoads: true
         # Triggers the iOS local-network permission prompt the first time
         # the App Intent or main app reaches a LAN IP.
-        NSLocalNetworkUsageDescription: "Deks talks to your Mac dev server over wifi when you're on the same network."
+        NSLocalNetworkUsageDescription: "Dexter talks to your Mac dev server over wifi when you're on the same network."
         # Bonjour service types our launch primer browses for. Required
         # alongside NSLocalNetworkUsageDescription, otherwise the browse
         # silently fails and the prompt never appears.
@@ -55,8 +55,8 @@ targets:
         # Voice input in chat (issue #83). On-device only — audio never
         # leaves the phone. Both keys are required: Speech for transcription,
         # Microphone for the audio capture that feeds it.
-        NSSpeechRecognitionUsageDescription: "Deks transcribes your voice into chat messages on-device. Audio never leaves your phone."
-        NSMicrophoneUsageDescription: "Deks listens to your voice so it can transcribe what you say into the chat."
+        NSSpeechRecognitionUsageDescription: "Dexter transcribes your voice into chat messages on-device. Audio never leaves your phone."
+        NSMicrophoneUsageDescription: "Dexter listens to your voice so it can transcribe what you say into the chat."
         UIAppFonts:
           - Calistoga-Regular.ttf
           - Inter-Regular.ttf


### PR DESCRIPTION
## Summary
- Rename app display name from "Deks" to **Dexter** (`CFBundleDisplayName`, permission prompts, App Intent title/description, Speech/Mic error messages).
- Settings page: drop Connection (server-bound, paused), drop Offline cache (only cleared a vestigial dashboard_stats blob), drop Bundle row in About. Footer now says **Dexter**.
- Net result on Settings: Appearance (Theme) + About (Version + Build) + Dexter footer.

Closes #88

## Test plan
- [x] Built and verified inside the IPA: `CFBundleDisplayName=Dexter`, no "Deks"/"Dashy" strings in the binary, "Capture to Dexter" + Dexter permission strings present.
- [x] Booted iPhone 16 simulator, installed, screenshotted home screen ("Dexter" icon) and Settings page (Appearance + About + Dexter footer, no Connection/Cache/Bundle).
- [x] Direct-installed to physical device via `xcrun devicectl device install app --verbose` after OTA wifi DDI mount kept failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)