### PR TITLE
feat(ios): replace chat empty-state sparkle with animated logo bars

### DIFF
--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -297,162 +297,86 @@ struct ChatView: View {
 }
 
 /// Three pill-capped bars + accent dot mirroring the Deks logo (top 55%,
-/// middle 85%, bottom 70%, dot just past the end of the top bar). While
-/// the chat empty state is showing and the input is untouched, the bar
-/// thickness itself ripples in a horizontal sine wave that travels from
-/// the leading to the trailing edge on loop — the bars stay solid (no
-/// overlay), they just bulge and pinch. The wave snaps flat the moment
-/// the user starts typing.
+/// middle 85%, bottom 70%, dot just past the end of the top bar). The
+/// bars are anchored at the leading edge; each bar's *length* oscillates
+/// continuously around its logo width, with its own period and phase so
+/// the trio feels organic rather than metronomic. The accent dot rides
+/// the right edge of the top bar so the silhouette stays coherent. When
+/// the user starts typing, the bars snap back to exact logo widths.
 private struct LogoBars: View {
     let isAnimating: Bool
 
     private let middleWidth: CGFloat = 48
-    private let baseHeight: CGFloat = 5
-    private let amplitude: CGFloat = 1.0
-    private let wavelength: CGFloat = 18
+    private let barHeight: CGFloat = 5
     private let gap: CGFloat = 4
     private let dotDiameter: CGFloat = 4
     private let topRatio: CGFloat = 55.0 / 85.0
     private let bottomRatio: CGFloat = 70.0 / 85.0
     /// Logo: top bar ends at x=640, dot center at x=700 (delta 60 of 870).
     private let dotGapRatio: CGFloat = 60.0 / 870.0
-    private let cycleSeconds: Double = 2.6
+    /// Maximum length deviation from the logo width, as a fraction.
+    private let modulation: CGFloat = 0.18
 
     var body: some View {
-        let topWidth = middleWidth * topRatio
-        let bottomWidth = middleWidth * bottomRatio
-        let dotLeading = topWidth + middleWidth * dotGapRatio - dotDiameter / 2
-        let rowHeight = baseHeight + amplitude * 2
+        let topBase = middleWidth * topRatio
+        let bottomBase = middleWidth * bottomRatio
+        let maxMiddle = middleWidth * (1 + modulation)
+        let containerWidth = maxMiddle + middleWidth * dotGapRatio + dotDiameter
 
         TimelineView(.animation(minimumInterval: 1.0 / 60.0, paused: !isAnimating)) { ctx in
-            let phase = currentPhase(at: ctx.date)
-            let amp = isAnimating ? amplitude : 0
+            let t = ctx.date.timeIntervalSinceReferenceDate
+            let mod = isAnimating ? modulation : 0
+
+            // Each bar runs on its own period and phase so the three never
+            // line up — keeps the motion feeling unscripted.
+            let topW    = animatedWidth(base: topBase,     time: t, period: 1.70, phase: 0.0, modulation: mod)
+            let middleW = animatedWidth(base: middleWidth, time: t, period: 2.40, phase: 0.6, modulation: mod)
+            let bottomW = animatedWidth(base: bottomBase,  time: t, period: 3.10, phase: 1.2, modulation: mod)
+
+            // Dot rides the right edge of the top bar with the same offset
+            // ratio as the logo (60 / 870 of the middle width).
+            let dotLeading = topW + middleWidth * dotGapRatio - dotDiameter / 2
 
             VStack(alignment: .leading, spacing: gap) {
                 ZStack(alignment: .leading) {
-                    WavyBar(
-                        phase: phase,
-                        amplitude: amp,
-                        wavelength: wavelength,
-                        baseHeight: baseHeight
-                    )
-                    .fill(Tokens.ink)
-                    .frame(width: topWidth, height: rowHeight)
+                    Capsule(style: .continuous)
+                        .fill(Tokens.ink)
+                        .frame(width: topW, height: barHeight)
 
                     Circle()
                         .fill(Tokens.ink)
                         .frame(width: dotDiameter, height: dotDiameter)
                         .offset(x: dotLeading)
                 }
-                .frame(height: rowHeight)
+                .frame(height: barHeight)
 
-                WavyBar(
-                    phase: phase,
-                    amplitude: amp,
-                    wavelength: wavelength,
-                    baseHeight: baseHeight
-                )
-                .fill(Tokens.ink)
-                .frame(width: middleWidth, height: rowHeight)
+                Capsule(style: .continuous)
+                    .fill(Tokens.ink)
+                    .frame(width: middleW, height: barHeight)
 
-                WavyBar(
-                    phase: phase,
-                    amplitude: amp,
-                    wavelength: wavelength,
-                    baseHeight: baseHeight
-                )
-                .fill(Tokens.ink)
-                .frame(width: bottomWidth, height: rowHeight)
+                Capsule(style: .continuous)
+                    .fill(Tokens.ink)
+                    .frame(width: bottomW, height: barHeight)
             }
-            .frame(width: middleWidth + dotDiameter, alignment: .leading)
+            .frame(width: containerWidth, alignment: .leading)
         }
     }
 
-    /// Phase advances negatively over time so the wave pattern travels from
-    /// the leading edge toward the trailing edge.
-    private func currentPhase(at date: Date) -> Double {
-        let t = date.timeIntervalSinceReferenceDate
-        let normalised = t.truncatingRemainder(dividingBy: cycleSeconds) / cycleSeconds
-        return -normalised * 2 * .pi
-    }
-}
-
-/// A pill-shaped bar whose thickness varies along its length following a
-/// sine wave. `phase` shifts the wave horizontally; advancing it negatively
-/// over time makes the bulge travel left-to-right. Amplitude tapers to
-/// zero at both ends so the wavy interior meets clean semicircular pill
-/// caps.
-private struct WavyBar: Shape {
-    var phase: Double
-    var amplitude: CGFloat
-    var wavelength: CGFloat
-    var baseHeight: CGFloat
-    var endTaper: CGFloat = 0.22
-
-    var animatableData: Double {
-        get { phase }
-        set { phase = newValue }
-    }
-
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        let r = baseHeight / 2
-        let midY = rect.midY
-        let leftCenterX = rect.minX + r
-        let rightCenterX = rect.maxX - r
-        let usableWidth = max(rightCenterX - leftCenterX, 0.0001)
-        let stepCount = max(Int(usableWidth.rounded()) * 2, 24)
-
-        func halfThickness(at x: CGFloat) -> CGFloat {
-            let local = x - leftCenterX
-            let normalised = local / usableWidth
-            let taper: CGFloat
-            if normalised < endTaper {
-                taper = max(0, normalised / endTaper)
-            } else if normalised > 1 - endTaper {
-                taper = max(0, (1 - normalised) / endTaper)
-            } else {
-                taper = 1
-            }
-            let s = sin(2 * .pi * Double(local) / Double(wavelength) + phase)
-            return r + amplitude * CGFloat(s) * taper
-        }
-
-        // Start of left semicircle (top of cap).
-        path.move(to: CGPoint(x: leftCenterX, y: midY - r))
-
-        // Top edge: leading center -> trailing center.
-        for i in 1...stepCount {
-            let x = leftCenterX + usableWidth * CGFloat(i) / CGFloat(stepCount)
-            path.addLine(to: CGPoint(x: x, y: midY - halfThickness(at: x)))
-        }
-
-        // Right pill cap.
-        path.addArc(
-            center: CGPoint(x: rightCenterX, y: midY),
-            radius: r,
-            startAngle: .degrees(-90),
-            endAngle: .degrees(90),
-            clockwise: false
-        )
-
-        // Bottom edge: trailing center -> leading center.
-        for i in stride(from: stepCount - 1, through: 0, by: -1) {
-            let x = leftCenterX + usableWidth * CGFloat(i) / CGFloat(stepCount)
-            path.addLine(to: CGPoint(x: x, y: midY + halfThickness(at: x)))
-        }
-
-        // Left pill cap, closing the path.
-        path.addArc(
-            center: CGPoint(x: leftCenterX, y: midY),
-            radius: r,
-            startAngle: .degrees(90),
-            endAngle: .degrees(270),
-            clockwise: false
-        )
-
-        path.closeSubpath()
-        return path
+    /// Width of a bar at time `t`. A primary sine carries the breath, a
+    /// shorter secondary sine adds wobble so the cycle never reads as a
+    /// clean sinusoid.
+    private func animatedWidth(
+        base: CGFloat,
+        time t: Double,
+        period: Double,
+        phase: Double,
+        modulation: CGFloat
+    ) -> CGFloat {
+        guard modulation > 0 else { return base }
+        let primary = sin(2 * .pi * t / period + phase)
+        let wobble = sin(2 * .pi * t / (period * 0.62) + phase * 1.4) * 0.45
+        let combined = CGFloat((primary + wobble) / 1.45)
+        return base * (1 + modulation * combined)
     }
 }
 

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -298,85 +298,161 @@ struct ChatView: View {
 
 /// Three pill-capped bars + accent dot mirroring the Deks logo (top 55%,
 /// middle 85%, bottom 70%, dot just past the end of the top bar). While
-/// the chat empty state is showing and the input is untouched, a soft
-/// highlight travels left-to-right across each bar on a staggered loop —
-/// the bars themselves stay put. The shimmer pauses the moment the user
-/// starts typing.
+/// the chat empty state is showing and the input is untouched, the bar
+/// thickness itself ripples in a horizontal sine wave that travels from
+/// the leading to the trailing edge on loop — the bars stay solid (no
+/// overlay), they just bulge and pinch. The wave snaps flat the moment
+/// the user starts typing.
 private struct LogoBars: View {
     let isAnimating: Bool
 
     private let middleWidth: CGFloat = 48
-    private let barHeight: CGFloat = 5
+    private let baseHeight: CGFloat = 5
+    private let amplitude: CGFloat = 1.0
+    private let wavelength: CGFloat = 18
     private let gap: CGFloat = 4
     private let dotDiameter: CGFloat = 4
     private let topRatio: CGFloat = 55.0 / 85.0
     private let bottomRatio: CGFloat = 70.0 / 85.0
     /// Logo: top bar ends at x=640, dot center at x=700 (delta 60 of 870).
     private let dotGapRatio: CGFloat = 60.0 / 870.0
-    private let cycle: Double = 2.4
-    private let stagger: Double = 0.12
+    private let cycleSeconds: Double = 2.6
 
     var body: some View {
         let topWidth = middleWidth * topRatio
         let bottomWidth = middleWidth * bottomRatio
         let dotLeading = topWidth + middleWidth * dotGapRatio - dotDiameter / 2
+        let rowHeight = baseHeight + amplitude * 2
 
         TimelineView(.animation(minimumInterval: 1.0 / 60.0, paused: !isAnimating)) { ctx in
-            let phase = isAnimating ? loopPhase(at: ctx.date) : -1
+            let phase = currentPhase(at: ctx.date)
+            let amp = isAnimating ? amplitude : 0
 
             VStack(alignment: .leading, spacing: gap) {
                 ZStack(alignment: .leading) {
-                    shimmerBar(width: topWidth, phase: phase)
+                    WavyBar(
+                        phase: phase,
+                        amplitude: amp,
+                        wavelength: wavelength,
+                        baseHeight: baseHeight
+                    )
+                    .fill(Tokens.ink)
+                    .frame(width: topWidth, height: rowHeight)
+
                     Circle()
                         .fill(Tokens.ink)
                         .frame(width: dotDiameter, height: dotDiameter)
                         .offset(x: dotLeading)
                 }
-                .frame(height: barHeight)
+                .frame(height: rowHeight)
 
-                shimmerBar(width: middleWidth, phase: shifted(phase, by: -stagger))
-                shimmerBar(width: bottomWidth, phase: shifted(phase, by: -stagger * 2))
+                WavyBar(
+                    phase: phase,
+                    amplitude: amp,
+                    wavelength: wavelength,
+                    baseHeight: baseHeight
+                )
+                .fill(Tokens.ink)
+                .frame(width: middleWidth, height: rowHeight)
+
+                WavyBar(
+                    phase: phase,
+                    amplitude: amp,
+                    wavelength: wavelength,
+                    baseHeight: baseHeight
+                )
+                .fill(Tokens.ink)
+                .frame(width: bottomWidth, height: rowHeight)
             }
             .frame(width: middleWidth + dotDiameter, alignment: .leading)
         }
     }
 
-    private func loopPhase(at date: Date) -> Double {
+    /// Phase advances negatively over time so the wave pattern travels from
+    /// the leading edge toward the trailing edge.
+    private func currentPhase(at date: Date) -> Double {
         let t = date.timeIntervalSinceReferenceDate
-        return t.truncatingRemainder(dividingBy: cycle) / cycle
+        let normalised = t.truncatingRemainder(dividingBy: cycleSeconds) / cycleSeconds
+        return -normalised * 2 * .pi
+    }
+}
+
+/// A pill-shaped bar whose thickness varies along its length following a
+/// sine wave. `phase` shifts the wave horizontally; advancing it negatively
+/// over time makes the bulge travel left-to-right. Amplitude tapers to
+/// zero at both ends so the wavy interior meets clean semicircular pill
+/// caps.
+private struct WavyBar: Shape {
+    var phase: Double
+    var amplitude: CGFloat
+    var wavelength: CGFloat
+    var baseHeight: CGFloat
+    var endTaper: CGFloat = 0.22
+
+    var animatableData: Double {
+        get { phase }
+        set { phase = newValue }
     }
 
-    private func shifted(_ phase: Double, by offset: Double) -> Double {
-        guard phase >= 0 else { return phase }
-        let p = phase + offset
-        return p - floor(p)
-    }
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let r = baseHeight / 2
+        let midY = rect.midY
+        let leftCenterX = rect.minX + r
+        let rightCenterX = rect.maxX - r
+        let usableWidth = max(rightCenterX - leftCenterX, 0.0001)
+        let stepCount = max(Int(usableWidth.rounded()) * 2, 24)
 
-    /// A bar with a soft brighter band sliding from leading to trailing edge.
-    /// `phase` ranges 0..1 across one cycle; <0 means "paused, no shimmer".
-    private func shimmerBar(width target: CGFloat, phase: Double) -> some View {
-        let bandWidth = target * 0.55
-        let bandX = -bandWidth + (target + bandWidth) * max(phase, 0)
-
-        return Capsule(style: .continuous)
-            .fill(Tokens.ink)
-            .frame(width: target, height: barHeight)
-            .overlay(alignment: .leading) {
-                if phase >= 0 {
-                    LinearGradient(
-                        stops: [
-                            .init(color: Color.clear,           location: 0.0),
-                            .init(color: Tokens.paper.opacity(0.55), location: 0.5),
-                            .init(color: Color.clear,           location: 1.0)
-                        ],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    )
-                    .frame(width: bandWidth, height: barHeight)
-                    .offset(x: bandX)
-                }
+        func halfThickness(at x: CGFloat) -> CGFloat {
+            let local = x - leftCenterX
+            let normalised = local / usableWidth
+            let taper: CGFloat
+            if normalised < endTaper {
+                taper = max(0, normalised / endTaper)
+            } else if normalised > 1 - endTaper {
+                taper = max(0, (1 - normalised) / endTaper)
+            } else {
+                taper = 1
             }
-            .clipShape(Capsule(style: .continuous))
+            let s = sin(2 * .pi * Double(local) / Double(wavelength) + phase)
+            return r + amplitude * CGFloat(s) * taper
+        }
+
+        // Start of left semicircle (top of cap).
+        path.move(to: CGPoint(x: leftCenterX, y: midY - r))
+
+        // Top edge: leading center -> trailing center.
+        for i in 1...stepCount {
+            let x = leftCenterX + usableWidth * CGFloat(i) / CGFloat(stepCount)
+            path.addLine(to: CGPoint(x: x, y: midY - halfThickness(at: x)))
+        }
+
+        // Right pill cap.
+        path.addArc(
+            center: CGPoint(x: rightCenterX, y: midY),
+            radius: r,
+            startAngle: .degrees(-90),
+            endAngle: .degrees(90),
+            clockwise: false
+        )
+
+        // Bottom edge: trailing center -> leading center.
+        for i in stride(from: stepCount - 1, through: 0, by: -1) {
+            let x = leftCenterX + usableWidth * CGFloat(i) / CGFloat(stepCount)
+            path.addLine(to: CGPoint(x: x, y: midY + halfThickness(at: x)))
+        }
+
+        // Left pill cap, closing the path.
+        path.addArc(
+            center: CGPoint(x: leftCenterX, y: midY),
+            radius: r,
+            startAngle: .degrees(90),
+            endAngle: .degrees(270),
+            clockwise: false
+        )
+
+        path.closeSubpath()
+        return path
     }
 }
 

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -294,29 +294,50 @@ struct ChatView: View {
     }
 }
 
-/// Three pill-capped horizontal bars mirroring the Deks logo (top 55%,
-/// middle 85%, bottom 70%). On first appearance each bar sweeps out from
-/// the leading edge to its target width with a small stagger between them.
+/// Three pill-capped horizontal bars + accent dot mirroring the Deks logo
+/// (top 55%, middle 85%, bottom 70%, dot just past the end of the top bar).
+/// On appear each bar sweeps from the leading edge to its target width with
+/// a left-to-right stagger; the dot fades in once the bars have settled.
 private struct LogoBars: View {
-    private let middleWidth: CGFloat = 96
-    private let barHeight: CGFloat = 10
+    private let middleWidth: CGFloat = 72
+    private let barHeight: CGFloat = 8
+    private let gap: CGFloat = 6
     private let topRatio: CGFloat = 55.0 / 85.0
     private let bottomRatio: CGFloat = 70.0 / 85.0
+    /// Logo: top bar ends at x=640, dot center at x=700 (delta 60 of 870).
+    private let dotGapRatio: CGFloat = 60.0 / 870.0
+    private let dotDiameter: CGFloat = 6
 
     @State private var revealed = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Space.sm) {
-            bar(width: middleWidth * topRatio, delay: 0.00)
-            bar(width: middleWidth,            delay: 0.08)
-            bar(width: middleWidth * bottomRatio, delay: 0.16)
+        let topWidth = middleWidth * topRatio
+        let bottomWidth = middleWidth * bottomRatio
+        let dotLeading = topWidth + middleWidth * dotGapRatio - dotDiameter / 2
+
+        VStack(alignment: .leading, spacing: gap) {
+            ZStack(alignment: .leading) {
+                bar(width: topWidth, delay: 0.00)
+                Circle()
+                    .fill(Tokens.ink)
+                    .frame(width: dotDiameter, height: dotDiameter)
+                    .offset(x: dotLeading)
+                    .opacity(revealed ? 1 : 0)
+                    .scaleEffect(revealed ? 1 : 0.4, anchor: .center)
+                    .animation(
+                        .easeOut(duration: 0.35).delay(0.45),
+                        value: revealed
+                    )
+            }
+            .frame(height: barHeight)
+
+            bar(width: middleWidth, delay: 0.15)
+            bar(width: bottomWidth, delay: 0.30)
         }
-        .frame(width: middleWidth, alignment: .leading)
+        .frame(width: middleWidth + dotDiameter, alignment: .leading)
         .onAppear {
             revealed = false
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                revealed = true
-            }
+            DispatchQueue.main.async { revealed = true }
         }
     }
 
@@ -326,7 +347,7 @@ private struct LogoBars: View {
             .frame(width: revealed ? target : 0, height: barHeight)
             .frame(width: target, alignment: .leading)
             .animation(
-                .spring(response: 0.55, dampingFraction: 0.85).delay(delay),
+                .easeOut(duration: 0.55).delay(delay),
                 value: revealed
             )
     }

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -177,7 +177,9 @@ struct ChatView: View {
             Spacer(minLength: Space.xxxl)
 
             VStack(spacing: Space.lg) {
-                LogoBars()
+                LogoBars(
+                    isAnimating: viewModel.draftInput.trimmingCharacters(in: .whitespaces).isEmpty
+                )
 
                 VStack(spacing: Space.md) {
                     Text("What can I help you organize?")
@@ -294,62 +296,87 @@ struct ChatView: View {
     }
 }
 
-/// Three pill-capped horizontal bars + accent dot mirroring the Deks logo
-/// (top 55%, middle 85%, bottom 70%, dot just past the end of the top bar).
-/// On appear each bar sweeps from the leading edge to its target width with
-/// a left-to-right stagger; the dot fades in once the bars have settled.
+/// Three pill-capped bars + accent dot mirroring the Deks logo (top 55%,
+/// middle 85%, bottom 70%, dot just past the end of the top bar). While
+/// the chat empty state is showing and the input is untouched, a soft
+/// highlight travels left-to-right across each bar on a staggered loop —
+/// the bars themselves stay put. The shimmer pauses the moment the user
+/// starts typing.
 private struct LogoBars: View {
-    private let middleWidth: CGFloat = 72
-    private let barHeight: CGFloat = 8
-    private let gap: CGFloat = 6
+    let isAnimating: Bool
+
+    private let middleWidth: CGFloat = 48
+    private let barHeight: CGFloat = 5
+    private let gap: CGFloat = 4
+    private let dotDiameter: CGFloat = 4
     private let topRatio: CGFloat = 55.0 / 85.0
     private let bottomRatio: CGFloat = 70.0 / 85.0
     /// Logo: top bar ends at x=640, dot center at x=700 (delta 60 of 870).
     private let dotGapRatio: CGFloat = 60.0 / 870.0
-    private let dotDiameter: CGFloat = 6
-
-    @State private var revealed = false
+    private let cycle: Double = 2.4
+    private let stagger: Double = 0.12
 
     var body: some View {
         let topWidth = middleWidth * topRatio
         let bottomWidth = middleWidth * bottomRatio
         let dotLeading = topWidth + middleWidth * dotGapRatio - dotDiameter / 2
 
-        VStack(alignment: .leading, spacing: gap) {
-            ZStack(alignment: .leading) {
-                bar(width: topWidth, delay: 0.00)
-                Circle()
-                    .fill(Tokens.ink)
-                    .frame(width: dotDiameter, height: dotDiameter)
-                    .offset(x: dotLeading)
-                    .opacity(revealed ? 1 : 0)
-                    .scaleEffect(revealed ? 1 : 0.4, anchor: .center)
-                    .animation(
-                        .easeOut(duration: 0.35).delay(0.45),
-                        value: revealed
-                    )
-            }
-            .frame(height: barHeight)
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0, paused: !isAnimating)) { ctx in
+            let phase = isAnimating ? loopPhase(at: ctx.date) : -1
 
-            bar(width: middleWidth, delay: 0.15)
-            bar(width: bottomWidth, delay: 0.30)
-        }
-        .frame(width: middleWidth + dotDiameter, alignment: .leading)
-        .onAppear {
-            revealed = false
-            DispatchQueue.main.async { revealed = true }
+            VStack(alignment: .leading, spacing: gap) {
+                ZStack(alignment: .leading) {
+                    shimmerBar(width: topWidth, phase: phase)
+                    Circle()
+                        .fill(Tokens.ink)
+                        .frame(width: dotDiameter, height: dotDiameter)
+                        .offset(x: dotLeading)
+                }
+                .frame(height: barHeight)
+
+                shimmerBar(width: middleWidth, phase: shifted(phase, by: -stagger))
+                shimmerBar(width: bottomWidth, phase: shifted(phase, by: -stagger * 2))
+            }
+            .frame(width: middleWidth + dotDiameter, alignment: .leading)
         }
     }
 
-    private func bar(width target: CGFloat, delay: Double) -> some View {
-        Capsule(style: .continuous)
+    private func loopPhase(at date: Date) -> Double {
+        let t = date.timeIntervalSinceReferenceDate
+        return t.truncatingRemainder(dividingBy: cycle) / cycle
+    }
+
+    private func shifted(_ phase: Double, by offset: Double) -> Double {
+        guard phase >= 0 else { return phase }
+        let p = phase + offset
+        return p - floor(p)
+    }
+
+    /// A bar with a soft brighter band sliding from leading to trailing edge.
+    /// `phase` ranges 0..1 across one cycle; <0 means "paused, no shimmer".
+    private func shimmerBar(width target: CGFloat, phase: Double) -> some View {
+        let bandWidth = target * 0.55
+        let bandX = -bandWidth + (target + bandWidth) * max(phase, 0)
+
+        return Capsule(style: .continuous)
             .fill(Tokens.ink)
-            .frame(width: revealed ? target : 0, height: barHeight)
-            .frame(width: target, alignment: .leading)
-            .animation(
-                .easeOut(duration: 0.55).delay(delay),
-                value: revealed
-            )
+            .frame(width: target, height: barHeight)
+            .overlay(alignment: .leading) {
+                if phase >= 0 {
+                    LinearGradient(
+                        stops: [
+                            .init(color: Color.clear,           location: 0.0),
+                            .init(color: Tokens.paper.opacity(0.55), location: 0.5),
+                            .init(color: Color.clear,           location: 1.0)
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: bandWidth, height: barHeight)
+                    .offset(x: bandX)
+                }
+            }
+            .clipShape(Capsule(style: .continuous))
     }
 }
 

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -177,13 +177,7 @@ struct ChatView: View {
             Spacer(minLength: Space.xxxl)
 
             VStack(spacing: Space.lg) {
-                Image(systemName: "sparkles")
-                    .font(.system(size: 32, weight: .regular))
-                    .foregroundStyle(Tokens.muted)
-
-                Rectangle()
-                    .fill(Tokens.accentChat)
-                    .frame(width: 32, height: 2)
+                LogoBars()
 
                 VStack(spacing: Space.md) {
                     Text("What can I help you organize?")
@@ -297,6 +291,44 @@ struct ChatView: View {
 
     private var hasLiveAssistantTurn: Bool {
         viewModel.turns.last?.isStreaming == true
+    }
+}
+
+/// Three pill-capped horizontal bars mirroring the Deks logo (top 55%,
+/// middle 85%, bottom 70%). On first appearance each bar sweeps out from
+/// the leading edge to its target width with a small stagger between them.
+private struct LogoBars: View {
+    private let middleWidth: CGFloat = 96
+    private let barHeight: CGFloat = 10
+    private let topRatio: CGFloat = 55.0 / 85.0
+    private let bottomRatio: CGFloat = 70.0 / 85.0
+
+    @State private var revealed = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            bar(width: middleWidth * topRatio, delay: 0.00)
+            bar(width: middleWidth,            delay: 0.08)
+            bar(width: middleWidth * bottomRatio, delay: 0.16)
+        }
+        .frame(width: middleWidth, alignment: .leading)
+        .onAppear {
+            revealed = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                revealed = true
+            }
+        }
+    }
+
+    private func bar(width target: CGFloat, delay: Double) -> some View {
+        Capsule(style: .continuous)
+            .fill(Tokens.ink)
+            .frame(width: revealed ? target : 0, height: barHeight)
+            .frame(width: target, alignment: .leading)
+            .animation(
+                .spring(response: 0.55, dampingFraction: 0.85).delay(delay),
+                value: revealed
+            )
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces the SF Symbol sparkle and short accent rectangle on the chat empty state with three pill-capped horizontal bars that mirror the Deks app icon (top 55%, middle 85%, bottom 70%)
- Bars sweep in from the leading edge on first appearance with a small stagger between them, giving the surface a branded entrance moment
- No background, border, or shadow around the mark; bars use `Tokens.ink` so they adapt to light/dark

Closes #95

## Test plan
- [x] `xcodebuild -sdk iphonesimulator build` succeeds
- [x] IPA installed on Flightmode 2.0 via `devicectl`
- [ ] On launch into Chat with no turns: three bars sweep in horizontally, staggered (top, then middle, then bottom)
- [ ] No background / no border / no card around the bars
- [ ] Headline "What can I help you organize?" + subtext + example chips render unchanged below the bars
- [ ] Looks correct in light and dark mode