### PR TITLE
feat(ios): itineraries with day-by-day timelines + chat/voice AI tools

### DIFF
--- a/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
+++ b/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
@@ -117,6 +117,54 @@ struct AssistantContextBuilder {
             }.joined(separator: "\n")
         }
 
+        // Trips: 20 most-recently-updated. The 3 newest get a full day-by-day
+        // breakdown; older trips only emit the header line to keep the prompt
+        // budget reasonable. Match the EXISTING TASKS pattern: skip the
+        // section entirely when there are zero trips.
+        if let trips = try? context.fetch(
+            FetchDescriptor<LocalTrip>(
+                sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
+            )
+        ).prefix(20), !trips.isEmpty {
+            // Pre-fetch every item once so we don't hit SwiftData N times.
+            let allItems = (try? context.fetch(
+                FetchDescriptor<LocalItineraryItem>(
+                    sortBy: [SortDescriptor(\.dayDate, order: .forward),
+                             SortDescriptor(\.sortOrder, order: .forward),
+                             SortDescriptor(\.createdAt, order: .forward)]
+                )
+            )) ?? []
+            let itemsByTrip = Dictionary(grouping: allItems, by: { $0.tripUUID })
+
+            out += "\n\nEXISTING TRIPS:\n"
+            out += trips.enumerated().map { (idx, trip) -> String in
+                let id = Self.uuidString(trip.clientUUID)
+                let startISO = Self.isoDate.string(from: trip.startDate)
+                let endISO = Self.isoDate.string(from: trip.endDate)
+                let days = max(1, Self.dayCount(from: trip.startDate, to: trip.endDate))
+                let items = itemsByTrip[trip.clientUUID] ?? []
+
+                var line = "- \(id) | \(trip.name) | \(startISO) → \(endISO) (\(days) day\(days == 1 ? "" : "s")) | \(items.count) item\(items.count == 1 ? "" : "s")"
+
+                // Full day-by-day breakdown only for the 3 most-recently-updated trips.
+                if idx < 3, !items.isEmpty {
+                    let groups = Dictionary(grouping: items, by: { $0.dayDate })
+                    let sortedDays = groups.keys.sorted()
+                    for day in sortedDays {
+                        let dayItems = groups[day] ?? []
+                        let dayNumber = Self.dayNumber(start: trip.startDate, day: day)
+                        let dayISO = Self.isoDate.string(from: day)
+                        let pretty = dayItems.map { item -> String in
+                            let kind = ItineraryKind(rawValue: item.kind) ?? .activity
+                            return "\(item.title) (\(kind.rawValue))"
+                        }.joined(separator: ", ")
+                        line += "\n  Day \(dayNumber) (\(dayISO)): \(pretty)"
+                    }
+                }
+                return line
+            }.joined(separator: "\n")
+        }
+
         // Personal vocabulary: words the user has explicitly taught the
         // assistant so the model can prefer them over close-sounding
         // mistranscriptions ("envisso" vs. "in visa", "Dexter" vs. "Dexter
@@ -156,4 +204,29 @@ struct AssistantContextBuilder {
         f.timeStyle = .none
         return f
     }()
+
+    /// `yyyy-MM-dd` for trip start/end and per-day labels. Matches the
+    /// "ISO date" shape the spec calls out for the EXISTING TRIPS block.
+    private static let isoDate: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    /// Inclusive day count between two `startOfDay`-normalised dates.
+    private static func dayCount(from start: Date, to end: Date) -> Int {
+        let cal = Calendar(identifier: .gregorian)
+        let comps = cal.dateComponents([.day], from: start, to: end)
+        return (comps.day ?? 0) + 1
+    }
+
+    /// 1-indexed day number for a given day inside a trip ("Day 1" = startDate).
+    private static func dayNumber(start: Date, day: Date) -> Int {
+        let cal = Calendar(identifier: .gregorian)
+        let comps = cal.dateComponents([.day], from: start, to: day)
+        return (comps.day ?? 0) + 1
+    }
 }

--- a/mobile/PersonalDashboard/AI/ChatActionResult.swift
+++ b/mobile/PersonalDashboard/AI/ChatActionResult.swift
@@ -124,15 +124,17 @@ extension ChatActionResult {
         case "note": return .notes
         case "list": return .lists
         case "folder": return .notes
+        case "trip", "itinerary_item": return .itineraries
         default: return nil
         }
     }
 
-    /// True when we have a usable id + section to focus a row. Folders skip
-    /// the affordance (the destination view doesn't focus folder rows yet).
+    /// True when we have a usable id + section to focus a row. Folders +
+    /// itinerary items skip the affordance (their destination views don't
+    /// support row-level focus yet — tracked as follow-up for #104).
     var supportsDeepLink: Bool {
         guard let outcome, !isFailure, state != .deleted else { return false }
-        if outcome.type == "folder" { return false }
+        if outcome.type == "folder" || outcome.type == "itinerary_item" { return false }
         return UUID(uuidString: outcome.id) != nil && deepLinkSection != nil
     }
 

--- a/mobile/PersonalDashboard/AI/ChatDraft.swift
+++ b/mobile/PersonalDashboard/AI/ChatDraft.swift
@@ -106,10 +106,171 @@ extension ChatDraft {
             let count = dict["items"]?.arrayValue?.count ?? 0
             return "List: \"\(dict["title"]?.stringValue ?? "Untitled")\" with \(count) item\(count == 1 ? "" : "s")"
 
+        case .createTrip:
+            let name = dict["name"]?.stringValue ?? "Untitled"
+            let start = (dict["start_date"]?.stringValue).flatMap(Self.parseAnyDate)
+            let end = (dict["end_date"]?.stringValue).flatMap(Self.parseAnyDate)
+            if let start, let end {
+                let range = Self.dateRange(start: start, end: end)
+                let days = Self.inclusiveDays(start: start, end: end)
+                return "\(name) · \(range) · \(days) day\(days == 1 ? "" : "s")"
+            }
+            return "Trip: \"\(name)\""
+
+        case .addItineraryItems:
+            let items = dict["items"]?.arrayValue ?? []
+            if items.count == 1, let only = items.first?.objectValue {
+                let title = only["title"]?.stringValue ?? "Untitled"
+                let kindRaw = (only["kind"]?.stringValue ?? "").lowercased()
+                let kind = ItineraryKind(rawValue: kindRaw)?.displayName ?? "Item"
+                // We don't know Day N without the trip context; show date only.
+                let day = (only["day_date"]?.stringValue).flatMap(Self.parseAnyDate)
+                let dayDisplay = day.map { Self.shortDayMonth.string(from: $0) } ?? ""
+                if !dayDisplay.isEmpty {
+                    return "\(title) · \(kind) · \(dayDisplay)"
+                }
+                return "\(title) · \(kind)"
+            }
+            // Multiple items. Build a comma-joined list of titles and
+            // truncate the joined run to ~40 chars total to stay readable.
+            let titles = items.compactMap { $0.objectValue?["title"]?.stringValue }
+            let joined = titles.joined(separator: ", ")
+            let truncated = joined.count > 40 ? String(joined.prefix(37)) + "…" : joined
+            return "\(items.count) item\(items.count == 1 ? "" : "s"): \(truncated)"
+
+        case .updateTrip:
+            return Self.updateTripSummary(dict: dict)
+
+        case .updateItineraryItem:
+            return Self.updateItineraryItemSummary(dict: dict)
+
+        case .deleteTrip:
+            return "Delete trip (ID: \(dict["id"]?.stringValue ?? "?"))"
+
+        case .deleteItineraryItem:
+            return "Delete itinerary item (ID: \(dict["id"]?.stringValue ?? "?"))"
+
         case .unknown:
             return "Unknown action"
         }
     }
+
+    /// Build the preview for `edit_trip`. Falls back to a generic line if
+    /// no field actually carries a change.
+    private static func updateTripSummary(dict: [String: AnthropicJSONValue]) -> String {
+        var pieces: [String] = []
+        if let name = dict["name"]?.stringValue, !name.isEmpty, name != "null" {
+            pieces.append("Rename to \(name)")
+        }
+        let start = (dict["start_date"]?.stringValue).flatMap { $0.isEmpty || $0 == "null" ? nil : parseAnyDate($0) }
+        let end = (dict["end_date"]?.stringValue).flatMap { $0.isEmpty || $0 == "null" ? nil : parseAnyDate($0) }
+        if let start, let end {
+            pieces.append("Move to \(dateRange(start: start, end: end))")
+        } else if let start {
+            pieces.append("Start \(shortDayMonth.string(from: start))")
+        } else if let end {
+            pieces.append("End \(shortDayMonth.string(from: end))")
+        }
+        if let raw = dict["notes"]?.stringValue {
+            if raw == "null" {
+                pieces.append("Clear notes")
+            } else if !raw.isEmpty {
+                pieces.append("Update notes")
+            }
+        }
+        if pieces.isEmpty {
+            return "Edit trip (ID: \(dict["id"]?.stringValue ?? "?"))"
+        }
+        return pieces.joined(separator: " · ")
+    }
+
+    private static func updateItineraryItemSummary(dict: [String: AnthropicJSONValue]) -> String {
+        var pieces: [String] = []
+        if let title = dict["title"]?.stringValue, !title.isEmpty, title != "null" {
+            pieces.append("Rename to \(title)")
+        }
+        if let raw = dict["day_date"]?.stringValue, !raw.isEmpty, raw != "null",
+           let day = parseAnyDate(raw) {
+            pieces.append("Move to \(shortDayMonth.string(from: day))")
+        }
+        if let raw = dict["kind"]?.stringValue, !raw.isEmpty, raw != "null",
+           let kind = ItineraryKind(rawValue: raw.lowercased()) {
+            pieces.append("Kind \(kind.displayName)")
+        }
+        if let raw = dict["notes"]?.stringValue {
+            if raw == "null" {
+                pieces.append("Clear notes")
+            } else if !raw.isEmpty {
+                pieces.append("Update notes")
+            }
+        }
+        if pieces.isEmpty {
+            return "Edit itinerary item (ID: \(dict["id"]?.stringValue ?? "?"))"
+        }
+        return pieces.joined(separator: " · ")
+    }
+
+    /// Inclusive day count between two dates (day-granularity).
+    private static func inclusiveDays(start: Date, end: Date) -> Int {
+        let cal = Calendar(identifier: .gregorian)
+        let s = cal.startOfDay(for: start)
+        let e = cal.startOfDay(for: end)
+        let comps = cal.dateComponents([.day], from: s, to: e)
+        return max(1, (comps.day ?? 0) + 1)
+    }
+
+    /// "14–21 Jun" / "29 Jun – 5 Jul" / "30 Dec 2026 – 4 Jan 2027".
+    private static func dateRange(start: Date, end: Date) -> String {
+        let cal = Calendar(identifier: .gregorian)
+        let sameYear = cal.component(.year, from: start) == cal.component(.year, from: end)
+        let sameMonth = sameYear && cal.component(.month, from: start) == cal.component(.month, from: end)
+        let currentYear = cal.component(.year, from: Date()) == cal.component(.year, from: start)
+
+        if sameMonth {
+            let day1 = String(cal.component(.day, from: start))
+            let day2 = String(cal.component(.day, from: end))
+            let mon = monthShort.string(from: end)
+            return "\(day1)–\(day2) \(mon)"
+        }
+        if sameYear && currentYear {
+            return "\(dayMonth.string(from: start)) – \(dayMonth.string(from: end))"
+        }
+        // Cross-year (or distant year): include both years.
+        return "\(dayMonthYear.string(from: start)) – \(dayMonthYear.string(from: end))"
+    }
+
+    static func parseAnyDate(_ raw: String) -> Date? {
+        if raw.isEmpty || raw == "null" { return nil }
+        if let d = iso8601Fractional.date(from: raw) { return d }
+        if let d = iso8601.date(from: raw) { return d }
+        if let d = dateOnlyUTC.date(from: raw) { return d }
+        return nil
+    }
+
+    private static let monthShort: DateFormatter = {
+        let f = DateFormatter(); f.locale = Locale(identifier: "en_US_POSIX"); f.dateFormat = "MMM"; return f
+    }()
+
+    private static let dayMonth: DateFormatter = {
+        let f = DateFormatter(); f.locale = Locale(identifier: "en_US_POSIX"); f.dateFormat = "d MMM"; return f
+    }()
+
+    private static let dayMonthYear: DateFormatter = {
+        let f = DateFormatter(); f.locale = Locale(identifier: "en_US_POSIX"); f.dateFormat = "d MMM yyyy"; return f
+    }()
+
+    private static let shortDayMonth: DateFormatter = {
+        let f = DateFormatter(); f.locale = Locale(identifier: "en_US_POSIX"); f.dateFormat = "d MMM"; return f
+    }()
+
+    private static let dateOnlyUTC: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
 
     private static func parseISODate(_ raw: String) -> Date? {
         if let d = iso8601Fractional.date(from: raw) { return d }

--- a/mobile/PersonalDashboard/AI/ChatStream.swift
+++ b/mobile/PersonalDashboard/AI/ChatStream.swift
@@ -31,7 +31,16 @@ struct ChatStream {
         )
     }
 
-    func run(input: String, timezone: String) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+    /// One prior turn for stateless-API history. Text-only — auto-executed
+    /// tool results aren't replayed back because the system prompt's EXISTING
+    /// TASKS / NOTES / LISTS / TRIPS context block is the source of truth for
+    /// what currently lives on the device.
+    struct PriorTurn: Sendable {
+        let role: String   // "user" or "assistant"
+        let text: String
+    }
+
+    func run(history: [PriorTurn] = [], input: String, timezone: String) -> AsyncThrowingStream<ChatStreamEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task { @MainActor in
                 do {
@@ -41,9 +50,10 @@ struct ChatStream {
                         nowIso: Self.iso8601Fractional.string(from: Date()),
                         contextBlock: contextBlock
                     )
-                    let messages: [AnthropicMessage] = [
-                        AnthropicMessage(role: "user", content: [.text(input)])
-                    ]
+                    var messages: [AnthropicMessage] = history
+                        .filter { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                        .map { AnthropicMessage(role: $0.role, content: [.text($0.text)]) }
+                    messages.append(AnthropicMessage(role: "user", content: [.text(input)]))
 
                     var accumulatedText = ""
                     var draftCount = 0
@@ -122,6 +132,8 @@ struct ChatStream {
         - draft_task: Create a NEW task/todo with title, description, due_at (ISO 8601), and tag
         - draft_note: Create a NEW note with title, body, and optional tags array
         - draft_list: Create a NEW list with title and items array
+        - draft_trip: Create a NEW trip with name, start_date, end_date, notes. Do NOT call unless both start_date AND end_date are known; ask the user for dates first.
+        - add_itinerary_item: Add stays / activities / places / restaurants to an existing trip (multi-item supported via items array; kind enum is stay|activity|place|restaurant)
 
         EDIT (for existing items - requires UUID):
         - complete_task: Mark a task as completed or incomplete
@@ -131,6 +143,8 @@ struct ChatStream {
         - add_to_list: Add new items to an existing list (keeps existing items)
         - edit_list_item: Edit a specific item in a list (requires list_id and item_index from context)
         - edit_folder: Rename an existing folder
+        - edit_trip: Edit an existing trip's name, start_date, end_date, or notes (notes can be cleared with "null")
+        - edit_itinerary_item: Edit an existing itinerary item's day_date, kind, title, or notes
 
         DELETE/REMOVE (for existing items - requires UUID):
         - delete_task: Delete an existing task
@@ -138,17 +152,23 @@ struct ChatStream {
         - delete_list: Delete an existing list
         - delete_folder: Delete an existing folder (notes move to no folder)
         - remove_list_item: Remove a specific item from a list (requires list_id and item_index)
+        - delete_trip: Delete an existing trip (cascades to all its itinerary items)
+        - delete_itinerary_item: Delete a single itinerary item
 
-        CAPTURE DEFAULTS (for NEW items via draft_task / draft_note / draft_list):
-        You MUST capture every new-item request into one of the three types. Never refuse a capture with "I can't help with that" or "this doesn't fit a task / note / list". Pick the best fit from the user's intent and create the draft. The user can edit the captured item afterwards, so prefer capturing over asking.
+        CAPTURE DEFAULTS (for NEW items via draft_task / draft_note / draft_list / draft_trip):
+        You MUST capture every new-item request into the best-fit type. Never refuse a capture with "I can't help with that". Pick the best fit from the user's intent and create the draft. The user can edit the captured item afterwards, so prefer capturing over asking.
 
         Type selection (in this priority order):
+        - Trip / travel planning intent ("plan a trip to X", "build me an itinerary for X", "I'm going to X next week", "vacation to X", "Italy trip") → draft_trip. If the user has NOT specified both start_date AND end_date, ask ONE short question for the dates first; do NOT default to draft_note for trip intents.
+        - Adding stays / activities / places / restaurants to an existing trip ("add a hotel in Rome", "Vatican on day 2", "dinner in Trastevere") when EXISTING TRIPS context has a matching trip → add_itinerary_item. If no trip exists or which trip is ambiguous, ask which trip first.
         - If the user explicitly says "task" / "todo" / "remind me" / "add a list" / "make a note" / "save this as a note", honour that type.
         - Long-form prose, paragraph(s), journaling or reflective tone, or phrases like "capture my thoughts", "remember this", "I was thinking", "note that…", "log this" → draft_note.
         - A single short actionable line (verb-led, often with a deadline like "tomorrow" / "next week" / a date) → draft_task.
         - Multiple short comma-, line-, or bullet-separated atoms ("milk, eggs, bread"; "groceries: …") → draft_list.
         - Unclear or ambiguous between task and list → default to draft_note.
         - A vague but content-bearing short input ("the thing about the meeting") → draft_note. Do NOT ask the user to clarify; just capture it as a note and move on.
+
+        Trip-intent override: travel and itinerary phrasings NEVER fall through to draft_note. They go to draft_trip (with a dates ask-back if needed) or add_itinerary_item.
 
         IMPORTANT RULES:
         1. NEVER perform actions directly - ONLY call tools to create draft proposals

--- a/mobile/PersonalDashboard/AI/ChatToDrafts.swift
+++ b/mobile/PersonalDashboard/AI/ChatToDrafts.swift
@@ -68,6 +68,11 @@ struct ChatToDrafts {
         var failed: [FailedDraftRecord] = []
         var assistantText: String? = nil
 
+        // Capture sees the full toolset (including trip tools) so voice
+        // requests like "plan a trip to Italy" route to draft_trip instead
+        // of falling through to draft_note. Tools that need dates the user
+        // didn't speak will surface an assistant text response asking for
+        // them — the Shortcut returns that as a spoken dialog.
         for _ in 0..<Self.maxIterations {
             let response = try await anthropic.send(
                 systemPrompt: systemPrompt,
@@ -188,6 +193,8 @@ struct ChatToDrafts {
         - draft_task: Create a NEW task/todo with title, description, due_at (ISO 8601), and tag
         - draft_note: Create a NEW note with title, body, and optional tags array
         - draft_list: Create a NEW list with title and items array
+        - draft_trip: Create a NEW trip with name, start_date, end_date, notes. Do NOT call unless both start_date AND end_date are known; ask the user for dates first if missing.
+        - add_itinerary_item: Add stays / activities / places / restaurants to an existing trip (multi-item supported via items array; kind enum is stay|activity|place|restaurant)
 
         EDIT (for existing items - requires UUID):
         - complete_task: Mark a task as completed or incomplete
@@ -197,6 +204,8 @@ struct ChatToDrafts {
         - add_to_list: Add new items to an existing list (keeps existing items)
         - edit_list_item: Edit a specific item in a list (requires list_id and item_index from context)
         - edit_folder: Rename an existing folder
+        - edit_trip: Edit an existing trip's name, start_date, end_date, or notes (notes can be cleared with "null")
+        - edit_itinerary_item: Edit an existing itinerary item's day_date, kind, title, or notes
 
         DELETE/REMOVE (for existing items - requires UUID):
         - delete_task: Delete an existing task
@@ -204,17 +213,23 @@ struct ChatToDrafts {
         - delete_list: Delete an existing list
         - delete_folder: Delete an existing folder (notes move to no folder)
         - remove_list_item: Remove a specific item from a list (requires list_id and item_index)
+        - delete_trip: Delete an existing trip (cascades to all its itinerary items)
+        - delete_itinerary_item: Delete a single itinerary item
 
-        CAPTURE DEFAULTS (for NEW items via draft_task / draft_note / draft_list):
-        You MUST capture every new-item request into one of the three types. Never refuse a capture with "I can't help with that" or "this doesn't fit a task / note / list". Pick the best fit from the user's intent and create the draft. The user can edit the captured item afterwards, so prefer capturing over asking.
+        CAPTURE DEFAULTS (for NEW items via draft_task / draft_note / draft_list / draft_trip):
+        You MUST capture every new-item request into the best-fit type. Never refuse a capture with "I can't help with that". Pick the best fit from the user's intent and create the draft.
 
         Type selection (in this priority order):
+        - Trip / travel planning intent ("plan a trip to X", "build me an itinerary for X", "I'm going to X next week", "vacation to X", "Italy trip") → draft_trip. If the user has NOT specified both start_date AND end_date, respond with assistant text asking for the dates; do NOT default to draft_note for trip intents.
+        - Adding stays / activities / places / restaurants to an existing trip ("add a hotel in Rome", "Vatican on day 2", "dinner in Trastevere") when EXISTING TRIPS context has a matching trip → add_itinerary_item. If no trip exists or which trip is ambiguous, respond with assistant text asking which trip.
         - If the user explicitly says "task" / "todo" / "remind me" / "add a list" / "make a note" / "save this as a note", honour that type.
         - Long-form prose, paragraph(s), journaling or reflective tone, or phrases like "capture my thoughts", "remember this", "I was thinking", "note that…", "log this" → draft_note.
         - A single short actionable line (verb-led, often with a deadline like "tomorrow" / "next week" / a date) → draft_task.
         - Multiple short comma-, line-, or bullet-separated atoms ("milk, eggs, bread"; "groceries: …") → draft_list.
         - Unclear or ambiguous between task and list → default to draft_note.
         - A vague but content-bearing short input ("the thing about the meeting") → draft_note. Do NOT ask the user to clarify; just capture it as a note and move on.
+
+        Trip-intent override: travel and itinerary phrasings NEVER fall through to draft_note. They go to draft_trip (with a dates ask-back as assistant text if needed) or add_itinerary_item.
 
         IMPORTANT RULES:
         1. NEVER perform actions directly - ONLY call tools to create draft proposals

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -24,7 +24,7 @@ enum DraftExecutionError: LocalizedError {
 /// Outcome of one applied tool call. Surfaced back to the App Intent for
 /// dialog rendering and to the chat UI for confirmation banners.
 struct DraftActionOutcome {
-    let type: String          // "todo" | "note" | "list" | "folder"
+    let type: String          // "todo" | "note" | "list" | "folder" | "trip" | "itinerary_item"
     let action: String        // see action constants below
     let id: String            // UUID string
     let title: String?
@@ -67,6 +67,12 @@ struct ExecuteDraftAction {
         case .deleteNote: return try deleteNote(input)
         case .deleteList: return try deleteList(input)
         case .deleteFolder: return try deleteFolder(input)
+        case .createTrip: return try createTrip(input)
+        case .addItineraryItems: return try addItineraryItems(input)
+        case .updateTrip: return try updateTrip(input)
+        case .deleteTrip: return try deleteTrip(input)
+        case .updateItineraryItem: return try updateItineraryItem(input)
+        case .deleteItineraryItem: return try deleteItineraryItem(input)
         case .unknown:
             throw DraftExecutionError.invalidArgument(field: "action", reason: "unknown action type")
         }
@@ -412,6 +418,249 @@ struct ExecuteDraftAction {
         )
     }
 
+    // MARK: - TRIPS (Itineraries)
+
+    private func createTrip(_ input: [String: AnthropicJSONValue]) throws -> DraftActionOutcome {
+        let name = trimmedString(input["name"]) ?? ""
+        guard !name.isEmpty else {
+            throw DraftExecutionError.invalidArgument(field: "name", reason: "required")
+        }
+        guard let startRaw = trimmedString(input["start_date"]), let start = parseAnyISODate(startRaw) else {
+            throw DraftExecutionError.invalidArgument(field: "start_date", reason: "required ISO 8601 date")
+        }
+        guard let endRaw = trimmedString(input["end_date"]), let end = parseAnyISODate(endRaw) else {
+            throw DraftExecutionError.invalidArgument(field: "end_date", reason: "required ISO 8601 date")
+        }
+        let startOfStart = Calendar(identifier: .gregorian).startOfDay(for: start)
+        let startOfEnd = Calendar(identifier: .gregorian).startOfDay(for: end)
+        guard startOfEnd >= startOfStart else {
+            throw DraftExecutionError.invalidArgument(field: "end_date", reason: "must be on or after start_date")
+        }
+
+        let notes = input["notes"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let cleanNotes = notes == "null" ? "" : notes
+
+        let now = Date()
+        let row = LocalTrip(
+            name: name,
+            startDate: startOfStart,
+            endDate: startOfEnd,
+            notes: cleanNotes,
+            createdAt: now,
+            updatedAt: now
+        )
+        store.context.insert(row)
+        try save()
+        return outcome(type: "trip", action: ActionString.created, id: row.clientUUID, title: row.name)
+    }
+
+    private func addItineraryItems(_ input: [String: AnthropicJSONValue]) throws -> DraftActionOutcome {
+        let tripUUID = try requireUUID(input["trip_id"], entity: "trip")
+        let trip: LocalTrip = try fetchOne(uuid: tripUUID, entity: "trip")
+
+        guard let rawItems = input["items"]?.arrayValue, !rawItems.isEmpty else {
+            throw DraftExecutionError.invalidArgument(field: "items", reason: "required and non-empty")
+        }
+
+        let cal = Calendar(identifier: .gregorian)
+        let now = Date()
+        var addedTitles: [String] = []
+
+        // Snapshot existing items for sortOrder math so we don't refetch per item.
+        let tripFK = tripUUID
+        var existing = (try? store.context.fetch(
+            FetchDescriptor<LocalItineraryItem>(
+                predicate: #Predicate { $0.tripUUID == tripFK }
+            )
+        )) ?? []
+
+        for entry in rawItems {
+            guard let dict = entry.objectValue else { continue }
+            let title = (dict["title"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !title.isEmpty else { continue }
+
+            guard let dayRaw = dict["day_date"]?.stringValue,
+                  let day = parseAnyISODate(dayRaw) else { continue }
+            let dayStart = cal.startOfDay(for: day)
+
+            // Map kind string; last-resort fallback is .activity per spec.
+            let kindRaw = (dict["kind"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let kind = ItineraryKind(rawValue: kindRaw) ?? .activity
+
+            let notes = (dict["notes"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            let cleanNotes = notes == "null" ? "" : notes
+
+            let maxForDay = existing
+                .filter { cal.isDate($0.dayDate, inSameDayAs: dayStart) }
+                .map { $0.sortOrder }
+                .max() ?? -1
+
+            let row = LocalItineraryItem(
+                tripUUID: tripUUID,
+                dayDate: dayStart,
+                kind: kind,
+                title: title,
+                notes: cleanNotes,
+                sortOrder: maxForDay + 1,
+                createdAt: now,
+                updatedAt: now
+            )
+            store.context.insert(row)
+            existing.append(row)
+            addedTitles.append(title)
+        }
+
+        guard !addedTitles.isEmpty else {
+            throw DraftExecutionError.invalidArgument(field: "items", reason: "no valid items provided")
+        }
+
+        trip.updatedAt = now
+        try save()
+
+        return DraftActionOutcome(
+            type: "itinerary_item",
+            action: ActionString.itemsAdded,
+            id: trip.clientUUID.uuidString.lowercased(),
+            title: trip.name,
+            dueDate: nil,
+            addedNames: addedTitles.joined(separator: ", ")
+        )
+    }
+
+    private func updateTrip(_ input: [String: AnthropicJSONValue]) throws -> DraftActionOutcome {
+        let uuid = try requireUUID(input["id"], entity: "trip")
+        let row: LocalTrip = try fetchOne(uuid: uuid, entity: "trip")
+        let cal = Calendar(identifier: .gregorian)
+
+        var changed = false
+        if let name = trimmedString(input["name"]), !name.isEmpty {
+            row.name = name; changed = true
+        }
+        // start_date / end_date: empty = keep, real value = set. No "null" support (can't clear dates).
+        if let raw = input["start_date"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty, raw != "null",
+           let parsed = parseAnyISODate(raw) {
+            row.startDate = cal.startOfDay(for: parsed); changed = true
+        }
+        if let raw = input["end_date"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty, raw != "null",
+           let parsed = parseAnyISODate(raw) {
+            row.endDate = cal.startOfDay(for: parsed); changed = true
+        }
+        // notes: empty = keep, "null" = clear (to ""), real value = set.
+        if let raw = input["notes"]?.stringValue {
+            if raw == "null" {
+                row.notes = ""; changed = true
+            } else {
+                let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    row.notes = trimmed; changed = true
+                }
+            }
+        }
+
+        guard changed else {
+            throw DraftExecutionError.invalidArgument(field: "trip", reason: "no changes provided")
+        }
+        guard row.endDate >= row.startDate else {
+            throw DraftExecutionError.invalidArgument(field: "end_date", reason: "must be on or after start_date")
+        }
+
+        row.updatedAt = Date()
+        try save()
+        return outcome(type: "trip", action: ActionString.updated, id: row.clientUUID, title: row.name)
+    }
+
+    private func deleteTrip(_ input: [String: AnthropicJSONValue]) throws -> DraftActionOutcome {
+        let uuid = try requireUUID(input["id"], entity: "trip")
+        let row: LocalTrip = try fetchOne(uuid: uuid, entity: "trip")
+        let name = row.name
+
+        // Cascade: delete every itinerary item that references this trip,
+        // then the trip itself. Single SwiftData save.
+        let tripFK = uuid
+        let children = (try? store.context.fetch(
+            FetchDescriptor<LocalItineraryItem>(
+                predicate: #Predicate { $0.tripUUID == tripFK }
+            )
+        )) ?? []
+        for child in children {
+            store.context.delete(child)
+        }
+        store.context.delete(row)
+        try save()
+
+        return DraftActionOutcome(
+            type: "trip", action: ActionString.deleted,
+            id: uuid.uuidString.lowercased(), title: name, dueDate: nil, addedNames: nil
+        )
+    }
+
+    private func updateItineraryItem(_ input: [String: AnthropicJSONValue]) throws -> DraftActionOutcome {
+        let uuid = try requireUUID(input["id"], entity: "itinerary_item")
+        let row: LocalItineraryItem = try fetchOne(uuid: uuid, entity: "itinerary_item")
+        let cal = Calendar(identifier: .gregorian)
+
+        var changed = false
+        if let raw = input["day_date"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty, raw != "null",
+           let parsed = parseAnyISODate(raw) {
+            row.dayDate = cal.startOfDay(for: parsed); changed = true
+        }
+        if let raw = input["kind"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           !raw.isEmpty, raw != "null",
+           let kind = ItineraryKind(rawValue: raw) {
+            row.kind = kind.rawValue; changed = true
+        }
+        if let title = trimmedString(input["title"]), !title.isEmpty {
+            row.title = title; changed = true
+        }
+        if let raw = input["notes"]?.stringValue {
+            if raw == "null" {
+                row.notes = ""; changed = true
+            } else {
+                let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    row.notes = trimmed; changed = true
+                }
+            }
+        }
+
+        guard changed else {
+            throw DraftExecutionError.invalidArgument(field: "itinerary item", reason: "no changes provided")
+        }
+
+        row.updatedAt = Date()
+        // Bump the parent trip's updatedAt so it floats to the top of the
+        // EXISTING TRIPS context next round.
+        let tripFK = row.tripUUID
+        if let trip = try? store.context.fetch(
+            FetchDescriptor<LocalTrip>(predicate: #Predicate { $0.clientUUID == tripFK })
+        ).first {
+            trip.updatedAt = Date()
+        }
+        try save()
+        return outcome(type: "itinerary_item", action: ActionString.updated, id: row.clientUUID, title: row.title)
+    }
+
+    private func deleteItineraryItem(_ input: [String: AnthropicJSONValue]) throws -> DraftActionOutcome {
+        let uuid = try requireUUID(input["id"], entity: "itinerary_item")
+        let row: LocalItineraryItem = try fetchOne(uuid: uuid, entity: "itinerary_item")
+        let title = row.title
+        let tripFK = row.tripUUID
+        store.context.delete(row)
+        if let trip = try? store.context.fetch(
+            FetchDescriptor<LocalTrip>(predicate: #Predicate { $0.clientUUID == tripFK })
+        ).first {
+            trip.updatedAt = Date()
+        }
+        try save()
+        return DraftActionOutcome(
+            type: "itinerary_item", action: ActionString.deleted,
+            id: uuid.uuidString.lowercased(), title: title, dueDate: nil, addedNames: nil
+        )
+    }
+
     // MARK: - Helpers
 
     private func save() throws {
@@ -451,6 +700,20 @@ struct ExecuteDraftAction {
             }
             return row as! T
         }
+        if T.self == LocalTrip.self {
+            let descriptor = FetchDescriptor<LocalTrip>(predicate: #Predicate { $0.clientUUID == uuid })
+            guard let row = try? store.context.fetch(descriptor).first else {
+                throw DraftExecutionError.notFound(entityType: entity, idString: uuid.uuidString.lowercased())
+            }
+            return row as! T
+        }
+        if T.self == LocalItineraryItem.self {
+            let descriptor = FetchDescriptor<LocalItineraryItem>(predicate: #Predicate { $0.clientUUID == uuid })
+            guard let row = try? store.context.fetch(descriptor).first else {
+                throw DraftExecutionError.notFound(entityType: entity, idString: uuid.uuidString.lowercased())
+            }
+            return row as! T
+        }
         throw DraftExecutionError.notFound(entityType: entity, idString: uuid.uuidString.lowercased())
     }
 
@@ -477,6 +740,18 @@ struct ExecuteDraftAction {
         if let date = Self.iso8601.date(from: raw) {
             return date
         }
+        return nil
+    }
+
+    /// Slightly more lenient ISO parser used by the trip tools. Accepts
+    /// full datetimes (with or without fractional seconds) AND bare
+    /// `yyyy-MM-dd` dates, which the model emits for day-level fields.
+    private func parseAnyISODate(_ raw: String?) -> Date? {
+        guard let raw, !raw.isEmpty, raw != "null" else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let d = Self.iso8601Fractional.date(from: trimmed) { return d }
+        if let d = Self.iso8601.date(from: trimmed) { return d }
+        if let d = Self.dateOnly.date(from: trimmed) { return d }
         return nil
     }
 
@@ -519,6 +794,17 @@ struct ExecuteDraftAction {
     private static let iso8601: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    /// Bare `yyyy-MM-dd` parsed in UTC. Used for date-only fields (trip
+    /// start/end, itinerary item day_date).
+    private static let dateOnly: DateFormatter = {
+        let f = DateFormatter()
+        f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
         return f
     }()
 }

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -250,6 +250,107 @@ enum ToolDefinitions {
         )
     )
 
+    // MARK: - Itineraries (trips + day-by-day items)
+
+    /// Single itinerary-item shape for the `add_itinerary_item` array.
+    private static let itineraryItemSchema: AnthropicJSONValue = .object([
+        "type": .string("object"),
+        "properties": .object([
+            "day_date": .object([
+                "type": .string("string"),
+                "description": .string("ISO 8601 date for the day this item belongs to (e.g., 2026-06-14 or 2026-06-14T00:00:00.000Z). Must fall within the trip's date range.")
+            ]),
+            "kind": .object([
+                "type": .string("string"),
+                "enum": .array([.string("stay"), .string("activity"), .string("place"), .string("restaurant")]),
+                "description": .string("Category of the itinerary item.")
+            ]),
+            "title": .object([
+                "type": .string("string"),
+                "description": .string("Short title (e.g., 'Hotel Roma', 'Vatican tour'). Required.")
+            ]),
+            "notes": .object([
+                "type": .string("string"),
+                "description": .string("Free-form notes. Use empty string if none.")
+            ])
+        ]),
+        "required": .array([.string("day_date"), .string("kind"), .string("title"), .string("notes")])
+    ])
+
+    private static let draftTrip = AnthropicTool(
+        name: "draft_trip",
+        description: "Create a NEW trip in the Itineraries section with a destination name and a date range. IMPORTANT: If the user does not specify start_date AND end_date, do NOT call this tool. Ask the user for the dates first.",
+        input_schema: object(
+            properties: [
+                "name": string("Destination or trip title (e.g., 'Italy', 'Vietnam')."),
+                "start_date": string("First day of the trip in ISO 8601 (e.g., 2026-06-14 or 2026-06-14T00:00:00.000Z). Required."),
+                "end_date": string("Last day of the trip (inclusive) in ISO 8601. Required."),
+                "notes": string("Free-form notes about the trip. Use empty string if none.")
+            ],
+            required: ["name", "start_date", "end_date", "notes"]
+        )
+    )
+
+    private static let addItineraryItem = AnthropicTool(
+        name: "add_itinerary_item",
+        description: "Add one or more day-by-day items (stays, activities, places, restaurants) to an EXISTING trip. The LLM should pick trip_id from the EXISTING TRIPS context block; reject ambiguity by asking which trip the user means rather than guessing. Use this for multi-item adds in a single call.",
+        input_schema: object(
+            properties: [
+                "trip_id": string("The UUID of the existing trip to add items to (from EXISTING TRIPS context)."),
+                "items": arrayOf(itineraryItemSchema, description: "Array of itinerary items to append to the trip.")
+            ],
+            required: ["trip_id", "items"]
+        )
+    )
+
+    private static let editTrip = AnthropicTool(
+        name: "edit_trip",
+        description: "Edit an EXISTING trip's name, date range, or notes. Requires the trip UUID. IMPORTANT: At least one field must actually change. Use empty string for fields you want to keep unchanged. Use the literal string \"null\" ONLY for notes to clear it. Name and dates cannot be cleared.",
+        input_schema: object(
+            properties: [
+                "id": string("The UUID of the existing trip to edit (from EXISTING TRIPS context)."),
+                "name": string("New trip name. Use empty string to keep unchanged."),
+                "start_date": string("New start date in ISO 8601. Use empty string to keep unchanged."),
+                "end_date": string("New end date in ISO 8601. Use empty string to keep unchanged."),
+                "notes": string("New notes. Use empty string to keep unchanged, or the literal \"null\" to clear.")
+            ],
+            required: ["id", "name", "start_date", "end_date", "notes"]
+        )
+    )
+
+    private static let deleteTrip = AnthropicTool(
+        name: "delete_trip",
+        description: "Delete an EXISTING trip and ALL its itinerary items (cascade). Use when the user wants to remove a trip entirely. Requires the trip UUID.",
+        input_schema: object(
+            properties: ["id": string("The UUID of the trip to delete (from EXISTING TRIPS context).")],
+            required: ["id"]
+        )
+    )
+
+    private static let editItineraryItem = AnthropicTool(
+        name: "edit_itinerary_item",
+        description: "Edit an EXISTING itinerary item's day, kind, title, or notes. Requires the item UUID. IMPORTANT: At least one field must actually change. Use empty string for fields to keep unchanged. Use the literal string \"null\" ONLY for notes to clear it. day_date, kind, and title cannot be cleared.",
+        input_schema: object(
+            properties: [
+                "id": string("The UUID of the existing itinerary item to edit (from EXISTING TRIPS context)."),
+                "day_date": string("New day for this item in ISO 8601. Use empty string to keep unchanged."),
+                "kind": string("New kind. Must be one of: stay, activity, place, restaurant. Use empty string to keep unchanged."),
+                "title": string("New title. Use empty string to keep unchanged."),
+                "notes": string("New notes. Use empty string to keep unchanged, or the literal \"null\" to clear.")
+            ],
+            required: ["id", "day_date", "kind", "title", "notes"]
+        )
+    )
+
+    private static let deleteItineraryItem = AnthropicTool(
+        name: "delete_itinerary_item",
+        description: "Delete an EXISTING itinerary item. Use when user wants to remove a single stay/activity/place/restaurant from a trip. Requires the item UUID.",
+        input_schema: object(
+            properties: ["id": string("The UUID of the itinerary item to delete (from EXISTING TRIPS context).")],
+            required: ["id"]
+        )
+    )
+
     // MARK: - Public surface
 
     static let allTools: [AnthropicTool] = [
@@ -267,7 +368,26 @@ enum ToolDefinitions {
         deleteTask,
         deleteNote,
         deleteList,
-        deleteFolder
+        deleteFolder,
+        draftTrip,
+        addItineraryItem,
+        editTrip,
+        deleteTrip,
+        editItineraryItem,
+        deleteItineraryItem
+    ]
+
+    /// Subset of `allTools` excluded from the capture (Shortcut) auto-execute
+    /// path. Capture auto-confirms everything the LLM emits; trip-related
+    /// tools require date confirmation and contextual review that only the
+    /// chat surface offers. Filter applied in `ChatToDrafts.run()`.
+    static let captureExcludedToolNames: Set<String> = [
+        "draft_trip",
+        "add_itinerary_item",
+        "edit_trip",
+        "delete_trip",
+        "edit_itinerary_item",
+        "delete_itinerary_item"
     ]
 
     /// Map tool name → action type. Mirrors `toolToActionType` in
@@ -289,6 +409,12 @@ enum ToolDefinitions {
         "delete_task": .deleteTodo,
         "delete_note": .deleteNote,
         "delete_list": .deleteList,
-        "delete_folder": .deleteFolder
+        "delete_folder": .deleteFolder,
+        "draft_trip": .createTrip,
+        "add_itinerary_item": .addItineraryItems,
+        "edit_trip": .updateTrip,
+        "delete_trip": .deleteTrip,
+        "edit_itinerary_item": .updateItineraryItem,
+        "delete_itinerary_item": .deleteItineraryItem
     ]
 }

--- a/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
+++ b/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
@@ -4,8 +4,8 @@ import SwiftData
 /// SwiftData container singleton.
 ///
 /// The store backs the iOS local-first data layer (#14). It holds
-/// `LocalTodo`, `LocalNote`, `LocalList`, `LocalNoteFolder`, and
-/// `LocalKeyword`.
+/// `LocalTodo`, `LocalNote`, `LocalList`, `LocalNoteFolder`, `LocalKeyword`,
+/// `LocalTrip`, and `LocalItineraryItem`.
 /// SwiftData persists to the app's Application Support directory by default,
 /// which survives cache eviction unlike the legacy JSON cache.
 ///
@@ -27,6 +27,8 @@ final class SwiftDataStore {
                 LocalNote.self,
                 LocalList.self,
                 LocalKeyword.self,
+                LocalTrip.self,
+                LocalItineraryItem.self,
             ])
             // SwiftData defaults the store URL to Application Support, but
             // on a fresh simulator that directory doesn't exist yet and
@@ -59,6 +61,8 @@ final class SwiftDataStore {
                 LocalNote.self,
                 LocalList.self,
                 LocalKeyword.self,
+                LocalTrip.self,
+                LocalItineraryItem.self,
             ])
             let configuration = ModelConfiguration(
                 schema: schema,

--- a/mobile/PersonalDashboard/Design/Tokens.swift
+++ b/mobile/PersonalDashboard/Design/Tokens.swift
@@ -11,6 +11,7 @@ enum AppSection: String, CaseIterable, Identifiable, Hashable {
     case lists
     case dashboard
     case activity
+    case itineraries
     case vocabulary
     case settings
     case helpCenter
@@ -19,32 +20,34 @@ enum AppSection: String, CaseIterable, Identifiable, Hashable {
 
     var displayName: String {
         switch self {
-        case .chat:       return "Chat"
-        case .today:      return "Today"
-        case .tasks:      return "Tasks"
-        case .notes:      return "Notes"
-        case .lists:      return "Lists"
-        case .dashboard:  return "Dashboard"
-        case .activity:   return "Activity"
-        case .vocabulary: return "Vocabulary"
-        case .settings:   return "Settings"
-        case .helpCenter: return "Help center"
+        case .chat:        return "Chat"
+        case .today:       return "Today"
+        case .tasks:       return "Tasks"
+        case .notes:       return "Notes"
+        case .lists:       return "Lists"
+        case .dashboard:   return "Dashboard"
+        case .activity:    return "Activity"
+        case .itineraries: return "Itineraries"
+        case .vocabulary:  return "Vocabulary"
+        case .settings:    return "Settings"
+        case .helpCenter:  return "Help center"
         }
     }
 
     /// SF Symbol used in the side drawer and bottom tab bar.
     var icon: String {
         switch self {
-        case .chat:       return "sparkles"
-        case .today:      return "calendar"
-        case .tasks:      return "checkmark.square"
-        case .notes:      return "doc.text"
-        case .lists:      return "list.bullet"
-        case .dashboard:  return "rectangle.grid.2x2"
-        case .activity:   return "clock.arrow.circlepath"
-        case .vocabulary: return "character.book.closed"
-        case .settings:   return "gearshape"
-        case .helpCenter: return "questionmark.circle"
+        case .chat:        return "sparkles"
+        case .today:       return "calendar"
+        case .tasks:       return "checkmark.square"
+        case .notes:       return "doc.text"
+        case .lists:       return "list.bullet"
+        case .dashboard:   return "rectangle.grid.2x2"
+        case .activity:    return "clock.arrow.circlepath"
+        case .itineraries: return "airplane"
+        case .vocabulary:  return "character.book.closed"
+        case .settings:    return "gearshape"
+        case .helpCenter:  return "questionmark.circle"
         }
     }
 }
@@ -92,6 +95,7 @@ enum Tokens {
     static let accentDashboard = Color.paper(0x1F1B16, 0xF2EBDA)
     static let accentActivity  = Color.paper(0x7C3F58, 0xE5A3BA)
     static let accentVocabulary = Color.paper(0x57534E, 0xB7B0A2)
+    static let accentItineraries = Color.paper(0x6D28D9, 0xA78BFA)
     static let accentSettings  = Color.paper(0x475569, 0x94A3B8)
     static let accentHelp      = Color.paper(0x475569, 0x94A3B8)
     static let accentFg        = Color.paper(0xFFFFFF, 0x14110D)
@@ -107,16 +111,17 @@ enum Tokens {
 
     static func accent(for section: AppSection) -> Color {
         switch section {
-        case .chat:       return accentChat
-        case .today:      return accentToday
-        case .tasks:      return accentTasks
-        case .notes:      return accentNotes
-        case .lists:      return accentLists
-        case .dashboard:  return accentDashboard
-        case .activity:   return accentActivity
-        case .vocabulary: return accentVocabulary
-        case .settings:   return accentSettings
-        case .helpCenter: return accentHelp
+        case .chat:        return accentChat
+        case .today:       return accentToday
+        case .tasks:       return accentTasks
+        case .notes:       return accentNotes
+        case .lists:       return accentLists
+        case .dashboard:   return accentDashboard
+        case .activity:    return accentActivity
+        case .itineraries: return accentItineraries
+        case .vocabulary:  return accentVocabulary
+        case .settings:    return accentSettings
+        case .helpCenter:  return accentHelp
         }
     }
 }

--- a/mobile/PersonalDashboard/Models/Draft.swift
+++ b/mobile/PersonalDashboard/Models/Draft.swift
@@ -16,5 +16,11 @@ enum DraftActionType: String, Codable, Hashable, Sendable {
     case deleteNote = "DELETE_NOTE"
     case deleteList = "DELETE_LIST"
     case deleteFolder = "DELETE_FOLDER"
+    case createTrip = "CREATE_TRIP"
+    case addItineraryItems = "ADD_ITINERARY_ITEMS"
+    case updateTrip = "UPDATE_TRIP"
+    case deleteTrip = "DELETE_TRIP"
+    case updateItineraryItem = "UPDATE_ITINERARY_ITEM"
+    case deleteItineraryItem = "DELETE_ITINERARY_ITEM"
     case unknown = "UNKNOWN"
 }

--- a/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
@@ -1,0 +1,97 @@
+import Foundation
+import SwiftData
+
+/// Category of an itinerary item. Stored on `LocalItineraryItem.kind` as the
+/// `rawValue` so SwiftData stays on plain `String` (no custom-codable
+/// migrations to worry about). The skeleton ships four kinds; new ones can be
+/// added without a schema change.
+enum ItineraryKind: String, CaseIterable, Identifiable, Hashable {
+    case stay
+    case activity
+    case place
+    case restaurant
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .stay:       return "Stay"
+        case .activity:   return "Activity"
+        case .place:      return "Place"
+        case .restaurant: return "Restaurant"
+        }
+    }
+
+    /// SF Symbol used in row icons and the kind picker chips.
+    var icon: String {
+        switch self {
+        case .stay:       return "bed.double"
+        case .activity:   return "figure.walk"
+        case .place:      return "mappin.and.ellipse"
+        case .restaurant: return "fork.knife"
+        }
+    }
+}
+
+/// One row on a trip's day-by-day timeline. Belongs to a `LocalTrip` via
+/// `tripUUID` foreign key (no SwiftData relationship — keeps the schema
+/// boring and cascade-on-delete explicit, matching the rest of the app).
+@Model
+final class LocalItineraryItem {
+    @Attribute(.unique) var clientUUID: UUID
+
+    /// `LocalTrip.clientUUID` this item belongs to.
+    var tripUUID: UUID
+
+    /// The day this item lives on. Always normalised to `Calendar.startOfDay`
+    /// so grouping by day is just a key-equality check.
+    var dayDate: Date
+
+    /// `ItineraryKind.rawValue`. Stored as a String to keep SwiftData happy.
+    /// Read via `kindEnum` for type-safe access.
+    var kind: String
+
+    /// Short title (e.g. "Hanoi Hotel", "Halong Bay tour"). Required.
+    var title: String
+
+    /// Free-form notes. Empty when none.
+    var notes: String
+
+    /// Ordering within a single day. Lower numbers render first; ties are
+    /// broken by `createdAt`. Skeleton uses append-on-create (max + 1); a
+    /// drag-to-reorder UI is a follow-up.
+    var sortOrder: Int
+
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        clientUUID: UUID = UUID(),
+        tripUUID: UUID,
+        dayDate: Date,
+        kind: ItineraryKind,
+        title: String,
+        notes: String = "",
+        sortOrder: Int = 0,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.clientUUID = clientUUID
+        self.tripUUID = tripUUID
+        self.dayDate = dayDate
+        self.kind = kind.rawValue
+        self.title = title
+        self.notes = notes
+        self.sortOrder = sortOrder
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    /// Type-safe accessor backed by the stored raw `kind` string. Falls back
+    /// to `.activity` if the stored value can't be decoded (e.g. an older
+    /// schema added a kind that was later removed).
+    var kindEnum: ItineraryKind {
+        get { ItineraryKind(rawValue: kind) ?? .activity }
+        set { kind = newValue.rawValue }
+    }
+}

--- a/mobile/PersonalDashboard/Models/Local/LocalTrip.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalTrip.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftData
+
+/// Local-first SwiftData model for a trip in the Itineraries section (#104).
+///
+/// A trip has a destination name and a date range. Day-by-day timeline items
+/// (stays, activities, places, restaurants) are stored in `LocalItineraryItem`
+/// and joined back to this trip via `tripUUID` (no SwiftData relationship).
+/// Same `clientUUID` convention as the rest of the local models.
+@Model
+final class LocalTrip {
+    @Attribute(.unique) var clientUUID: UUID
+
+    /// Destination or trip title (e.g. "Vietnam"). Required.
+    var name: String
+
+    /// First day of the trip, inclusive. Stored at `Calendar.startOfDay`.
+    var startDate: Date
+
+    /// Last day of the trip, inclusive. Stored at `Calendar.startOfDay`.
+    var endDate: Date
+
+    /// Free-form notes the user types about the trip. Empty when none.
+    var notes: String
+
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+        clientUUID: UUID = UUID(),
+        name: String,
+        startDate: Date,
+        endDate: Date,
+        notes: String = "",
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.clientUUID = clientUUID
+        self.name = name
+        self.startDate = startDate
+        self.endDate = endDate
+        self.notes = notes
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/mobile/PersonalDashboard/Services/AIStreamingService.swift
+++ b/mobile/PersonalDashboard/Services/AIStreamingService.swift
@@ -23,6 +23,7 @@ struct AIStreamingService {
     /// Forwards `ChatStream.run` events into the local enum so callers stay
     /// decoupled from the Anthropic-flavored wire types.
     func parseStream(
+        history: [ChatStream.PriorTurn] = [],
         input: String,
         sessionId: String? = nil,
         timezone: String = TimeZone.current.identifier
@@ -30,7 +31,7 @@ struct AIStreamingService {
         AsyncThrowingStream { continuation in
             let task = Task { @MainActor in
                 do {
-                    for try await event in chatStream.run(input: input, timezone: timezone) {
+                    for try await event in chatStream.run(history: history, input: input, timezone: timezone) {
                         switch event {
                         case .draft(let d):
                             continuation.yield(.draft(d))

--- a/mobile/PersonalDashboard/ViewModels/ChatViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ChatViewModel.swift
@@ -78,6 +78,21 @@ final class ChatViewModel {
         let input = draftInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !input.isEmpty else { return }
         draftInput = ""
+
+        // Snapshot conversation history BEFORE appending the new user turn,
+        // so the stateless Anthropic API sees what was said earlier (and we
+        // don't double-count the current input). Auto-executed action
+        // results aren't replayed — the system prompt's EXISTING items
+        // context block is the source of truth for current device state.
+        let history: [ChatStream.PriorTurn] = turns.compactMap { turn in
+            let trimmed = turn.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            return ChatStream.PriorTurn(
+                role: turn.role == .user ? "user" : "assistant",
+                text: trimmed
+            )
+        }
+
         turns.append(ChatTurn(role: .user, text: input))
         isSending = true
         errorMessage = nil
@@ -89,7 +104,7 @@ final class ChatViewModel {
         turns.append(ChatTurn(id: assistantTurnId, role: .assistant, text: "", isStreaming: true))
 
         do {
-            for try await event in streamingService.parseStream(input: input, sessionId: sessionId) {
+            for try await event in streamingService.parseStream(history: history, input: input, sessionId: sessionId) {
                 guard let idx = turns.firstIndex(where: { $0.id == assistantTurnId }) else { break }
                 switch event {
                 case .draft(let d):

--- a/mobile/PersonalDashboard/Views/Chat/ChatResultCard.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatResultCard.swift
@@ -116,6 +116,12 @@ struct ChatResultCard: View {
             return "item"
         case .updateFolder, .deleteFolder:
             return "folder"
+        case .createTrip, .updateTrip, .deleteTrip:
+            return "trip"
+        case .addItineraryItems:
+            return "trip"
+        case .updateItineraryItem, .deleteItineraryItem:
+            return "item"
         case .unknown:
             return "action"
         }

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -194,6 +194,8 @@ struct ContentView: View {
             SettingsView(router: router, schemePref: schemePref)
         case .today:
             TodayView(router: router)
+        case .itineraries:
+            ItinerariesView(router: router)
         case .vocabulary:
             PersonalVocabularyView(router: router)
         case .helpCenter:

--- a/mobile/PersonalDashboard/Views/Itineraries/ItinerariesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/ItinerariesView.swift
@@ -1,0 +1,534 @@
+import SwiftUI
+import SwiftData
+
+/// Top-level surface where the user plans trips (issue #104).
+///
+/// The root view shows all `LocalTrip`s sorted by start date descending.
+/// Tapping a trip swaps the header in place to a detail header and renders
+/// `TripDetailView` below it — same inline-swap pattern `ListsView` uses, no
+/// `NavigationStack`. The leading-edge back gesture pops the detail back to
+/// the root via `router.leadingEdgeBackHandler`.
+///
+/// Both create and edit go through `TripEditorSheet` keyed by an
+/// `Identifiable` `TripEditorTarget`, mirroring `PersonalVocabularyView`.
+/// Deleting a trip cascades manually: every `LocalItineraryItem` whose
+/// `tripUUID` matches is deleted before the trip itself.
+struct ItinerariesView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @Bindable var router: AppRouter
+
+    @Query(sort: \LocalTrip.startDate, order: .reverse) private var trips: [LocalTrip]
+
+    /// Drives the trip editor sheet. `.new` for create, `.existing(_)` for edit.
+    @State private var editingTrip: TripEditorTarget?
+
+    /// `nil` means root list is showing. Setting a UUID swaps to detail.
+    @State private var selectedTripUUID: UUID?
+
+    var body: some View {
+        ZStack {
+            Tokens.paper.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                if let id = selectedTripUUID, let trip = trips.first(where: { $0.clientUUID == id }) {
+                    TripDetailHeader(
+                        trip: trip,
+                        onBack: {
+                            withAnimation(.easeOut(duration: 0.2)) { selectedTripUUID = nil }
+                        },
+                        onEdit: { editingTrip = .existing(id) }
+                    )
+                    TripDetailView(trip: trip)
+                } else {
+                    TopBar(
+                        title: "Itineraries",
+                        onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
+                    )
+                    rootContent
+                }
+            }
+
+            if selectedTripUUID == nil {
+                Button {
+                    editingTrip = .new
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
+                .padding(.trailing, 22)
+                .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                .accessibilityLabel("New trip")
+            }
+        }
+        .activeSection(.itineraries)
+        .onAppear { syncBackHandler() }
+        .onDisappear {
+            if selectedTripUUID != nil {
+                router.leadingEdgeBackHandler = nil
+            }
+        }
+        .onChange(of: selectedTripUUID) { _, _ in syncBackHandler() }
+        .sheet(item: $editingTrip) { target in
+            TripEditorSheet(target: target)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    // MARK: - Root content
+
+    @ViewBuilder
+    private var rootContent: some View {
+        if trips.isEmpty {
+            emptyState
+        } else {
+            tripList
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Space.md) {
+            Spacer()
+            Image(systemName: "airplane")
+                .font(.system(size: 28, weight: .regular))
+                .foregroundStyle(Tokens.muted)
+            Text("Plan your next trip")
+                .font(.edHeading)
+                .foregroundStyle(Tokens.ink)
+                .multilineTextAlignment(.center)
+            Text("Add a destination and date range, then lay out the day-by-day timeline of stays, activities, places, and restaurants.")
+                .font(.edSubheadline)
+                .foregroundStyle(Tokens.muted)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Space.xl)
+            Spacer()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, Space.lg)
+    }
+
+    private var tripList: some View {
+        List {
+            ForEach(trips) { trip in
+                TripRow(trip: trip, itemCount: itemCount(for: trip)) {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        selectedTripUUID = trip.clientUUID
+                    }
+                }
+                .swipeToDeleteTrash {
+                    delete(trip)
+                }
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
+            }
+
+            Color.clear
+                .frame(height: 96)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Tokens.paper)
+        .scrollDismissesKeyboard(.interactively)
+    }
+
+    // MARK: - Back-swipe wiring (mirrors ListsView.syncBackHandler)
+
+    private func syncBackHandler() {
+        let binding = $selectedTripUUID
+        if selectedTripUUID != nil {
+            router.leadingEdgeBackHandler = {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    binding.wrappedValue = nil
+                }
+            }
+        } else {
+            router.leadingEdgeBackHandler = nil
+        }
+    }
+
+    // MARK: - Persistence
+
+    /// Cascade delete: items first (so no orphans linger in the store), then
+    /// the trip. Same pattern Lists uses for embedded items, just spelled out
+    /// across two model types.
+    private func delete(_ trip: LocalTrip) {
+        let tripID = trip.clientUUID
+        let descriptor = FetchDescriptor<LocalItineraryItem>(
+            predicate: #Predicate { $0.tripUUID == tripID }
+        )
+        if let items = try? modelContext.fetch(descriptor) {
+            for item in items { modelContext.delete(item) }
+        }
+        modelContext.delete(trip)
+        try? modelContext.save()
+    }
+
+    /// Cheap count for the row badge. Item counts will be small enough that a
+    /// per-row fetch is fine for a skeleton; revisit if a trip ever holds
+    /// hundreds of items.
+    private func itemCount(for trip: LocalTrip) -> Int {
+        let tripID = trip.clientUUID
+        let descriptor = FetchDescriptor<LocalItineraryItem>(
+            predicate: #Predicate { $0.tripUUID == tripID }
+        )
+        return (try? modelContext.fetchCount(descriptor)) ?? 0
+    }
+}
+
+// MARK: - Editor target
+
+/// Identifiable wrapper used as the `.sheet(item:)` payload for the trip
+/// editor. Carries the UUID (not the live model) so the sheet stays stateless
+/// across re-renders.
+enum TripEditorTarget: Identifiable {
+    case new
+    case existing(UUID)
+
+    var id: String {
+        switch self {
+        case .new:                return "new"
+        case .existing(let uuid): return uuid.uuidString
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct TripRow: View {
+    let trip: LocalTrip
+    let itemCount: Int
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: Space.sm) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(trip.name)
+                        .font(.edBodyMedium)
+                        .foregroundStyle(Tokens.ink)
+                        .lineLimit(1)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .regular))
+                        .foregroundStyle(Tokens.mutedSoft)
+                }
+
+                HStack(spacing: Space.sm) {
+                    Text(Self.formatRange(start: trip.startDate, end: trip.endDate))
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.muted)
+                    Spacer()
+                    HStack(spacing: 4) {
+                        Image(systemName: "list.bullet")
+                            .font(.system(size: 10, weight: .regular))
+                        Text("\(itemCount)")
+                    }
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.muted)
+                    .padding(.horizontal, Space.sm)
+                    .padding(.vertical, 2)
+                    .background(Tokens.paper2, in: Capsule())
+                }
+            }
+            .padding(.horizontal, Space.md)
+            .padding(.vertical, Space.md)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+            .paperBorder(Tokens.border, radius: Radius.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(trip.name), \(Self.formatRange(start: trip.startDate, end: trip.endDate)). Tap to open.")
+    }
+
+    /// "1 May – 10 May 2026" / "28 Dec 2026 – 3 Jan 2027" / single-day
+    /// "5 Mar 2026". Year is suppressed on the start side when both dates
+    /// share the same year.
+    static func formatRange(start: Date, end: Date) -> String {
+        let cal = Calendar.current
+        let sameDay = cal.isDate(start, inSameDayAs: end)
+        let sameYear = cal.component(.year, from: start) == cal.component(.year, from: end)
+
+        let startNoYear = start.formatted(.dateTime.day().month(.abbreviated))
+        let endFull = end.formatted(.dateTime.day().month(.abbreviated).year())
+        let startFull = start.formatted(.dateTime.day().month(.abbreviated).year())
+
+        if sameDay { return startFull }
+        if sameYear { return "\(startNoYear) – \(endFull)" }
+        return "\(startFull) – \(endFull)"
+    }
+}
+
+// MARK: - Detail header
+
+/// Header shown above `TripDetailView` when a trip is selected. Mirrors
+/// `ListDetailHeader` in `ListsView.swift`: back chevron + label, centred
+/// title, trailing affordance (Edit instead of Delete because trip edits
+/// span name + dates + notes and warrant the full sheet).
+private struct TripDetailHeader: View {
+    let trip: LocalTrip
+    let onBack: () -> Void
+    let onEdit: () -> Void
+
+    var body: some View {
+        HStack(spacing: Space.md) {
+            Button(action: onBack) {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                    Text("Trips")
+                }
+                .font(.edBody)
+                .foregroundStyle(Tokens.muted)
+                .frame(height: 44)
+                .contentShape(Rectangle())
+            }
+            Spacer()
+            VStack(spacing: 2) {
+                Text(trip.name)
+                    .font(.edTitle)
+                    .foregroundStyle(Tokens.ink)
+                    .lineLimit(1)
+                Text(TripRow.formatRange(start: trip.startDate, end: trip.endDate))
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.muted)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button(action: onEdit) {
+                Image(systemName: "square.and.pencil")
+                    .frame(width: 44, height: 44)
+                    .foregroundStyle(Tokens.muted)
+            }
+            .accessibilityLabel("Edit trip")
+        }
+        .padding(.horizontal, Space.md)
+        .frame(height: 56)
+        .background(Tokens.paper.overlay(alignment: .bottom) {
+            Rectangle().fill(Tokens.divider).frame(height: 0.5)
+        })
+    }
+}
+
+// MARK: - Trip editor sheet
+
+private struct TripEditorSheet: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    let target: TripEditorTarget
+
+    @State private var name: String = ""
+    @State private var startDate: Date = Calendar.current.startOfDay(for: Date())
+    @State private var endDate: Date = Calendar.current.startOfDay(for: Date())
+    @State private var notes: String = ""
+    @State private var loaded: Bool = false
+    @FocusState private var nameFocused: Bool
+
+    private let nameMaxLength = 64
+    private let notesMaxLength = 1000
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Space.lg) {
+                        nameField
+                        dateFields
+                        notesField
+                    }
+                    .padding(Space.lg)
+                }
+            }
+            .navigationTitle(isEditing ? "Edit trip" : "New trip")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Tokens.muted)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isEditing ? "Save" : "Add") {
+                        save()
+                        dismiss()
+                    }
+                    .disabled(trimmedName.isEmpty)
+                    .foregroundStyle(trimmedName.isEmpty ? Tokens.muted : Tokens.ink)
+                }
+            }
+        }
+        .onAppear { loadIfNeeded() }
+        .onChange(of: startDate) { _, newStart in
+            // Keep end >= start. Adjust silently rather than reject.
+            if endDate < newStart { endDate = newStart }
+        }
+    }
+
+    // MARK: - Fields
+
+    private var nameField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Destination").eyebrow()
+            TextField("e.g. Vietnam", text: $name)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .padding(Space.md)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                .paperBorder(Tokens.border, radius: Radius.md)
+                .submitLabel(.done)
+                .focused($nameFocused)
+                .onChange(of: name) { _, newValue in
+                    if newValue.count > nameMaxLength {
+                        name = String(newValue.prefix(nameMaxLength))
+                    }
+                }
+                .accessibilityLabel("Destination")
+        }
+    }
+
+    private var dateFields: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Dates").eyebrow()
+            VStack(spacing: Space.sm) {
+                HStack {
+                    Text("Start").font(.edBody).foregroundStyle(Tokens.inkSoft)
+                    Spacer()
+                    DatePicker("", selection: $startDate, displayedComponents: .date)
+                        .labelsHidden()
+                        .tint(Tokens.accent(for: .itineraries))
+                }
+                Rectangle().fill(Tokens.divider).frame(height: 0.5)
+                HStack {
+                    Text("End").font(.edBody).foregroundStyle(Tokens.inkSoft)
+                    Spacer()
+                    DatePicker("", selection: $endDate, in: startDate..., displayedComponents: .date)
+                        .labelsHidden()
+                        .tint(Tokens.accent(for: .itineraries))
+                }
+            }
+            .padding(Space.md)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    private var notesField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            HStack {
+                Text("Notes").eyebrow()
+                Spacer()
+                Text("Optional")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            ZStack(alignment: .topLeading) {
+                if notes.isEmpty {
+                    Text("Anything to remember about this trip…")
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.mutedSoft)
+                        .padding(.horizontal, Space.md + 4)
+                        .padding(.vertical, Space.md + 8)
+                        .allowsHitTesting(false)
+                }
+                TextEditor(text: $notes)
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.ink)
+                    .scrollContentBackground(.hidden)
+                    .padding(.horizontal, Space.md)
+                    .padding(.vertical, Space.sm)
+                    .frame(minHeight: 96, alignment: .topLeading)
+                    .onChange(of: notes) { _, newValue in
+                        if newValue.count > notesMaxLength {
+                            notes = String(newValue.prefix(notesMaxLength))
+                        }
+                    }
+                    .accessibilityLabel("Notes")
+            }
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    // MARK: - Persistence
+
+    private var isEditing: Bool {
+        if case .existing = target { return true }
+        return false
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedNotes: String {
+        notes.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        loaded = true
+
+        if case let .existing(uuid) = target {
+            let descriptor = FetchDescriptor<LocalTrip>(
+                predicate: #Predicate { $0.clientUUID == uuid }
+            )
+            if let existing = try? modelContext.fetch(descriptor).first {
+                name = existing.name
+                startDate = existing.startDate
+                endDate = existing.endDate
+                notes = existing.notes
+            }
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                nameFocused = true
+            }
+        }
+    }
+
+    private func save() {
+        let cleanName = trimmedName
+        guard !cleanName.isEmpty else { return }
+        let cleanNotes = trimmedNotes
+        let cal = Calendar.current
+        let normalisedStart = cal.startOfDay(for: startDate)
+        let normalisedEnd = cal.startOfDay(for: endDate)
+
+        switch target {
+        case .new:
+            let trip = LocalTrip(
+                name: cleanName,
+                startDate: normalisedStart,
+                endDate: normalisedEnd,
+                notes: cleanNotes
+            )
+            modelContext.insert(trip)
+        case .existing(let uuid):
+            let descriptor = FetchDescriptor<LocalTrip>(
+                predicate: #Predicate { $0.clientUUID == uuid }
+            )
+            if let existing = try? modelContext.fetch(descriptor).first {
+                existing.name = cleanName
+                existing.startDate = normalisedStart
+                existing.endDate = normalisedEnd
+                existing.notes = cleanNotes
+                existing.updatedAt = Date()
+            } else {
+                let trip = LocalTrip(
+                    name: cleanName,
+                    startDate: normalisedStart,
+                    endDate: normalisedEnd,
+                    notes: cleanNotes
+                )
+                modelContext.insert(trip)
+            }
+        }
+        try? modelContext.save()
+    }
+}

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -1,0 +1,553 @@
+import SwiftUI
+import SwiftData
+
+/// Day-by-day timeline for a single `LocalTrip`. One section per calendar day
+/// from `trip.startDate` through `trip.endDate` (inclusive). Items render
+/// inside the section that matches their `dayDate`. Any item with a `dayDate`
+/// outside the trip range still gets a section so users don't lose data when
+/// they shrink a trip's range.
+///
+/// Items are added via a per-day "+ Add" button that opens
+/// `ItineraryItemEditorSheet` pre-filled with that day's date and a default
+/// kind. Tapping an existing item re-opens the same sheet for edit.
+/// Swipe-to-delete fires `Haptics.destructive()` and removes the item.
+struct TripDetailView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    let trip: LocalTrip
+
+    @Query private var items: [LocalItineraryItem]
+
+    /// Drives the item editor. `.new(day:)` carries the pre-filled day so a
+    /// per-day "+ Add" button doesn't need to re-derive it. `.existing(_)`
+    /// carries the item UUID for edit.
+    @State private var editingItem: ItineraryItemEditorTarget?
+
+    init(trip: LocalTrip) {
+        self.trip = trip
+        let tripID = trip.clientUUID
+        _items = Query(
+            filter: #Predicate<LocalItineraryItem> { $0.tripUUID == tripID },
+            sort: [
+                SortDescriptor(\.dayDate, order: .forward),
+                SortDescriptor(\.sortOrder, order: .forward),
+                SortDescriptor(\.createdAt, order: .forward)
+            ]
+        )
+    }
+
+    var body: some View {
+        List {
+            ForEach(days, id: \.self) { day in
+                Section {
+                    let dayItems = itemsByDay[day] ?? []
+                    if dayItems.isEmpty {
+                        emptyDayRow
+                    } else {
+                        ForEach(dayItems) { item in
+                            ItineraryItemRow(item: item) {
+                                editingItem = .existing(item.clientUUID)
+                            }
+                            .swipeToDeleteTrash {
+                                Haptics.destructive()
+                                delete(item)
+                            }
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
+                        }
+                    }
+
+                    addRow(day: day)
+                } header: {
+                    dayHeader(for: day)
+                }
+            }
+
+            Color.clear
+                .frame(height: 96)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets())
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Tokens.paper)
+        .scrollDismissesKeyboard(.interactively)
+        .sheet(item: $editingItem) { target in
+            ItineraryItemEditorSheet(trip: trip, target: target)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    // MARK: - Day computation
+
+    /// Union of (calendar days from start to end inclusive) and (distinct
+    /// dayDates of existing items). Sorted ascending. This way a trip with
+    /// items beyond its current end date still shows those items in their
+    /// own section instead of silently hiding them.
+    private var days: [Date] {
+        let cal = Calendar.current
+        let start = cal.startOfDay(for: trip.startDate)
+        let end = cal.startOfDay(for: trip.endDate)
+
+        var set = Set<Date>()
+        var cursor = start
+        while cursor <= end {
+            set.insert(cursor)
+            guard let next = cal.date(byAdding: .day, value: 1, to: cursor) else { break }
+            cursor = next
+        }
+        for item in items {
+            set.insert(cal.startOfDay(for: item.dayDate))
+        }
+        return set.sorted()
+    }
+
+    private var itemsByDay: [Date: [LocalItineraryItem]] {
+        let cal = Calendar.current
+        return Dictionary(grouping: items) { cal.startOfDay(for: $0.dayDate) }
+    }
+
+    // MARK: - Subviews
+
+    private func dayHeader(for day: Date) -> some View {
+        let cal = Calendar.current
+        let tripStart = cal.startOfDay(for: trip.startDate)
+        let tripEnd = cal.startOfDay(for: trip.endDate)
+        let withinTrip = day >= tripStart && day <= tripEnd
+        let dayNumber = cal.dateComponents([.day], from: tripStart, to: day).day.map { $0 + 1 } ?? 0
+        let weekdayDate = day.formatted(.dateTime.weekday(.abbreviated).day().month(.abbreviated))
+
+        return HStack(spacing: Space.sm) {
+            if withinTrip {
+                Text("Day \(dayNumber)")
+                    .font(.edEyebrow)
+                    .foregroundStyle(Tokens.accent(for: .itineraries))
+                Text("·")
+                    .font(.edEyebrow)
+                    .foregroundStyle(Tokens.mutedSoft)
+                Text(weekdayDate)
+                    .font(.edEyebrow)
+                    .foregroundStyle(Tokens.muted)
+            } else {
+                Text("Outside trip")
+                    .font(.edEyebrow)
+                    .foregroundStyle(Tokens.muted)
+                Text("·")
+                    .font(.edEyebrow)
+                    .foregroundStyle(Tokens.mutedSoft)
+                Text(weekdayDate)
+                    .font(.edEyebrow)
+                    .foregroundStyle(Tokens.muted)
+            }
+            Spacer()
+        }
+        .textCase(nil)
+        .padding(.horizontal, Space.lg)
+        .padding(.top, Space.lg)
+        .padding(.bottom, Space.xs)
+        .background(Tokens.paper)
+    }
+
+    private var emptyDayRow: some View {
+        Text("Nothing planned")
+            .font(.edSubheadline)
+            .foregroundStyle(Tokens.mutedSoft)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, Space.sm)
+            .listRowBackground(Color.clear)
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
+    }
+
+    private func addRow(day: Date) -> some View {
+        Button {
+            editingItem = .new(day: day)
+        } label: {
+            HStack(spacing: Space.sm) {
+                Image(systemName: "plus")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Add to this day")
+                    .font(.edFootnote)
+                Spacer()
+            }
+            .foregroundStyle(Tokens.accent(for: .itineraries))
+            .padding(.horizontal, Space.md)
+            .padding(.vertical, Space.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+            .paperBorder(Tokens.border, radius: Radius.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.lg, trailing: Space.lg))
+        .accessibilityLabel("Add item to \(day.formatted(.dateTime.weekday().day().month()))")
+    }
+
+    // MARK: - Persistence
+
+    private func delete(_ item: LocalItineraryItem) {
+        modelContext.delete(item)
+        try? modelContext.save()
+    }
+}
+
+// MARK: - Editor target
+
+/// Identifiable wrapper used as the `.sheet(item:)` payload for the item
+/// editor. `.new(day:)` carries the day so the per-day "+ Add" button can
+/// pre-fill the picker; `.existing(_)` carries the UUID.
+enum ItineraryItemEditorTarget: Identifiable {
+    case new(day: Date)
+    case existing(UUID)
+
+    var id: String {
+        switch self {
+        case .new(let day):       return "new-\(day.timeIntervalSince1970)"
+        case .existing(let uuid): return uuid.uuidString
+        }
+    }
+}
+
+// MARK: - Item row
+
+private struct ItineraryItemRow: View {
+    let item: LocalItineraryItem
+    let onTap: () -> Void
+
+    var body: some View {
+        let kind = item.kindEnum
+        Button(action: onTap) {
+            HStack(alignment: .top, spacing: Space.md) {
+                Image(systemName: kind.icon)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundStyle(Tokens.accent(for: .itineraries))
+                    .frame(width: 24, height: 24)
+                    .padding(.top, 2)
+
+                VStack(alignment: .leading, spacing: Space.xs) {
+                    Text(item.title)
+                        .font(.edBodyMedium)
+                        .foregroundStyle(Tokens.ink)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+
+                    HStack(spacing: Space.sm) {
+                        Text(kind.displayName.uppercased())
+                            .font(.edEyebrow)
+                            .foregroundStyle(Tokens.muted)
+
+                        let trimmed = item.notes.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !trimmed.isEmpty {
+                            Text("·")
+                                .font(.edEyebrow)
+                                .foregroundStyle(Tokens.mutedSoft)
+                            Text(trimmed)
+                                .font(.edSubheadline)
+                                .foregroundStyle(Tokens.muted)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                        }
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, Space.md)
+            .padding(.vertical, Space.md)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+            .paperBorder(Tokens.border, radius: Radius.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(kind.displayName): \(item.title). Tap to edit.")
+    }
+}
+
+// MARK: - Item editor sheet
+
+private struct ItineraryItemEditorSheet: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    let trip: LocalTrip
+    let target: ItineraryItemEditorTarget
+
+    @State private var title: String = ""
+    @State private var kind: ItineraryKind = .activity
+    @State private var dayDate: Date = Calendar.current.startOfDay(for: Date())
+    @State private var notes: String = ""
+    @State private var loaded: Bool = false
+    @FocusState private var titleFocused: Bool
+
+    private let titleMaxLength = 96
+    private let notesMaxLength = 1000
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Space.lg) {
+                        kindField
+                        titleField
+                        dayField
+                        notesField
+                    }
+                    .padding(Space.lg)
+                }
+            }
+            .navigationTitle(isEditing ? "Edit item" : "New item")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Tokens.muted)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isEditing ? "Save" : "Add") {
+                        save()
+                        dismiss()
+                    }
+                    .disabled(trimmedTitle.isEmpty)
+                    .foregroundStyle(trimmedTitle.isEmpty ? Tokens.muted : Tokens.ink)
+                }
+            }
+        }
+        .onAppear { loadIfNeeded() }
+    }
+
+    // MARK: - Fields
+
+    private var kindField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Kind").eyebrow()
+            HStack(spacing: Space.sm) {
+                ForEach(ItineraryKind.allCases) { option in
+                    KindChip(kind: option, isSelected: option == kind) {
+                        kind = option
+                    }
+                }
+            }
+        }
+    }
+
+    private var titleField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Title").eyebrow()
+            TextField(placeholder(for: kind), text: $title)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .padding(Space.md)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                .paperBorder(Tokens.border, radius: Radius.md)
+                .submitLabel(.done)
+                .focused($titleFocused)
+                .onChange(of: title) { _, newValue in
+                    if newValue.count > titleMaxLength {
+                        title = String(newValue.prefix(titleMaxLength))
+                    }
+                }
+                .accessibilityLabel("Title")
+        }
+    }
+
+    private var dayField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Day").eyebrow()
+            HStack {
+                Text("Date").font(.edBody).foregroundStyle(Tokens.inkSoft)
+                Spacer()
+                // Trip dates aren't a hard constraint here — picking outside
+                // the range keeps the item visible under an "Outside trip"
+                // section, so the user can still extend the trip later
+                // without losing the item.
+                DatePicker("", selection: $dayDate, displayedComponents: .date)
+                    .labelsHidden()
+                    .tint(Tokens.accent(for: .itineraries))
+            }
+            .padding(Space.md)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    private var notesField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            HStack {
+                Text("Notes").eyebrow()
+                Spacer()
+                Text("Optional")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            ZStack(alignment: .topLeading) {
+                if notes.isEmpty {
+                    Text("Address, time, anything to remember…")
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.mutedSoft)
+                        .padding(.horizontal, Space.md + 4)
+                        .padding(.vertical, Space.md + 8)
+                        .allowsHitTesting(false)
+                }
+                TextEditor(text: $notes)
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.ink)
+                    .scrollContentBackground(.hidden)
+                    .padding(.horizontal, Space.md)
+                    .padding(.vertical, Space.sm)
+                    .frame(minHeight: 96, alignment: .topLeading)
+                    .onChange(of: notes) { _, newValue in
+                        if newValue.count > notesMaxLength {
+                            notes = String(newValue.prefix(notesMaxLength))
+                        }
+                    }
+                    .accessibilityLabel("Notes")
+            }
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    private func placeholder(for kind: ItineraryKind) -> String {
+        switch kind {
+        case .stay:       return "e.g. Hanoi Hilton"
+        case .activity:   return "e.g. Halong Bay tour"
+        case .place:      return "e.g. Hội An old town"
+        case .restaurant: return "e.g. Bún chả Hương Liên"
+        }
+    }
+
+    // MARK: - Persistence
+
+    private var isEditing: Bool {
+        if case .existing = target { return true }
+        return false
+    }
+
+    private var trimmedTitle: String {
+        title.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedNotes: String {
+        notes.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        loaded = true
+
+        switch target {
+        case .new(let day):
+            dayDate = Calendar.current.startOfDay(for: day)
+            // Default kind heuristic: if the day is the trip's first day,
+            // most users add a Stay first. Otherwise default to Activity.
+            if Calendar.current.isDate(day, inSameDayAs: trip.startDate) {
+                kind = .stay
+            } else {
+                kind = .activity
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                titleFocused = true
+            }
+        case .existing(let uuid):
+            let descriptor = FetchDescriptor<LocalItineraryItem>(
+                predicate: #Predicate { $0.clientUUID == uuid }
+            )
+            if let existing = try? modelContext.fetch(descriptor).first {
+                title = existing.title
+                kind = existing.kindEnum
+                dayDate = existing.dayDate
+                notes = existing.notes
+            }
+        }
+    }
+
+    private func save() {
+        let cleanTitle = trimmedTitle
+        guard !cleanTitle.isEmpty else { return }
+        let cleanNotes = trimmedNotes
+        let normalisedDay = Calendar.current.startOfDay(for: dayDate)
+
+        switch target {
+        case .new:
+            let nextSort = nextSortOrder(for: normalisedDay)
+            let item = LocalItineraryItem(
+                tripUUID: trip.clientUUID,
+                dayDate: normalisedDay,
+                kind: kind,
+                title: cleanTitle,
+                notes: cleanNotes,
+                sortOrder: nextSort
+            )
+            modelContext.insert(item)
+        case .existing(let uuid):
+            let descriptor = FetchDescriptor<LocalItineraryItem>(
+                predicate: #Predicate { $0.clientUUID == uuid }
+            )
+            if let existing = try? modelContext.fetch(descriptor).first {
+                existing.title = cleanTitle
+                existing.kindEnum = kind
+                if Calendar.current.startOfDay(for: existing.dayDate) != normalisedDay {
+                    // Day moved: re-sortOrder so the item lands at the end of
+                    // the new day instead of slotting into the old position.
+                    existing.sortOrder = nextSortOrder(for: normalisedDay)
+                }
+                existing.dayDate = normalisedDay
+                existing.notes = cleanNotes
+                existing.updatedAt = Date()
+            }
+        }
+        try? modelContext.save()
+    }
+
+    /// Append-on-create ordering: max sortOrder for the day + 1. Falls back to
+    /// 0 when the day has no existing items.
+    private func nextSortOrder(for day: Date) -> Int {
+        let tripID = trip.clientUUID
+        let descriptor = FetchDescriptor<LocalItineraryItem>(
+            predicate: #Predicate { $0.tripUUID == tripID && $0.dayDate == day }
+        )
+        let existing = (try? modelContext.fetch(descriptor)) ?? []
+        return (existing.map(\.sortOrder).max() ?? -1) + 1
+    }
+}
+
+// MARK: - Kind chip
+
+private struct KindChip: View {
+    let kind: ItineraryKind
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 4) {
+                Image(systemName: kind.icon)
+                    .font(.system(size: 12, weight: .regular))
+                Text(kind.displayName)
+                    .font(.edFootnote)
+            }
+            .padding(.horizontal, Space.sm)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity)
+            .foregroundStyle(isSelected ? Tokens.accentFg : Tokens.inkSoft)
+            .background(
+                isSelected ? Tokens.accent(for: .itineraries) : Tokens.surface,
+                in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                    .stroke(isSelected ? Color.clear : Tokens.border, lineWidth: 0.5)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(kind.displayName)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}

--- a/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
+++ b/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
@@ -111,13 +111,14 @@ struct SideDrawer: View {
 
             DrawerDivider()
 
-            // Four rows: Today, Personal vocabulary, Help center, Settings.
-            // Primary surfaces (Notes, Lists, Tasks, Activity) and Chat now
-            // live in the bottom tab bar. Dashboard remains hidden (issue #30).
-            // Vocabulary sits second because it's the user's "teach the
-            // assistant" surface — close to Today as a daily-use destination,
-            // not buried under Settings (issue #100 follow-up).
+            // Five rows: Today, Itineraries, Vocabulary, Help center, Settings.
+            // Primary surfaces (Notes, Lists, Tasks, Activity) and Chat live
+            // in the bottom tab bar. Dashboard remains hidden (issue #30).
+            // Itineraries sits between Today and Vocabulary so the user's
+            // travel planning surface stays close to their daily-use rows
+            // (issue #104).
             DrawerRow(section: .today, router: router)
+            DrawerRow(section: .itineraries, router: router)
             DrawerRow(section: .vocabulary, router: router)
             DrawerRow(section: .helpCenter, router: router)
             DrawerRow(section: .settings, router: router)


### PR DESCRIPTION
## Summary

Lands the Itineraries surface end-to-end and wires up natural-language planning via chat + voice.

- **#104 — Itineraries skeleton**: new top-level section between Today and Vocabulary, SwiftData models (`LocalTrip`, `LocalItineraryItem`), per-day timeline view, create / edit / delete UX, empty state.
- **#106 — Chat + voice AI tools**: 6 new tools (`draft_trip`, `add_itinerary_item`, `edit_trip`, `delete_trip`, `edit_itinerary_item`, `delete_itinerary_item`), dispatcher arms with cascade-delete on trips, EXISTING TRIPS context block, trip-intent routing in both chat and capture prompts.
- Bonus fix: chat now threads conversation history to Anthropic so the model doesn't forget prior turns (was sending each message in isolation).
- Bonus fix: capture / Shortcut voice path no longer hard-coded to task / note / list; trip phrasings route to `draft_trip`.

## Test plan

QA was done live on iPhone 16 Pro Max across multiple builds (final: build 10):

- [x] Drawer shows `Itineraries` between Today and Vocabulary.
- [x] Create / open / edit / delete a trip from the UI.
- [x] Day rows render between start and end dates; `+` adds stay / activity / place / restaurant.
- [x] Chat: `"Plan a trip to Italy"` asks for dates first.
- [x] Chat: `"Plan a trip to Italy from 14 to 21 June"` creates the trip.
- [x] Chat: follow-up `"add a hotel in Rome on day 1"` adds an itinerary item to the existing trip.
- [x] Chat: session memory works across turns (regression fix).
- [x] Capture / voice: `"plan a trip to Italy from 14 to 21 June"` creates the trip via Shortcut.
- [x] Capture / voice without dates returns an assistant dialog asking for them.
- [x] Static build clean (`xcodegen generate` + `xcodebuild build`).

Closes #104
Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)