### PR TITLE
feat(ios): empty-by-default vertical itinerary timeline + optional times

### DIFF
--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -495,6 +495,18 @@ struct ExecuteDraftAction {
             // model can omit the field entirely; we don't require it.
             let startTime = parseAnyISODate(dict["start_time"]?.stringValue)
 
+            // Stay-only check-out fields. For non-stay kinds, both are
+            // discarded even if the model accidentally provided them.
+            var endDateValue: Date? = nil
+            var endTimeValue: Date? = nil
+            if kind == .stay {
+                if let endRaw = dict["end_date"]?.stringValue,
+                   let parsedEnd = parseAnyISODate(endRaw) {
+                    endDateValue = cal.startOfDay(for: parsedEnd)
+                }
+                endTimeValue = parseAnyISODate(dict["end_time"]?.stringValue)
+            }
+
             let maxForDay = existing
                 .filter { cal.isDate($0.dayDate, inSameDayAs: dayStart) }
                 .map { $0.sortOrder }
@@ -507,6 +519,8 @@ struct ExecuteDraftAction {
                 title: title,
                 notes: cleanNotes,
                 startTime: startTime,
+                endDate: endDateValue,
+                endTime: endTimeValue,
                 sortOrder: maxForDay + 1,
                 createdAt: now,
                 updatedAt: now
@@ -641,6 +655,30 @@ struct ExecuteDraftAction {
             } else if !trimmed.isEmpty, let parsed = parseAnyISODate(trimmed) {
                 row.startTime = parsed; changed = true
             }
+        }
+        // end_date / end_time: same tri-state. Cleared automatically when
+        // kind switches away from stay (handled below after `changed` check).
+        if let raw = input["end_date"]?.stringValue {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == "null" {
+                row.endDate = nil; changed = true
+            } else if !trimmed.isEmpty, let parsed = parseAnyISODate(trimmed) {
+                row.endDate = cal.startOfDay(for: parsed); changed = true
+            }
+        }
+        if let raw = input["end_time"]?.stringValue {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == "null" {
+                row.endTime = nil; changed = true
+            } else if !trimmed.isEmpty, let parsed = parseAnyISODate(trimmed) {
+                row.endTime = parsed; changed = true
+            }
+        }
+        // If the kind isn't stay any more, clear the stay-only fields so the
+        // persisted shape doesn't leak stale data through the timeline.
+        if row.kindEnum != .stay {
+            if row.endDate != nil { row.endDate = nil; changed = true }
+            if row.endTime != nil { row.endTime = nil; changed = true }
         }
 
         guard changed else {

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -490,6 +490,11 @@ struct ExecuteDraftAction {
             let notes = (dict["notes"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
             let cleanNotes = notes == "null" ? "" : notes
 
+            // Optional start_time: any unparseable value silently falls back
+            // to nil (untimed) rather than failing the whole batch. The
+            // model can omit the field entirely; we don't require it.
+            let startTime = parseAnyISODate(dict["start_time"]?.stringValue)
+
             let maxForDay = existing
                 .filter { cal.isDate($0.dayDate, inSameDayAs: dayStart) }
                 .map { $0.sortOrder }
@@ -501,6 +506,7 @@ struct ExecuteDraftAction {
                 kind: kind,
                 title: title,
                 notes: cleanNotes,
+                startTime: startTime,
                 sortOrder: maxForDay + 1,
                 createdAt: now,
                 updatedAt: now
@@ -623,6 +629,17 @@ struct ExecuteDraftAction {
                 if !trimmed.isEmpty {
                     row.notes = trimmed; changed = true
                 }
+            }
+        }
+        // start_time follows the same empty/"null"/value tri-state as notes.
+        // Empty string = keep current value, "null" = clear (untimed),
+        // anything else = parse as ISO 8601 and set.
+        if let raw = input["start_time"]?.stringValue {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == "null" {
+                row.startTime = nil; changed = true
+            } else if !trimmed.isEmpty, let parsed = parseAnyISODate(trimmed) {
+                row.startTime = parsed; changed = true
             }
         }
 

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -272,6 +272,10 @@ enum ToolDefinitions {
             "notes": .object([
                 "type": .string("string"),
                 "description": .string("Free-form notes. Use empty string if none.")
+            ]),
+            "start_time": .object([
+                "type": .string("string"),
+                "description": .string("OPTIONAL start time for this item as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T19:00:00-04:00 or 2026-06-14T11:00:00Z). The DATE portion MUST match day_date. Set this whenever the user mentions a time (e.g., 'dinner at 8', '11am check-in', 'tour at 14:00'); otherwise omit. Items without a start_time render as 'untimed' on the timeline.")
             ])
         ]),
         "required": .array([.string("day_date"), .string("kind"), .string("title"), .string("notes")])
@@ -329,14 +333,15 @@ enum ToolDefinitions {
 
     private static let editItineraryItem = AnthropicTool(
         name: "edit_itinerary_item",
-        description: "Edit an EXISTING itinerary item's day, kind, title, or notes. Requires the item UUID. IMPORTANT: At least one field must actually change. Use empty string for fields to keep unchanged. Use the literal string \"null\" ONLY for notes to clear it. day_date, kind, and title cannot be cleared.",
+        description: "Edit an EXISTING itinerary item's day, kind, title, notes, or start time. Requires the item UUID. IMPORTANT: At least one field must actually change. Use empty string for fields to keep unchanged. Use the literal string \"null\" for notes or start_time to CLEAR them. day_date, kind, and title cannot be cleared.",
         input_schema: object(
             properties: [
                 "id": string("The UUID of the existing itinerary item to edit (from EXISTING TRIPS context)."),
                 "day_date": string("New day for this item in ISO 8601. Use empty string to keep unchanged."),
                 "kind": string("New kind. Must be one of: stay, activity, place, restaurant. Use empty string to keep unchanged."),
                 "title": string("New title. Use empty string to keep unchanged."),
-                "notes": string("New notes. Use empty string to keep unchanged, or the literal \"null\" to clear.")
+                "notes": string("New notes. Use empty string to keep unchanged, or the literal \"null\" to clear."),
+                "start_time": string("New start time as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T19:00:00-04:00). The date portion should match day_date. Use empty string to keep unchanged, or the literal \"null\" to clear (make the item untimed).")
             ],
             required: ["id", "day_date", "kind", "title", "notes"]
         )

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -276,6 +276,14 @@ enum ToolDefinitions {
             "start_time": .object([
                 "type": .string("string"),
                 "description": .string("OPTIONAL start time for this item as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T19:00:00-04:00 or 2026-06-14T11:00:00Z). The DATE portion MUST match day_date. Set this whenever the user mentions a time (e.g., 'dinner at 8', '11am check-in', 'tour at 14:00'); otherwise omit. Items without a start_time render as 'untimed' on the timeline.")
+            ]),
+            "end_date": .object([
+                "type": .string("string"),
+                "description": .string("STAY ONLY: ISO 8601 date for the check-out day (e.g., 2026-06-17). REQUIRED when kind is 'stay' (use day_date + 1 if user didn't specify, since most stays are at least one night). Must be > day_date. Omit for non-stay kinds.")
+            ]),
+            "end_time": .object([
+                "type": .string("string"),
+                "description": .string("STAY ONLY, OPTIONAL: check-out time as a full ISO 8601 datetime with timezone (e.g., 2026-06-17T11:00:00-04:00). The DATE portion MUST match end_date. Set this when the user mentions a check-out time; otherwise omit.")
             ])
         ]),
         "required": .array([.string("day_date"), .string("kind"), .string("title"), .string("notes")])
@@ -333,7 +341,7 @@ enum ToolDefinitions {
 
     private static let editItineraryItem = AnthropicTool(
         name: "edit_itinerary_item",
-        description: "Edit an EXISTING itinerary item's day, kind, title, notes, or start time. Requires the item UUID. IMPORTANT: At least one field must actually change. Use empty string for fields to keep unchanged. Use the literal string \"null\" for notes or start_time to CLEAR them. day_date, kind, and title cannot be cleared.",
+        description: "Edit an EXISTING itinerary item's day, kind, title, notes, start time, or (for stays) check-out date / time. Requires the item UUID. IMPORTANT: At least one field must actually change. Use empty string for fields to keep unchanged. Use the literal string \"null\" for notes, start_time, end_date, or end_time to CLEAR them. day_date, kind, and title cannot be cleared.",
         input_schema: object(
             properties: [
                 "id": string("The UUID of the existing itinerary item to edit (from EXISTING TRIPS context)."),
@@ -341,7 +349,9 @@ enum ToolDefinitions {
                 "kind": string("New kind. Must be one of: stay, activity, place, restaurant. Use empty string to keep unchanged."),
                 "title": string("New title. Use empty string to keep unchanged."),
                 "notes": string("New notes. Use empty string to keep unchanged, or the literal \"null\" to clear."),
-                "start_time": string("New start time as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T19:00:00-04:00). The date portion should match day_date. Use empty string to keep unchanged, or the literal \"null\" to clear (make the item untimed).")
+                "start_time": string("New start time as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T19:00:00-04:00). The date portion should match day_date. Use empty string to keep unchanged, or the literal \"null\" to clear (make the item untimed)."),
+                "end_date": string("STAY ONLY: new check-out date in ISO 8601 (e.g., 2026-06-17). Must be > day_date. Use empty string to keep unchanged, or the literal \"null\" to clear."),
+                "end_time": string("STAY ONLY: new check-out time as a full ISO 8601 datetime with timezone (e.g., 2026-06-17T11:00:00-04:00). The date portion should match end_date. Use empty string to keep unchanged, or the literal \"null\" to clear.")
             ],
             required: ["id", "day_date", "kind", "title", "notes"]
         )

--- a/mobile/PersonalDashboard/Design/Haptics.swift
+++ b/mobile/PersonalDashboard/Design/Haptics.swift
@@ -14,4 +14,13 @@ enum Haptics {
         generator.prepare()
         generator.notificationOccurred(.warning)
     }
+
+    /// A short, soft impact for affirmative button presses (e.g. the
+    /// itinerary FAB). Re-uses a one-shot `UIImpactFeedbackGenerator` so
+    /// the call site can fire-and-forget.
+    static func light() {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.prepare()
+        generator.impactOccurred()
+    }
 }

--- a/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
@@ -57,6 +57,15 @@ final class LocalItineraryItem {
     /// Free-form notes. Empty when none.
     var notes: String
 
+    /// Optional start time for this item. Stored as a full `Date` so the
+    /// hours/minutes always round-trip cleanly with the day they belong to
+    /// (the editor combines `dayDate` + the picked time-of-day before
+    /// persisting). `nil` means the item is "untimed" and renders with a
+    /// hollow marker plus no time label. The day grouping continues to use
+    /// `dayDate` so timezone shifts in `startTime` can't accidentally move
+    /// an item to a neighbouring day.
+    var startTime: Date?
+
     /// Ordering within a single day. Lower numbers render first; ties are
     /// broken by `createdAt`. Skeleton uses append-on-create (max + 1); a
     /// drag-to-reorder UI is a follow-up.
@@ -72,6 +81,7 @@ final class LocalItineraryItem {
         kind: ItineraryKind,
         title: String,
         notes: String = "",
+        startTime: Date? = nil,
         sortOrder: Int = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
@@ -82,6 +92,7 @@ final class LocalItineraryItem {
         self.kind = kind.rawValue
         self.title = title
         self.notes = notes
+        self.startTime = startTime
         self.sortOrder = sortOrder
         self.createdAt = createdAt
         self.updatedAt = updatedAt

--- a/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
@@ -66,6 +66,17 @@ final class LocalItineraryItem {
     /// an item to a neighbouring day.
     var startTime: Date?
 
+    /// Check-out day for `.stay` items. `nil` for other kinds. Stored as a
+    /// start-of-day Date, same shape as `dayDate`. The timeline still renders
+    /// the stay on its check-in day (`dayDate`); the card just shows a
+    /// "Check-out · Sun May 17" sub-line so the duration is visible at a
+    /// glance.
+    var endDate: Date?
+
+    /// Optional check-out time for `.stay` items (same `Date` shape as
+    /// `startTime`). Only used when `endDate` is set.
+    var endTime: Date?
+
     /// Ordering within a single day. Lower numbers render first; ties are
     /// broken by `createdAt`. Skeleton uses append-on-create (max + 1); a
     /// drag-to-reorder UI is a follow-up.
@@ -82,6 +93,8 @@ final class LocalItineraryItem {
         title: String,
         notes: String = "",
         startTime: Date? = nil,
+        endDate: Date? = nil,
+        endTime: Date? = nil,
         sortOrder: Int = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
@@ -93,6 +106,8 @@ final class LocalItineraryItem {
         self.title = title
         self.notes = notes
         self.startTime = startTime
+        self.endDate = endDate
+        self.endTime = endTime
         self.sortOrder = sortOrder
         self.createdAt = createdAt
         self.updatedAt = updatedAt

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -67,7 +67,7 @@ struct TripDetailView: View {
                     TripDayCluster(
                         trip: trip,
                         day: cluster.day,
-                        items: cluster.items,
+                        entries: cluster.entries,
                         topPadding: idx == 0 ? Space.xl : Space.xl,
                         onTap: { item in
                             editingItem = .existing(item.clientUUID)
@@ -142,32 +142,50 @@ struct TripDetailView: View {
 
     // MARK: - Grouping
 
-    /// `(day, items)` clusters in ascending date order. Skips days with no
-    /// items (no eyebrow-only empty days). Within a day, untimed items
-    /// render first (preserving `sortOrder`); then timed items sorted
-    /// ascending by `startTime`, with `sortOrder` as the secondary tiebreak.
-    private var grouped: [(day: Date, items: [LocalItineraryItem])] {
+    /// `(day, entries)` clusters in ascending date order. Stays expand into
+    /// two entries (check-in on dayDate, check-out on endDate) when endDate
+    /// is set and differs from dayDate. Within a day: untimed entries render
+    /// first (in sortOrder), then timed entries sorted ascending by the
+    /// entry's effective time (`startTime` for single/check-in,
+    /// `endTime` for check-out).
+    private var grouped: [(day: Date, entries: [TimelineEntry])] {
         let cal = Calendar.current
-        let buckets = Dictionary(grouping: items) { cal.startOfDay(for: $0.dayDate) }
+        var buckets: [Date: [TimelineEntry]] = [:]
+
+        for item in items {
+            let kind = item.kindEnum
+            let inDay = cal.startOfDay(for: item.dayDate)
+
+            if kind == .stay, let endDate = item.endDate {
+                let outDay = cal.startOfDay(for: endDate)
+                buckets[inDay, default: []].append(.stayCheckIn(item: item))
+                if outDay != inDay {
+                    buckets[outDay, default: []].append(.stayCheckOut(item: item))
+                }
+            } else {
+                buckets[inDay, default: []].append(.single(item: item))
+            }
+        }
+
         return buckets.keys.sorted().map { day in
             let raw = buckets[day] ?? []
             let sorted = raw.sorted { lhs, rhs in
-                switch (lhs.startTime, rhs.startTime) {
+                switch (lhs.effectiveTime, rhs.effectiveTime) {
                 case (nil, nil):
-                    // Both untimed: existing sortOrder, then createdAt.
-                    if lhs.sortOrder != rhs.sortOrder { return lhs.sortOrder < rhs.sortOrder }
-                    return lhs.createdAt < rhs.createdAt
+                    if lhs.item.sortOrder != rhs.item.sortOrder {
+                        return lhs.item.sortOrder < rhs.item.sortOrder
+                    }
+                    return lhs.item.createdAt < rhs.item.createdAt
                 case (nil, _):
-                    // Untimed first.
-                    return true
+                    return true   // untimed entries pin to the top of the day
                 case (_, nil):
                     return false
                 case let (l?, r?):
                     if l != r { return l < r }
-                    return lhs.sortOrder < rhs.sortOrder
+                    return lhs.item.sortOrder < rhs.item.sortOrder
                 }
             }
-            return (day: day, items: sorted)
+            return (day: day, entries: sorted)
         }
     }
 
@@ -195,12 +213,14 @@ struct TripDetailView: View {
 /// Locked numbers for the trip-detail timeline. Spec lives on issue #108;
 /// do not change these values without re-locking the spec there.
 enum TimelineLayout {
-    /// Distance from the cluster leading edge to the rail centerline.
-    static let railLeading: CGFloat = 34
-    /// Width reserved at the leading edge for the time label column.
-    static let timeColumnWidth: CGFloat = 56
+    /// Distance from the cluster leading edge to the rail centerline. The
+    /// day eyebrow's dot, every item marker, and the rail itself all share
+    /// this x-position, so they form a clean vertical column.
+    static let railLeading: CGFloat = 16
     /// Distance from cluster leading edge to the item card's leading edge.
-    static let cardLeading: CGFloat = 44
+    /// Equals `railLeading + markerRadius + gutter` (~11pt gutter past the
+    /// marker outer edge).
+    static let cardLeading: CGFloat = 32
     /// Diameter of each item's marker dot.
     static let markerDiameter: CGFloat = 10
     /// Diameter of the day eyebrow's leading dot.
@@ -214,6 +234,61 @@ enum TimelineLayout {
     /// 12pt card vertical padding (`Space.md`) plus the title's first-line
     /// half-height for `.edBodyMedium` (≈10pt).
     static let markerCenterFromRowTop: CGFloat = 22
+}
+
+// MARK: - Timeline entries (one row on the timeline)
+
+/// A single "event" the timeline renders. A non-stay item produces one
+/// `.single` entry on its `dayDate`. A stay with an `endDate` distinct from
+/// `dayDate` produces TWO entries: `.stayCheckIn` on `dayDate` and
+/// `.stayCheckOut` on `endDate`. A stay without an `endDate` (legacy) or a
+/// same-day stay collapses to a single `.stayCheckIn` entry.
+enum TimelineEntry: Identifiable {
+    case single(item: LocalItineraryItem)
+    case stayCheckIn(item: LocalItineraryItem)
+    case stayCheckOut(item: LocalItineraryItem)
+
+    var id: String {
+        switch self {
+        case .single(let item):       return "single-\(item.clientUUID.uuidString)"
+        case .stayCheckIn(let item):  return "in-\(item.clientUUID.uuidString)"
+        case .stayCheckOut(let item): return "out-\(item.clientUUID.uuidString)"
+        }
+    }
+
+    var item: LocalItineraryItem {
+        switch self {
+        case .single(let item), .stayCheckIn(let item), .stayCheckOut(let item):
+            return item
+        }
+    }
+
+    /// The effective time for sort order and marker fill. `startTime` for
+    /// single + check-in events; `endTime` for check-out events.
+    var effectiveTime: Date? {
+        switch self {
+        case .single(let item):       return item.startTime
+        case .stayCheckIn(let item):  return item.startTime
+        case .stayCheckOut(let item): return item.endTime
+        }
+    }
+
+    /// The "Anytime / Check-in / Check-out · HH:mm" line shown inside the
+    /// card below the kind chip.
+    var dateTimeLine: String {
+        let timeFormat: (Date) -> String = { $0.formatted(.dateTime.hour().minute()) }
+        switch self {
+        case .single(let item):
+            if let t = item.startTime { return timeFormat(t) }
+            return "Anytime"
+        case .stayCheckIn(let item):
+            if let t = item.startTime { return "Check-in · \(timeFormat(t))" }
+            return "Check-in"
+        case .stayCheckOut(let item):
+            if let t = item.endTime { return "Check-out · \(timeFormat(t))" }
+            return "Check-out"
+        }
+    }
 }
 
 // MARK: - Editor target
@@ -238,11 +313,13 @@ enum ItineraryItemEditorTarget: Identifiable {
 /// One day's eyebrow + rail + items. The rail is drawn as a background
 /// rectangle behind the items VStack, anchored top/bottom to the first
 /// and last marker centers via vertical padding equal to the
-/// `markerCenterFromRowTop` constant.
+/// `markerCenterFromRowTop` constant. The day eyebrow's dot is indented to
+/// share the marker x-position, so day dot + every marker form a vertical
+/// column.
 private struct TripDayCluster: View {
     let trip: LocalTrip
     let day: Date
-    let items: [LocalItineraryItem]
+    let entries: [TimelineEntry]
     let topPadding: CGFloat
     let onTap: (LocalItineraryItem) -> Void
     let onDelete: (LocalItineraryItem) -> Void
@@ -298,6 +375,9 @@ private struct TripDayCluster: View {
             }
             Spacer(minLength: 0)
         }
+        // Indent so the dot's centerline sits at `railLeading`, lined up
+        // with every item marker below it.
+        .padding(.leading, TimelineLayout.railLeading - TimelineLayout.dayDotDiameter / 2)
         .frame(height: 36)
     }
 
@@ -307,15 +387,14 @@ private struct TripDayCluster: View {
         // The rail lives as a background rect behind the items VStack, with
         // top/bottom padding equal to `markerCenterFromRowTop` so it starts
         // at the first marker center and ends at the last marker center.
-        // ZStack(.topLeading) places it at x = railLeading - railWidth/2.
         VStack(alignment: .leading, spacing: Space.md) {
-            ForEach(items) { item in
-                TripTimelineRow(item: item)
+            ForEach(entries) { entry in
+                TripTimelineRow(entry: entry)
                     .contentShape(Rectangle())
-                    .onTapGesture { onTap(item) }
+                    .onTapGesture { onTap(entry.item) }
                     .contextMenu {
                         Button(role: .destructive) {
-                            onDelete(item)
+                            onDelete(entry.item)
                         } label: {
                             Label("Delete", systemImage: "trash")
                         }
@@ -330,9 +409,9 @@ private struct TripDayCluster: View {
         // Single rail. Top/bottom padding clip the rect to marker
         // centerlines (each marker sits `markerCenterFromRowTop` below its
         // row's top edge). `.offset(x:)` slides the 1pt-wide rect so its
-        // horizontal center lands on `railLeading`. Single-item days
+        // horizontal center lands on `railLeading`. Single-entry days
         // suppress the rail entirely — there's nothing to connect.
-        if items.count > 1 {
+        if entries.count > 1 {
             Rectangle()
                 .fill(Tokens.border)
                 .frame(width: TimelineLayout.railWidth)
@@ -346,46 +425,26 @@ private struct TripDayCluster: View {
 
 // MARK: - Timeline row
 
-/// One item row: time | marker | card. Marker centerline aligns with the
-/// card title's first line; time label baseline aligns horizontally with
-/// the marker.
+/// One row on the timeline: marker column | card. Uniform structure:
+/// title (1 line) → kind chip → date/time line. Tiles are the same height
+/// across all kinds so the column feels like a real timeline rather than a
+/// jagged list.
 private struct TripTimelineRow: View {
-    let item: LocalItineraryItem
+    let entry: TimelineEntry
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
-            timeColumn
             markerColumn
-            Spacer().frame(width: 4)
             card
         }
     }
 
-    private var timeColumn: some View {
-        // Width 28pt: time text right-aligned to its trailing edge, which
-        // sits 6pt before the rail centerline at 34pt. The remaining 28pt
-        // up to the marker column is "negative space" — see spec.
-        Group {
-            if let start = item.startTime {
-                Text(start.formatted(.dateTime.hour().minute()))
-                    .font(.edFootnote)
-                    .foregroundStyle(Tokens.muted)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.85)
-            } else {
-                Color.clear
-            }
-        }
-        .frame(width: 28, alignment: .trailing)
-        .padding(.top, TimelineLayout.markerCenterFromRowTop - 8)
-    }
-
+    /// Fixed-width column whose center sits on `railLeading`. The marker
+    /// itself is vertically padded so its centerline aligns with the card
+    /// title's first line.
     private var markerColumn: some View {
-        // 12pt-wide column; marker centered horizontally puts the dot at
-        // local x=6, and the column is offset to start at 28pt, so marker
-        // centerline lands at 28+6=34pt from cluster leading. ✓
-        ZStack {
-            if item.startTime != nil {
+        Group {
+            if entry.effectiveTime != nil {
                 Circle()
                     .fill(Tokens.accent(for: .itineraries))
                     .frame(width: TimelineLayout.markerDiameter, height: TimelineLayout.markerDiameter)
@@ -399,57 +458,36 @@ private struct TripTimelineRow: View {
                     )
             }
         }
-        .frame(width: 12, alignment: .center)
+        .frame(width: TimelineLayout.cardLeading, alignment: .center)
         .padding(.top, TimelineLayout.markerCenterFromRowTop - TimelineLayout.markerDiameter / 2)
     }
 
     private var card: some View {
+        let item = entry.item
         let kind = item.kindEnum
-        let trimmedNotes = item.notes.trimmingCharacters(in: .whitespacesAndNewlines)
 
         return VStack(alignment: .leading, spacing: Space.xs) {
             Text(item.title)
                 .font(.edBodyMedium)
                 .foregroundStyle(Tokens.ink)
-                .lineLimit(2)
+                .lineLimit(1)
                 .truncationMode(.tail)
-                .multilineTextAlignment(.leading)
 
             HStack(spacing: Space.sm) {
                 TripKindChip(kind: kind)
                 Spacer(minLength: 0)
             }
 
-            if kind == .stay, let endDate = item.endDate {
-                Text(checkoutSubline(endDate: endDate, endTime: item.endTime))
-                    .font(.edCaption)
-                    .foregroundStyle(Tokens.muted)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-
-            if !trimmedNotes.isEmpty {
-                Text(trimmedNotes)
-                    .font(.edSubheadline)
-                    .foregroundStyle(Tokens.muted)
-                    .lineLimit(2)
-                    .truncationMode(.tail)
-                    .multilineTextAlignment(.leading)
-            }
+            Text(entry.dateTimeLine)
+                .font(.edCaption)
+                .foregroundStyle(Tokens.muted)
+                .lineLimit(1)
+                .truncationMode(.tail)
         }
         .padding(Space.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
         .paperBorder(Tokens.border, radius: Radius.md)
-    }
-
-    private func checkoutSubline(endDate: Date, endTime: Date?) -> String {
-        let datePart = endDate.formatted(.dateTime.weekday(.abbreviated).day().month(.abbreviated))
-        if let endTime {
-            let timePart = endTime.formatted(.dateTime.hour().minute())
-            return "Check-out · \(datePart) · \(timePart)"
-        }
-        return "Check-out · \(datePart)"
     }
 }
 

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -1,16 +1,17 @@
 import SwiftUI
 import SwiftData
 
-/// Day-by-day timeline for a single `LocalTrip`. One section per calendar day
-/// from `trip.startDate` through `trip.endDate` (inclusive). Items render
-/// inside the section that matches their `dayDate`. Any item with a `dayDate`
-/// outside the trip range still gets a section so users don't lose data when
-/// they shrink a trip's range.
+/// Vertical timeline for a single `LocalTrip` (issue #108).
 ///
-/// Items are added via a per-day "+ Add" button that opens
-/// `ItineraryItemEditorSheet` pre-filled with that day's date and a default
-/// kind. Tapping an existing item re-opens the same sheet for edit.
-/// Swipe-to-delete fires `Haptics.destructive()` and removes the item.
+/// Items render inside per-day clusters in ascending date order. Within a
+/// day, untimed items render first (preserving their `sortOrder`), then
+/// timed items sorted ascending by `startTime`. Tapping an item opens
+/// `ItineraryItemEditorSheet` for edit. A single global "+" FAB at the
+/// bottom-trailing creates a new item, defaulting to today (if today is
+/// inside the trip range) or `trip.startDate` otherwise.
+///
+/// Visual spec lives in issue #108. Layout constants are pinned in
+/// `TimelineLayout` below — do not improvise away from these numbers.
 struct TripDetailView: View {
     @Environment(\.modelContext) private var modelContext
 
@@ -18,9 +19,8 @@ struct TripDetailView: View {
 
     @Query private var items: [LocalItineraryItem]
 
-    /// Drives the item editor. `.new(day:)` carries the pre-filled day so a
-    /// per-day "+ Add" button doesn't need to re-derive it. `.existing(_)`
-    /// carries the item UUID for edit.
+    /// Drives the item editor. `.new(day:)` carries the pre-filled day;
+    /// `.existing(_)` carries the item UUID for edit.
     @State private var editingItem: ItineraryItemEditorTarget?
 
     init(trip: LocalTrip) {
@@ -37,43 +37,20 @@ struct TripDetailView: View {
     }
 
     var body: some View {
-        List {
-            ForEach(days, id: \.self) { day in
-                Section {
-                    let dayItems = itemsByDay[day] ?? []
-                    if dayItems.isEmpty {
-                        emptyDayRow
-                    } else {
-                        ForEach(dayItems) { item in
-                            ItineraryItemRow(item: item) {
-                                editingItem = .existing(item.clientUUID)
-                            }
-                            .swipeToDeleteTrash {
-                                Haptics.destructive()
-                                delete(item)
-                            }
-                            .listRowBackground(Color.clear)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
-                        }
-                    }
+        ZStack {
+            Tokens.paper.ignoresSafeArea()
 
-                    addRow(day: day)
-                } header: {
-                    dayHeader(for: day)
-                }
+            if grouped.isEmpty {
+                emptyState
+            } else {
+                timelineScroll
             }
 
-            Color.clear
-                .frame(height: 96)
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-                .listRowInsets(EdgeInsets())
+            // FAB sits above the bottom tab bar AND the home indicator. The
+            // 96pt bumper at the end of the scroll content guarantees the
+            // last card is not hidden by this overlay.
+            fabOverlay
         }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
-        .background(Tokens.paper)
-        .scrollDismissesKeyboard(.interactively)
         .sheet(item: $editingItem) { target in
             ItineraryItemEditorSheet(trip: trip, target: target)
                 .presentationDetents([.medium, .large])
@@ -81,111 +58,131 @@ struct TripDetailView: View {
         }
     }
 
-    // MARK: - Day computation
+    // MARK: - Timeline
 
-    /// Union of (calendar days from start to end inclusive) and (distinct
-    /// dayDates of existing items). Sorted ascending. This way a trip with
-    /// items beyond its current end date still shows those items in their
-    /// own section instead of silently hiding them.
-    private var days: [Date] {
+    private var timelineScroll: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(grouped.enumerated()), id: \.element.day) { idx, cluster in
+                    TripDayCluster(
+                        trip: trip,
+                        day: cluster.day,
+                        items: cluster.items,
+                        topPadding: idx == 0 ? Space.xl : Space.xl,
+                        onTap: { item in
+                            editingItem = .existing(item.clientUUID)
+                        },
+                        onDelete: { item in
+                            Haptics.destructive()
+                            delete(item)
+                        }
+                    )
+                }
+                Color.clear.frame(height: TimelineLayout.bottomBumper)
+            }
+            .padding(.horizontal, Space.lg)
+        }
+        .scrollDismissesKeyboard(.interactively)
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        // Vertically positioned ~45% from top of the area below the trip
+        // header. We approximate that with a flexible top spacer that's
+        // slightly smaller than the bottom one so the block sits above
+        // dead-centre.
+        VStack(spacing: 0) {
+            Spacer().frame(minHeight: 0).layoutPriority(0.9)
+            VStack(spacing: 0) {
+                Image(systemName: "airplane.departure")
+                    .font(.system(size: 32, weight: .light))
+                    .foregroundStyle(Tokens.mutedSoft)
+                Spacer().frame(height: Space.md)
+                Text("Nothing planned yet")
+                    .font(.edTitle)
+                    .foregroundStyle(Tokens.ink)
+                    .multilineTextAlignment(.center)
+                Spacer().frame(height: Space.xs)
+                Text("Tap + to add your first stop")
+                    .font(.edSubheadline)
+                    .foregroundStyle(Tokens.muted)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: 280)
+            Spacer().frame(minHeight: 0).layoutPriority(1.1)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, Space.lg)
+    }
+
+    // MARK: - FAB
+
+    private var fabOverlay: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Spacer()
+                Button {
+                    Haptics.light()
+                    editingItem = .new(day: defaultDayForNewItem)
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundStyle(Tokens.accentFg)
+                        .frame(width: 48, height: 48)
+                        .background(Tokens.accent(for: .itineraries), in: Circle())
+                        .shadow(color: .black.opacity(0.18), radius: 12, x: 0, y: 6)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Add itinerary item")
+            }
+        }
+        .padding(.trailing, Space.lg)
+        .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+        .allowsHitTesting(true)
+    }
+
+    // MARK: - Grouping
+
+    /// `(day, items)` clusters in ascending date order. Skips days with no
+    /// items (no eyebrow-only empty days). Within a day, untimed items
+    /// render first (preserving `sortOrder`); then timed items sorted
+    /// ascending by `startTime`, with `sortOrder` as the secondary tiebreak.
+    private var grouped: [(day: Date, items: [LocalItineraryItem])] {
         let cal = Calendar.current
+        let buckets = Dictionary(grouping: items) { cal.startOfDay(for: $0.dayDate) }
+        return buckets.keys.sorted().map { day in
+            let raw = buckets[day] ?? []
+            let sorted = raw.sorted { lhs, rhs in
+                switch (lhs.startTime, rhs.startTime) {
+                case (nil, nil):
+                    // Both untimed: existing sortOrder, then createdAt.
+                    if lhs.sortOrder != rhs.sortOrder { return lhs.sortOrder < rhs.sortOrder }
+                    return lhs.createdAt < rhs.createdAt
+                case (nil, _):
+                    // Untimed first.
+                    return true
+                case (_, nil):
+                    return false
+                case let (l?, r?):
+                    if l != r { return l < r }
+                    return lhs.sortOrder < rhs.sortOrder
+                }
+            }
+            return (day: day, items: sorted)
+        }
+    }
+
+    /// Default day to seed the FAB-launched editor. Today if it falls
+    /// within the trip's range; else the trip's start date.
+    private var defaultDayForNewItem: Date {
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: Date())
         let start = cal.startOfDay(for: trip.startDate)
         let end = cal.startOfDay(for: trip.endDate)
-
-        var set = Set<Date>()
-        var cursor = start
-        while cursor <= end {
-            set.insert(cursor)
-            guard let next = cal.date(byAdding: .day, value: 1, to: cursor) else { break }
-            cursor = next
-        }
-        for item in items {
-            set.insert(cal.startOfDay(for: item.dayDate))
-        }
-        return set.sorted()
-    }
-
-    private var itemsByDay: [Date: [LocalItineraryItem]] {
-        let cal = Calendar.current
-        return Dictionary(grouping: items) { cal.startOfDay(for: $0.dayDate) }
-    }
-
-    // MARK: - Subviews
-
-    private func dayHeader(for day: Date) -> some View {
-        let cal = Calendar.current
-        let tripStart = cal.startOfDay(for: trip.startDate)
-        let tripEnd = cal.startOfDay(for: trip.endDate)
-        let withinTrip = day >= tripStart && day <= tripEnd
-        let dayNumber = cal.dateComponents([.day], from: tripStart, to: day).day.map { $0 + 1 } ?? 0
-        let weekdayDate = day.formatted(.dateTime.weekday(.abbreviated).day().month(.abbreviated))
-
-        return HStack(spacing: Space.sm) {
-            if withinTrip {
-                Text("Day \(dayNumber)")
-                    .font(.edEyebrow)
-                    .foregroundStyle(Tokens.accent(for: .itineraries))
-                Text("·")
-                    .font(.edEyebrow)
-                    .foregroundStyle(Tokens.mutedSoft)
-                Text(weekdayDate)
-                    .font(.edEyebrow)
-                    .foregroundStyle(Tokens.muted)
-            } else {
-                Text("Outside trip")
-                    .font(.edEyebrow)
-                    .foregroundStyle(Tokens.muted)
-                Text("·")
-                    .font(.edEyebrow)
-                    .foregroundStyle(Tokens.mutedSoft)
-                Text(weekdayDate)
-                    .font(.edEyebrow)
-                    .foregroundStyle(Tokens.muted)
-            }
-            Spacer()
-        }
-        .textCase(nil)
-        .padding(.horizontal, Space.lg)
-        .padding(.top, Space.lg)
-        .padding(.bottom, Space.xs)
-        .background(Tokens.paper)
-    }
-
-    private var emptyDayRow: some View {
-        Text("Nothing planned")
-            .font(.edSubheadline)
-            .foregroundStyle(Tokens.mutedSoft)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, Space.sm)
-            .listRowBackground(Color.clear)
-            .listRowSeparator(.hidden)
-            .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.xs, trailing: Space.lg))
-    }
-
-    private func addRow(day: Date) -> some View {
-        Button {
-            editingItem = .new(day: day)
-        } label: {
-            HStack(spacing: Space.sm) {
-                Image(systemName: "plus")
-                    .font(.system(size: 13, weight: .semibold))
-                Text("Add to this day")
-                    .font(.edFootnote)
-                Spacer()
-            }
-            .foregroundStyle(Tokens.accent(for: .itineraries))
-            .padding(.horizontal, Space.md)
-            .padding(.vertical, Space.sm)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
-            .paperBorder(Tokens.border, radius: Radius.md)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .listRowBackground(Color.clear)
-        .listRowSeparator(.hidden)
-        .listRowInsets(EdgeInsets(top: Space.xs, leading: Space.lg, bottom: Space.lg, trailing: Space.lg))
-        .accessibilityLabel("Add item to \(day.formatted(.dateTime.weekday().day().month()))")
+        if today >= start && today <= end { return today }
+        return start
     }
 
     // MARK: - Persistence
@@ -196,11 +193,37 @@ struct TripDetailView: View {
     }
 }
 
+// MARK: - Layout constants
+
+/// Locked numbers for the trip-detail timeline. Spec lives on issue #108;
+/// do not change these values without re-locking the spec there.
+enum TimelineLayout {
+    /// Distance from the cluster leading edge to the rail centerline.
+    static let railLeading: CGFloat = 34
+    /// Width reserved at the leading edge for the time label column.
+    static let timeColumnWidth: CGFloat = 56
+    /// Distance from cluster leading edge to the item card's leading edge.
+    static let cardLeading: CGFloat = 44
+    /// Diameter of each item's marker dot.
+    static let markerDiameter: CGFloat = 10
+    /// Diameter of the day eyebrow's leading dot.
+    static let dayDotDiameter: CGFloat = 6
+    /// Thickness of the vertical rail line.
+    static let railWidth: CGFloat = 1
+    /// Bottom safe-area bumper so the FAB never covers the last card.
+    static let bottomBumper: CGFloat = 96
+    /// Vertical offset (from row top) at which the marker's centerline
+    /// aligns with the first line of the item card's title. Driven by the
+    /// 12pt card vertical padding (`Space.md`) plus the title's first-line
+    /// half-height for `.edBodyMedium` (≈10pt).
+    static let markerCenterFromRowTop: CGFloat = 22
+}
+
 // MARK: - Editor target
 
 /// Identifiable wrapper used as the `.sheet(item:)` payload for the item
-/// editor. `.new(day:)` carries the day so the per-day "+ Add" button can
-/// pre-fill the picker; `.existing(_)` carries the UUID.
+/// editor. `.new(day:)` carries the pre-filled day from the FAB; `.existing(_)`
+/// carries the UUID for edit.
 enum ItineraryItemEditorTarget: Identifiable {
     case new(day: Date)
     case existing(UUID)
@@ -213,63 +236,246 @@ enum ItineraryItemEditorTarget: Identifiable {
     }
 }
 
-// MARK: - Item row
+// MARK: - Day cluster
 
-private struct ItineraryItemRow: View {
-    let item: LocalItineraryItem
-    let onTap: () -> Void
+/// One day's eyebrow + rail + items. The rail is drawn as a background
+/// rectangle behind the items VStack, anchored top/bottom to the first
+/// and last marker centers via vertical padding equal to the
+/// `markerCenterFromRowTop` constant.
+private struct TripDayCluster: View {
+    let trip: LocalTrip
+    let day: Date
+    let items: [LocalItineraryItem]
+    let topPadding: CGFloat
+    let onTap: (LocalItineraryItem) -> Void
+    let onDelete: (LocalItineraryItem) -> Void
 
     var body: some View {
-        let kind = item.kindEnum
-        Button(action: onTap) {
-            HStack(alignment: .top, spacing: Space.md) {
-                Image(systemName: kind.icon)
-                    .font(.system(size: 15, weight: .regular))
-                    .foregroundStyle(Tokens.accent(for: .itineraries))
-                    .frame(width: 24, height: 24)
-                    .padding(.top, 2)
+        VStack(alignment: .leading, spacing: 0) {
+            dayEyebrow
+                .padding(.top, topPadding)
+                .padding(.bottom, Space.md)
 
-                VStack(alignment: .leading, spacing: Space.xs) {
-                    Text(item.title)
-                        .font(.edBodyMedium)
-                        .foregroundStyle(Tokens.ink)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
+            itemsStack
+        }
+    }
 
-                    HStack(spacing: Space.sm) {
-                        Text(kind.displayName.uppercased())
-                            .font(.edEyebrow)
-                            .foregroundStyle(Tokens.muted)
+    // MARK: Eyebrow
 
-                        let trimmed = item.notes.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !trimmed.isEmpty {
-                            Text("·")
-                                .font(.edEyebrow)
-                                .foregroundStyle(Tokens.mutedSoft)
-                            Text(trimmed)
-                                .font(.edSubheadline)
-                                .foregroundStyle(Tokens.muted)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
+    private var dayEyebrow: some View {
+        let cal = Calendar.current
+        let tripStart = cal.startOfDay(for: trip.startDate)
+        let tripEnd = cal.startOfDay(for: trip.endDate)
+        let withinTrip = day >= tripStart && day <= tripEnd
+        let dayNumber = cal.dateComponents([.day], from: tripStart, to: day).day.map { $0 + 1 } ?? 0
+        let weekdayDate = day
+            .formatted(.dateTime.weekday(.abbreviated).day().month(.abbreviated))
+            .uppercased()
+
+        return HStack(spacing: Space.sm) {
+            Circle()
+                .fill(Tokens.accent(for: .itineraries))
+                .frame(width: TimelineLayout.dayDotDiameter, height: TimelineLayout.dayDotDiameter)
+            HStack(spacing: 0) {
+                if withinTrip {
+                    Text("DAY \(dayNumber)")
+                        .font(.edEyebrow)
+                        .textCase(.uppercase)
+                        .tracking(1.4)
+                        .foregroundStyle(Tokens.accent(for: .itineraries))
+                } else {
+                    Text("OUTSIDE TRIP")
+                        .font(.edEyebrow)
+                        .textCase(.uppercase)
+                        .tracking(1.4)
+                        .foregroundStyle(Tokens.muted)
+                }
+                Text(" · ")
+                    .font(.edEyebrow)
+                    .foregroundStyle(Tokens.mutedSoft)
+                Text(weekdayDate)
+                    .font(.edEyebrow)
+                    .textCase(.uppercase)
+                    .tracking(1.4)
+                    .foregroundStyle(Tokens.muted)
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(height: 36)
+    }
+
+    // MARK: Items + rail
+
+    private var itemsStack: some View {
+        // The rail lives as a background rect behind the items VStack, with
+        // top/bottom padding equal to `markerCenterFromRowTop` so it starts
+        // at the first marker center and ends at the last marker center.
+        // ZStack(.topLeading) places it at x = railLeading - railWidth/2.
+        VStack(alignment: .leading, spacing: Space.md) {
+            ForEach(items) { item in
+                TripTimelineRow(item: item)
+                    .contentShape(Rectangle())
+                    .onTapGesture { onTap(item) }
+                    .contextMenu {
+                        Button(role: .destructive) {
+                            onDelete(item)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
                         }
                     }
-                }
+            }
+        }
+        .background(railOverlay, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private var railOverlay: some View {
+        // Single rail. Top/bottom padding clip the rect to marker
+        // centerlines (each marker sits `markerCenterFromRowTop` below its
+        // row's top edge). `.offset(x:)` slides the 1pt-wide rect so its
+        // horizontal center lands on `railLeading`. Single-item days
+        // suppress the rail entirely — there's nothing to connect.
+        if items.count > 1 {
+            Rectangle()
+                .fill(Tokens.border)
+                .frame(width: TimelineLayout.railWidth)
+                .padding(.top, TimelineLayout.markerCenterFromRowTop)
+                .padding(.bottom, TimelineLayout.markerCenterFromRowTop)
+                .offset(x: TimelineLayout.railLeading - TimelineLayout.railWidth / 2)
+                .frame(maxHeight: .infinity)
+        }
+    }
+}
+
+// MARK: - Timeline row
+
+/// One item row: time | marker | card. Marker centerline aligns with the
+/// card title's first line; time label baseline aligns horizontally with
+/// the marker.
+private struct TripTimelineRow: View {
+    let item: LocalItineraryItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            timeColumn
+            markerColumn
+            Spacer().frame(width: 4)
+            card
+        }
+    }
+
+    private var timeColumn: some View {
+        // Width 28pt: time text right-aligned to its trailing edge, which
+        // sits 6pt before the rail centerline at 34pt. The remaining 28pt
+        // up to the marker column is "negative space" — see spec.
+        Group {
+            if let start = item.startTime {
+                Text(start.formatted(.dateTime.hour().minute()))
+                    .font(.edFootnote)
+                    .foregroundStyle(Tokens.muted)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            } else {
+                Color.clear
+            }
+        }
+        .frame(width: 28, alignment: .trailing)
+        .padding(.top, TimelineLayout.markerCenterFromRowTop - 8)
+    }
+
+    private var markerColumn: some View {
+        // 12pt-wide column; marker centered horizontally puts the dot at
+        // local x=6, and the column is offset to start at 28pt, so marker
+        // centerline lands at 28+6=34pt from cluster leading. ✓
+        ZStack {
+            if item.startTime != nil {
+                Circle()
+                    .fill(Tokens.accent(for: .itineraries))
+                    .frame(width: TimelineLayout.markerDiameter, height: TimelineLayout.markerDiameter)
+            } else {
+                Circle()
+                    .fill(Tokens.paper)
+                    .frame(width: TimelineLayout.markerDiameter, height: TimelineLayout.markerDiameter)
+                    .overlay(
+                        Circle()
+                            .strokeBorder(Tokens.accent(for: .itineraries), lineWidth: 1.5)
+                    )
+            }
+        }
+        .frame(width: 12, alignment: .center)
+        .padding(.top, TimelineLayout.markerCenterFromRowTop - TimelineLayout.markerDiameter / 2)
+    }
+
+    private var card: some View {
+        let kind = item.kindEnum
+        let trimmedNotes = item.notes.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return VStack(alignment: .leading, spacing: Space.xs) {
+            Text(item.title)
+                .font(.edBodyMedium)
+                .foregroundStyle(Tokens.ink)
+                .lineLimit(2)
+                .truncationMode(.tail)
+                .multilineTextAlignment(.leading)
+
+            HStack(spacing: Space.sm) {
+                TripKindChip(kind: kind)
                 Spacer(minLength: 0)
             }
-            .padding(.horizontal, Space.md)
-            .padding(.vertical, Space.md)
-            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
-            .paperBorder(Tokens.border, radius: Radius.md)
-            .contentShape(Rectangle())
+
+            if !trimmedNotes.isEmpty {
+                Text(trimmedNotes)
+                    .font(.edSubheadline)
+                    .foregroundStyle(Tokens.muted)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .multilineTextAlignment(.leading)
+            }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel("\(kind.displayName): \(item.title). Tap to edit.")
+        .padding(Space.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+        .paperBorder(Tokens.border, radius: Radius.md)
+    }
+}
+
+// MARK: - Kind chip (timeline variant)
+
+/// Capsule chip for an item's kind. Distinct from the picker chip in the
+/// editor sheet (which is selectable / accent-tinted). This one is
+/// display-only: surface2 background, accent-tinted icon, soft ink label.
+private struct TripKindChip: View {
+    let kind: ItineraryKind
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: kind.icon)
+                .font(.system(size: 11, weight: .regular))
+                .foregroundStyle(Tokens.accent(for: .itineraries))
+            Text(kind.displayName.uppercased())
+                .font(.edEyebrow)
+                .textCase(.uppercase)
+                .tracking(1.4)
+                .foregroundStyle(Tokens.inkSoft)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(Tokens.surface2, in: Capsule(style: .continuous))
     }
 }
 
 // MARK: - Item editor sheet
 
-private struct ItineraryItemEditorSheet: View {
+/// Same sheet as before, extended with an optional time picker. Kind /
+/// title / day / notes flows are unchanged; the new "Time" section sits
+/// between "Day" and "Notes" and gates the time picker behind a toggle.
+///
+/// Persisted shape: when the toggle is OFF, `LocalItineraryItem.startTime`
+/// is `nil`. When ON, `startTime` is `dayDate` combined with the hour and
+/// minute from `timeOfDay`. Storing a full `Date` (not a clock-time) means
+/// the timeline can sort timed items lexicographically and the day
+/// grouping stays driven by `dayDate` alone.
+struct ItineraryItemEditorSheet: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
 
@@ -279,6 +485,14 @@ private struct ItineraryItemEditorSheet: View {
     @State private var title: String = ""
     @State private var kind: ItineraryKind = .activity
     @State private var dayDate: Date = Calendar.current.startOfDay(for: Date())
+    @State private var hasTime: Bool = false
+    /// Holds the hours/minutes for the time picker while the sheet is
+    /// open. The persisted `startTime` is rebuilt on save by combining
+    /// `dayDate` + the time-of-day extracted from this value.
+    @State private var timeOfDay: Date = {
+        let cal = Calendar.current
+        return cal.date(bySettingHour: 9, minute: 0, second: 0, of: Date()) ?? Date()
+    }()
     @State private var notes: String = ""
     @State private var loaded: Bool = false
     @FocusState private var titleFocused: Bool
@@ -296,6 +510,7 @@ private struct ItineraryItemEditorSheet: View {
                         kindField
                         titleField
                         dayField
+                        timeField
                         notesField
                     }
                     .padding(Space.lg)
@@ -328,7 +543,7 @@ private struct ItineraryItemEditorSheet: View {
             Text("Kind").eyebrow()
             HStack(spacing: Space.sm) {
                 ForEach(ItineraryKind.allCases) { option in
-                    KindChip(kind: option, isSelected: option == kind) {
+                    KindPickerChip(kind: option, isSelected: option == kind) {
                         kind = option
                     }
                 }
@@ -362,15 +577,41 @@ private struct ItineraryItemEditorSheet: View {
             HStack {
                 Text("Date").font(.edBody).foregroundStyle(Tokens.inkSoft)
                 Spacer()
-                // Trip dates aren't a hard constraint here — picking outside
-                // the range keeps the item visible under an "Outside trip"
-                // section, so the user can still extend the trip later
-                // without losing the item.
                 DatePicker("", selection: $dayDate, displayedComponents: .date)
                     .labelsHidden()
                     .tint(Tokens.accent(for: .itineraries))
             }
             .padding(Space.md)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    private var timeField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Time").eyebrow()
+            VStack(spacing: 0) {
+                HStack {
+                    Text("Add time").font(.edBody).foregroundStyle(Tokens.inkSoft)
+                    Spacer()
+                    Toggle("", isOn: $hasTime)
+                        .labelsHidden()
+                        .tint(Tokens.accent(for: .itineraries))
+                }
+                .padding(Space.md)
+
+                if hasTime {
+                    Divider().background(Tokens.divider)
+                    HStack {
+                        Text("Start").font(.edBody).foregroundStyle(Tokens.inkSoft)
+                        Spacer()
+                        DatePicker("", selection: $timeOfDay, displayedComponents: .hourAndMinute)
+                            .labelsHidden()
+                            .tint(Tokens.accent(for: .itineraries))
+                    }
+                    .padding(Space.md)
+                }
+            }
             .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
             .paperBorder(Tokens.border, radius: Radius.md)
         }
@@ -444,8 +685,7 @@ private struct ItineraryItemEditorSheet: View {
         switch target {
         case .new(let day):
             dayDate = Calendar.current.startOfDay(for: day)
-            // Default kind heuristic: if the day is the trip's first day,
-            // most users add a Stay first. Otherwise default to Activity.
+            // Default kind heuristic: a first-day item is most often a Stay.
             if Calendar.current.isDate(day, inSameDayAs: trip.startDate) {
                 kind = .stay
             } else {
@@ -463,6 +703,10 @@ private struct ItineraryItemEditorSheet: View {
                 kind = existing.kindEnum
                 dayDate = existing.dayDate
                 notes = existing.notes
+                if let start = existing.startTime {
+                    hasTime = true
+                    timeOfDay = start
+                }
             }
         }
     }
@@ -471,7 +715,22 @@ private struct ItineraryItemEditorSheet: View {
         let cleanTitle = trimmedTitle
         guard !cleanTitle.isEmpty else { return }
         let cleanNotes = trimmedNotes
-        let normalisedDay = Calendar.current.startOfDay(for: dayDate)
+        let cal = Calendar.current
+        let normalisedDay = cal.startOfDay(for: dayDate)
+
+        // Combine the day (date-only) with the time-of-day picker if the
+        // toggle is on. Falling back to dayDate keeps the call total in
+        // case the time-of-day extraction fails (it shouldn't).
+        let combinedStart: Date? = {
+            guard hasTime else { return nil }
+            let comps = cal.dateComponents([.hour, .minute], from: timeOfDay)
+            return cal.date(
+                bySettingHour: comps.hour ?? 0,
+                minute: comps.minute ?? 0,
+                second: 0,
+                of: normalisedDay
+            )
+        }()
 
         switch target {
         case .new:
@@ -482,6 +741,7 @@ private struct ItineraryItemEditorSheet: View {
                 kind: kind,
                 title: cleanTitle,
                 notes: cleanNotes,
+                startTime: combinedStart,
                 sortOrder: nextSort
             )
             modelContext.insert(item)
@@ -492,13 +752,14 @@ private struct ItineraryItemEditorSheet: View {
             if let existing = try? modelContext.fetch(descriptor).first {
                 existing.title = cleanTitle
                 existing.kindEnum = kind
-                if Calendar.current.startOfDay(for: existing.dayDate) != normalisedDay {
+                if cal.startOfDay(for: existing.dayDate) != normalisedDay {
                     // Day moved: re-sortOrder so the item lands at the end of
                     // the new day instead of slotting into the old position.
                     existing.sortOrder = nextSortOrder(for: normalisedDay)
                 }
                 existing.dayDate = normalisedDay
                 existing.notes = cleanNotes
+                existing.startTime = combinedStart
                 existing.updatedAt = Date()
             }
         }
@@ -517,9 +778,11 @@ private struct ItineraryItemEditorSheet: View {
     }
 }
 
-// MARK: - Kind chip
+// MARK: - Kind picker chip (editor sheet)
 
-private struct KindChip: View {
+/// Selectable chip used inside the editor sheet's Kind row. Distinct from
+/// `TripKindChip` (display-only chip on the timeline).
+private struct KindPickerChip: View {
     let kind: ItineraryKind
     let isSelected: Bool
     let onTap: () -> Void

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -546,6 +546,7 @@ struct ItineraryItemEditorSheet: View {
     @State private var hasEndTime: Bool = false
     @State private var notes: String = ""
     @State private var loaded: Bool = false
+    @State private var showingDeleteConfirmation: Bool = false
     @FocusState private var titleFocused: Bool
 
     private let titleMaxLength = 96
@@ -565,6 +566,10 @@ struct ItineraryItemEditorSheet: View {
                             endDateField
                         }
                         notesField
+                        if isEditing {
+                            deleteButton
+                                .padding(.top, Space.sm)
+                        }
                     }
                     .padding(Space.lg)
                 }
@@ -584,6 +589,18 @@ struct ItineraryItemEditorSheet: View {
                     .disabled(trimmedTitle.isEmpty)
                     .foregroundStyle(trimmedTitle.isEmpty ? Tokens.muted : Tokens.ink)
                 }
+            }
+            .confirmationDialog(
+                "Delete this item?",
+                isPresented: $showingDeleteConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Delete", role: .destructive) {
+                    deleteItem()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This can't be undone.")
             }
         }
         .onAppear { loadIfNeeded() }
@@ -782,6 +799,31 @@ struct ItineraryItemEditorSheet: View {
         }
     }
 
+    /// Destructive "Delete item" button shown at the bottom of the editor
+    /// scroll content when editing an existing item. Long-press on the tile
+    /// in the timeline is still available (context menu); this gives the user
+    /// a discoverable in-editor path.
+    private var deleteButton: some View {
+        Button(role: .destructive) {
+            Haptics.destructive()
+            showingDeleteConfirmation = true
+        } label: {
+            HStack(spacing: Space.sm) {
+                Image(systemName: "trash")
+                    .font(.system(size: 15, weight: .regular))
+                Text("Delete item")
+                    .font(.edBodyMedium)
+            }
+            .foregroundStyle(Color.red)
+            .frame(maxWidth: .infinity)
+            .padding(Space.md)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Delete item")
+    }
+
     private func placeholder(for kind: ItineraryKind) -> String {
         switch kind {
         case .stay:       return "e.g. Hanoi Hilton"
@@ -906,6 +948,22 @@ struct ItineraryItemEditorSheet: View {
             }
         }
         try? modelContext.save()
+    }
+
+    /// Fetch the existing item by UUID and remove it from the model context.
+    /// Triggered by the in-editor "Delete item" button after the confirmation
+    /// dialog. The sheet dismisses on completion; the timeline picks up the
+    /// removal via the `@Query` observer.
+    private func deleteItem() {
+        guard case .existing(let uuid) = target else { return }
+        let descriptor = FetchDescriptor<LocalItineraryItem>(
+            predicate: #Predicate { $0.clientUUID == uuid }
+        )
+        if let existing = try? modelContext.fetch(descriptor).first {
+            modelContext.delete(existing)
+            try? modelContext.save()
+        }
+        dismiss()
     }
 
     /// Append-on-create ordering: max sortOrder for the day + 1. Falls back to

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -53,7 +53,7 @@ struct TripDetailView: View {
         }
         .sheet(item: $editingItem) { target in
             ItineraryItemEditorSheet(trip: trip, target: target)
-                .presentationDetents([.medium, .large])
+                .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
     }
@@ -88,12 +88,9 @@ struct TripDetailView: View {
     // MARK: - Empty state
 
     private var emptyState: some View {
-        // Vertically positioned ~45% from top of the area below the trip
-        // header. We approximate that with a flexible top spacer that's
-        // slightly smaller than the bottom one so the block sits above
-        // dead-centre.
+        // True vertical centre of the available area below the trip header.
         VStack(spacing: 0) {
-            Spacer().frame(minHeight: 0).layoutPriority(0.9)
+            Spacer()
             VStack(spacing: 0) {
                 Image(systemName: "airplane.departure")
                     .font(.system(size: 32, weight: .light))
@@ -110,7 +107,7 @@ struct TripDetailView: View {
                     .multilineTextAlignment(.center)
             }
             .frame(maxWidth: 280)
-            Spacer().frame(minHeight: 0).layoutPriority(1.1)
+            Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, Space.lg)
@@ -423,6 +420,14 @@ private struct TripTimelineRow: View {
                 Spacer(minLength: 0)
             }
 
+            if kind == .stay, let endDate = item.endDate {
+                Text(checkoutSubline(endDate: endDate, endTime: item.endTime))
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.muted)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
             if !trimmedNotes.isEmpty {
                 Text(trimmedNotes)
                     .font(.edSubheadline)
@@ -436,6 +441,15 @@ private struct TripTimelineRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
         .paperBorder(Tokens.border, radius: Radius.md)
+    }
+
+    private func checkoutSubline(endDate: Date, endTime: Date?) -> String {
+        let datePart = endDate.formatted(.dateTime.weekday(.abbreviated).day().month(.abbreviated))
+        if let endTime {
+            let timePart = endTime.formatted(.dateTime.hour().minute())
+            return "Check-out · \(datePart) · \(timePart)"
+        }
+        return "Check-out · \(datePart)"
     }
 }
 
@@ -484,15 +498,14 @@ struct ItineraryItemEditorSheet: View {
 
     @State private var title: String = ""
     @State private var kind: ItineraryKind = .activity
+    /// For non-stay kinds: the item's day (with time when `hasTime` is on).
+    /// For stay: the check-in date+time.
     @State private var dayDate: Date = Calendar.current.startOfDay(for: Date())
     @State private var hasTime: Bool = false
-    /// Holds the hours/minutes for the time picker while the sheet is
-    /// open. The persisted `startTime` is rebuilt on save by combining
-    /// `dayDate` + the time-of-day extracted from this value.
-    @State private var timeOfDay: Date = {
-        let cal = Calendar.current
-        return cal.date(bySettingHour: 9, minute: 0, second: 0, of: Date()) ?? Date()
-    }()
+    /// Stay only: the check-out date+time. Defaulted to `dayDate + 1 day` when
+    /// the kind first switches to stay.
+    @State private var endDate: Date = Calendar.current.startOfDay(for: Date())
+    @State private var hasEndTime: Bool = false
     @State private var notes: String = ""
     @State private var loaded: Bool = false
     @FocusState private var titleFocused: Bool
@@ -509,8 +522,10 @@ struct ItineraryItemEditorSheet: View {
                     VStack(alignment: .leading, spacing: Space.lg) {
                         kindField
                         titleField
-                        dayField
-                        timeField
+                        primaryDateField
+                        if kind == .stay {
+                            endDateField
+                        }
                         notesField
                     }
                     .padding(Space.lg)
@@ -534,6 +549,43 @@ struct ItineraryItemEditorSheet: View {
             }
         }
         .onAppear { loadIfNeeded() }
+        .onChange(of: kind) { _, newKind in
+            // Switching to stay: make sure check-out is at least the day after
+            // check-in. Switching away from stay: reset the end-time flag so
+            // the persisted shape matches what's hidden in the UI.
+            let cal = Calendar.current
+            if newKind == .stay {
+                let inDay = cal.startOfDay(for: dayDate)
+                let outDay = cal.startOfDay(for: endDate)
+                if outDay <= inDay {
+                    endDate = cal.date(byAdding: .day, value: 1, to: inDay) ?? inDay
+                }
+            } else {
+                hasEndTime = false
+            }
+        }
+        .onChange(of: dayDate) { _, newValue in
+            // Keep check-out >= check-in for stay items.
+            guard kind == .stay else { return }
+            let cal = Calendar.current
+            let inDay = cal.startOfDay(for: newValue)
+            let outDay = cal.startOfDay(for: endDate)
+            if outDay < inDay {
+                endDate = cal.date(byAdding: .day, value: 1, to: inDay) ?? inDay
+            }
+        }
+        .onChange(of: hasTime) { _, newValue in
+            // Toggling time on: if the current Date is at midnight, seed a 9 AM
+            // default so the picker doesn't open showing 12:00 AM.
+            guard newValue else { return }
+            dayDate = seededTime(on: dayDate, defaultHour: 9)
+        }
+        .onChange(of: hasEndTime) { _, newValue in
+            guard newValue else { return }
+            // Default check-out time: 11 AM (most hotels). Same midnight
+            // guard as the check-in time toggle.
+            endDate = seededTime(on: endDate, defaultHour: 11)
+        }
     }
 
     // MARK: - Fields
@@ -571,50 +623,88 @@ struct ItineraryItemEditorSheet: View {
         }
     }
 
-    private var dayField: some View {
-        VStack(alignment: .leading, spacing: Space.sm) {
-            Text("Day").eyebrow()
-            HStack {
-                Text("Date").font(.edBody).foregroundStyle(Tokens.inkSoft)
-                Spacer()
-                DatePicker("", selection: $dayDate, displayedComponents: .date)
-                    .labelsHidden()
-                    .tint(Tokens.accent(for: .itineraries))
-            }
-            .padding(Space.md)
-            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
-            .paperBorder(Tokens.border, radius: Radius.md)
-        }
-    }
-
-    private var timeField: some View {
-        VStack(alignment: .leading, spacing: Space.sm) {
-            Text("Time").eyebrow()
+    /// Primary date picker. For non-stay kinds: label "Date". For stay:
+    /// label "Check-in". Picker displays date alone or date + time depending
+    /// on `hasTime`, so the time renders inline with the date (no narrow
+    /// truncated time-only picker).
+    private var primaryDateField: some View {
+        let label = kind == .stay ? "Check-in" : "Date"
+        return VStack(alignment: .leading, spacing: Space.sm) {
+            Text(label).eyebrow()
             VStack(spacing: 0) {
                 HStack {
-                    Text("Add time").font(.edBody).foregroundStyle(Tokens.inkSoft)
+                    DatePicker(
+                        "",
+                        selection: $dayDate,
+                        displayedComponents: hasTime ? [.date, .hourAndMinute] : .date
+                    )
+                    .labelsHidden()
+                    .tint(Tokens.accent(for: .itineraries))
+                    Spacer(minLength: 0)
+                }
+                .padding(Space.md)
+
+                Divider().background(Tokens.divider)
+
+                HStack {
+                    Text("Include time").font(.edBody).foregroundStyle(Tokens.inkSoft)
                     Spacer()
                     Toggle("", isOn: $hasTime)
                         .labelsHidden()
                         .tint(Tokens.accent(for: .itineraries))
                 }
                 .padding(Space.md)
-
-                if hasTime {
-                    Divider().background(Tokens.divider)
-                    HStack {
-                        Text("Start").font(.edBody).foregroundStyle(Tokens.inkSoft)
-                        Spacer()
-                        DatePicker("", selection: $timeOfDay, displayedComponents: .hourAndMinute)
-                            .labelsHidden()
-                            .tint(Tokens.accent(for: .itineraries))
-                    }
-                    .padding(Space.md)
-                }
             }
             .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
             .paperBorder(Tokens.border, radius: Radius.md)
         }
+    }
+
+    /// Stay-only second picker for the check-out date / time. Constrained to
+    /// `>= dayDate` so the user can't pick a check-out before the check-in.
+    private var endDateField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Check-out").eyebrow()
+            VStack(spacing: 0) {
+                HStack {
+                    DatePicker(
+                        "",
+                        selection: $endDate,
+                        in: Calendar.current.startOfDay(for: dayDate)...,
+                        displayedComponents: hasEndTime ? [.date, .hourAndMinute] : .date
+                    )
+                    .labelsHidden()
+                    .tint(Tokens.accent(for: .itineraries))
+                    Spacer(minLength: 0)
+                }
+                .padding(Space.md)
+
+                Divider().background(Tokens.divider)
+
+                HStack {
+                    Text("Include time").font(.edBody).foregroundStyle(Tokens.inkSoft)
+                    Spacer()
+                    Toggle("", isOn: $hasEndTime)
+                        .labelsHidden()
+                        .tint(Tokens.accent(for: .itineraries))
+                }
+                .padding(Space.md)
+            }
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    /// Returns `existing` with the time-of-day replaced by `defaultHour:00` if
+    /// the existing time is midnight; otherwise leaves it as-is. Used when
+    /// the "Include time" toggle flips on so the picker doesn't surface 12:00 AM.
+    private func seededTime(on existing: Date, defaultHour: Int) -> Date {
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.hour, .minute], from: existing)
+        if (comps.hour ?? 0) == 0 && (comps.minute ?? 0) == 0 {
+            return cal.date(bySettingHour: defaultHour, minute: 0, second: 0, of: existing) ?? existing
+        }
+        return existing
     }
 
     private var notesField: some View {
@@ -682,14 +772,18 @@ struct ItineraryItemEditorSheet: View {
         guard !loaded else { return }
         loaded = true
 
+        let cal = Calendar.current
+
         switch target {
         case .new(let day):
-            dayDate = Calendar.current.startOfDay(for: day)
+            dayDate = cal.startOfDay(for: day)
             // Default kind heuristic: a first-day item is most often a Stay.
-            if Calendar.current.isDate(day, inSameDayAs: trip.startDate) {
+            if cal.isDate(day, inSameDayAs: trip.startDate) {
                 kind = .stay
+                endDate = cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: day)) ?? dayDate
             } else {
                 kind = .activity
+                endDate = cal.startOfDay(for: day)
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
                 titleFocused = true
@@ -705,7 +799,18 @@ struct ItineraryItemEditorSheet: View {
                 notes = existing.notes
                 if let start = existing.startTime {
                     hasTime = true
-                    timeOfDay = start
+                    dayDate = start
+                }
+                if let end = existing.endDate {
+                    endDate = end
+                    if let endT = existing.endTime {
+                        hasEndTime = true
+                        endDate = endT
+                    }
+                } else if existing.kindEnum == .stay {
+                    // Stay with no persisted endDate (legacy item before the
+                    // field existed): seed a sane default of +1 day.
+                    endDate = cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: existing.dayDate)) ?? existing.dayDate
                 }
             }
         }
@@ -718,19 +823,14 @@ struct ItineraryItemEditorSheet: View {
         let cal = Calendar.current
         let normalisedDay = cal.startOfDay(for: dayDate)
 
-        // Combine the day (date-only) with the time-of-day picker if the
-        // toggle is on. Falling back to dayDate keeps the call total in
-        // case the time-of-day extraction fails (it shouldn't).
-        let combinedStart: Date? = {
-            guard hasTime else { return nil }
-            let comps = cal.dateComponents([.hour, .minute], from: timeOfDay)
-            return cal.date(
-                bySettingHour: comps.hour ?? 0,
-                minute: comps.minute ?? 0,
-                second: 0,
-                of: normalisedDay
-            )
-        }()
+        // For non-stay or when "Include time" is off: persist only the day.
+        // For non-stay with time on: persist the full date+time as `startTime`,
+        // dayDate stays start-of-day so the grouping bucket is unambiguous.
+        let startTimeValue: Date? = hasTime ? dayDate : nil
+
+        // Stay-only end fields. Other kinds clear both.
+        let endDateValue: Date? = kind == .stay ? cal.startOfDay(for: endDate) : nil
+        let endTimeValue: Date? = (kind == .stay && hasEndTime) ? endDate : nil
 
         switch target {
         case .new:
@@ -741,7 +841,9 @@ struct ItineraryItemEditorSheet: View {
                 kind: kind,
                 title: cleanTitle,
                 notes: cleanNotes,
-                startTime: combinedStart,
+                startTime: startTimeValue,
+                endDate: endDateValue,
+                endTime: endTimeValue,
                 sortOrder: nextSort
             )
             modelContext.insert(item)
@@ -759,7 +861,9 @@ struct ItineraryItemEditorSheet: View {
                 }
                 existing.dayDate = normalisedDay
                 existing.notes = cleanNotes
-                existing.startTime = combinedStart
+                existing.startTime = startTimeValue
+                existing.endDate = endDateValue
+                existing.endTime = endTimeValue
                 existing.updatedAt = Date()
             }
         }
@@ -792,8 +896,12 @@ private struct KindPickerChip: View {
             HStack(spacing: 4) {
                 Image(systemName: kind.icon)
                     .font(.system(size: 12, weight: .regular))
+                    .layoutPriority(1)
                 Text(kind.displayName)
                     .font(.edFootnote)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                    .truncationMode(.tail)
             }
             .padding(.horizontal, Space.sm)
             .padding(.vertical, 6)


### PR DESCRIPTION
## Summary
- Rework itinerary detail as a true vertical timeline (closes #108).
- Empty trip shows a hint + single global "+" FAB only — day shells gone.
- Day clusters render only for days with items; within a day, untimed items pin top and timed items sort asc by startTime.
- Adds nullable `startTime: Date?` to `LocalItineraryItem` (additive SwiftData migration). AI tools `add_itinerary_item` / `edit_itinerary_item` accept optional `start_time` (ISO 8601).
- Visual spec produced by `ui-ux-design` agent, implemented by `frontend-ux-architect`.

Closes #108

## Test plan
- [ ] Empty trip shows hint + FAB only.
- [ ] Add item with date, no time → appears top of day, hollow marker.
- [ ] Same day, mix of timed + untimed → untimed first, timed sorted ascending.
- [ ] Items across multiple dates → days ordered oldest-to-latest with eyebrow per cluster.
- [ ] Capture: "add dinner at 7pm Friday to Lisbon trip" lands a 7:00 PM item.
- [ ] Edit time → reorders within day. Edit date → moves cluster.
- [ ] Long-press item → Delete (context menu fallback in ScrollView composition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)