### PR TITLE
feat(ios): finance placeholder in side drawer

### DIFF
--- a/mobile/PersonalDashboard/Design/Tokens.swift
+++ b/mobile/PersonalDashboard/Design/Tokens.swift
@@ -12,6 +12,7 @@ enum AppSection: String, CaseIterable, Identifiable, Hashable {
     case dashboard
     case activity
     case itineraries
+    case finance
     case vocabulary
     case settings
     case helpCenter
@@ -28,6 +29,7 @@ enum AppSection: String, CaseIterable, Identifiable, Hashable {
         case .dashboard:   return "Dashboard"
         case .activity:    return "Activity"
         case .itineraries: return "Itineraries"
+        case .finance:     return "Finance"
         case .vocabulary:  return "Vocabulary"
         case .settings:    return "Settings"
         case .helpCenter:  return "Help center"
@@ -45,6 +47,7 @@ enum AppSection: String, CaseIterable, Identifiable, Hashable {
         case .dashboard:   return "rectangle.grid.2x2"
         case .activity:    return "clock.arrow.circlepath"
         case .itineraries: return "airplane"
+        case .finance:     return "dollarsign.circle"
         case .vocabulary:  return "character.book.closed"
         case .settings:    return "gearshape"
         case .helpCenter:  return "questionmark.circle"
@@ -96,6 +99,7 @@ enum Tokens {
     static let accentActivity  = Color.paper(0x7C3F58, 0xE5A3BA)
     static let accentVocabulary = Color.paper(0x57534E, 0xB7B0A2)
     static let accentItineraries = Color.paper(0x6D28D9, 0xA78BFA)
+    static let accentFinance   = Color.paper(0x047857, 0x10B981)
     static let accentSettings  = Color.paper(0x475569, 0x94A3B8)
     static let accentHelp      = Color.paper(0x475569, 0x94A3B8)
     static let accentFg        = Color.paper(0xFFFFFF, 0x14110D)
@@ -119,6 +123,7 @@ enum Tokens {
         case .dashboard:   return accentDashboard
         case .activity:    return accentActivity
         case .itineraries: return accentItineraries
+        case .finance:     return accentFinance
         case .vocabulary:  return accentVocabulary
         case .settings:    return accentSettings
         case .helpCenter:  return accentHelp

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -196,6 +196,8 @@ struct ContentView: View {
             TodayView(router: router)
         case .itineraries:
             ItinerariesView(router: router)
+        case .finance:
+            FinanceView(router: router)
         case .vocabulary:
             PersonalVocabularyView(router: router)
         case .helpCenter:

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Finance surface placeholder (issue #110). Mirrors the HelpCenter pattern:
+/// a routed page so the drawer entry has a real destination instead of a
+/// 404. Real content (accounts, spending, recurring bills) lands here later.
+struct FinanceView: View {
+    @Bindable var router: AppRouter
+
+    var body: some View {
+        ZStack {
+            Tokens.paper.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                TopBar(
+                    title: "Finance",
+                    onMenu: {
+                        withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true }
+                    }
+                )
+
+                Spacer()
+
+                VStack(spacing: Space.lg) {
+                    Image(systemName: "dollarsign.circle")
+                        .font(.system(size: 32, weight: .regular))
+                        .foregroundStyle(Tokens.muted)
+
+                    Rectangle()
+                        .fill(Tokens.accentFinance)
+                        .frame(width: 32, height: 2)
+
+                    VStack(spacing: Space.sm) {
+                        Text("Coming soon")
+                            .font(.edDisplay)
+                            .foregroundStyle(Tokens.ink)
+                            .multilineTextAlignment(.center)
+                            .tracking(-0.4)
+
+                        Text("Accounts, spending, and recurring bills will live here.")
+                            .font(.edBody)
+                            .foregroundStyle(Tokens.muted)
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: 320)
+                    }
+                }
+                .padding(.horizontal, Space.xl)
+
+                Spacer()
+                Spacer()
+            }
+        }
+        .activeSection(.finance)
+    }
+}

--- a/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
+++ b/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
@@ -111,14 +111,14 @@ struct SideDrawer: View {
 
             DrawerDivider()
 
-            // Five rows: Today, Itineraries, Vocabulary, Help center, Settings.
-            // Primary surfaces (Notes, Lists, Tasks, Activity) and Chat live
-            // in the bottom tab bar. Dashboard remains hidden (issue #30).
-            // Itineraries sits between Today and Vocabulary so the user's
-            // travel planning surface stays close to their daily-use rows
-            // (issue #104).
+            // Six rows: Today, Itineraries, Finance, Vocabulary, Help center,
+            // Settings. Primary surfaces (Notes, Lists, Tasks, Activity) and
+            // Chat live in the bottom tab bar. Dashboard remains hidden
+            // (issue #30). Finance sits directly below Itineraries as a
+            // placeholder with a "Coming soon" pill (issue #110).
             DrawerRow(section: .today, router: router)
             DrawerRow(section: .itineraries, router: router)
+            DrawerRow(section: .finance, router: router, badge: "Coming soon")
             DrawerRow(section: .vocabulary, router: router)
             DrawerRow(section: .helpCenter, router: router)
             DrawerRow(section: .settings, router: router)
@@ -181,6 +181,10 @@ private struct DrawerDivider: View {
 private struct DrawerRow: View {
     let section: AppSection
     @Bindable var router: AppRouter
+    /// Optional pill rendered on the trailing edge. Used to flag in-progress
+    /// surfaces (e.g. Finance, issue #110) without spinning up a separate
+    /// row component.
+    var badge: String? = nil
 
     var body: some View {
         let isActive = router.currentSection == section
@@ -206,6 +210,20 @@ private struct DrawerRow: View {
                     .foregroundStyle(isActive ? Tokens.ink : Tokens.muted)
 
                 Spacer()
+
+                if let badge {
+                    Text(badge)
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.muted)
+                        .padding(.horizontal, Space.sm)
+                        .padding(.vertical, 3)
+                        .background(
+                            Capsule().fill(Tokens.paper2)
+                        )
+                        .overlay(
+                            Capsule().stroke(Tokens.border, lineWidth: 0.5)
+                        )
+                }
             }
             .padding(.trailing, Space.lg)
             .frame(height: 44)


### PR DESCRIPTION
## Summary
- Add Finance entry to the side drawer directly below Itineraries, with a "Coming soon" pill on the trailing edge.
- Tapping Finance routes to a dedicated `FinanceView` "Coming soon" surface modelled on `HelpCenterView`, so the drawer entry has a real destination instead of a 404.
- New `AppSection.finance` wired through `displayName`, `icon` (dollarsign.circle), and `Tokens.accent(for:)`. `DrawerRow` gains an optional `badge` pill for in-progress surfaces.

Closes #110

## Test plan
- [x] Static build clean (`xcodegen generate` + `xcodebuild build`).
- [x] Installed to iPhone via `devicectl` (build 999, marketing 1.4.0).
- [ ] Drawer row order on device: Today → Itineraries → Finance (with "Coming soon" pill) → Vocabulary → Help center → Settings.
- [ ] Tapping Finance routes to the "Coming soon" destination with the dollar-sign icon and the finance accent.
- [ ] No regressions on Itineraries / Vocabulary / Help center / Settings rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)