### PR TITLE
feat(ios): finance v1 — expense tracker with receipt vision capture

### DIFF
--- a/mobile/PersonalDashboard/AI/AnthropicClient+ExtractExpense.swift
+++ b/mobile/PersonalDashboard/AI/AnthropicClient+ExtractExpense.swift
@@ -1,0 +1,273 @@
+import Foundation
+
+/// One parsed receipt-extraction result. Mirrors the JSON schema the model
+/// is instructed to emit. Every field is optional except `confidence` —
+/// the LLM is told to return `null` for anything it can't reliably read.
+///
+/// `category` is the **raw display name** of an `ExpenseCategory`
+/// (e.g. "Food & Dining"). Callers map it back to the enum via
+/// `ExpenseCategory.matchingDisplayName`.
+struct ExtractedExpense: Decodable, Sendable, Equatable {
+    let merchant: String?
+    let date: String?              // "YYYY-MM-DD"
+    let totalAmount: Double?
+    let currency: String?          // ISO 4217
+    let category: String?          // ExpenseCategory.displayName
+    let items: [String]?
+    let confidence: Confidence?
+
+    enum Confidence: String, Decodable, Sendable {
+        case high, medium, low
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case merchant
+        case date
+        case totalAmount = "total_amount"
+        case currency
+        case category
+        case items
+        case confidence
+    }
+}
+
+/// Errors surfaced to the Finance UI when extraction fails. The receipt
+/// file is always saved regardless — these errors only describe the
+/// Vision call. The UI falls back to opening AddExpenseSheet with the
+/// receipt attached and the user fills in the rest manually.
+enum ReceiptExtractionError: LocalizedError {
+    case notConfigured
+    case transport(Error)
+    case http(Int, String)
+    case noJSON
+    case parse(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured:
+            return "Anthropic API key not configured."
+        case .transport(let err):
+            return "Couldn't reach Anthropic. \(err.localizedDescription)"
+        case .http(let status, let preview):
+            return "Anthropic API HTTP \(status). \(preview)"
+        case .noJSON:
+            return "Couldn't find a JSON block in Claude's response."
+        case .parse(let err):
+            return "Couldn't parse Claude's response. \(err.localizedDescription)"
+        }
+    }
+}
+
+extension AnthropicClient {
+    /// Send an image to Claude and ask for structured receipt fields.
+    /// `mediaType` is the MIME type ("image/jpeg", "image/png", "image/heic").
+    func extractExpense(imageData: Data, mediaType: String) async throws -> ExtractedExpense {
+        let base64 = imageData.base64EncodedString()
+        let content: [AnthropicJSONValue] = [
+            .object([
+                "type": .string("image"),
+                "source": .object([
+                    "type": .string("base64"),
+                    "media_type": .string(mediaType),
+                    "data": .string(base64)
+                ])
+            ]),
+            .object([
+                "type": .string("text"),
+                "text": .string(Self.extractionPrompt)
+            ])
+        ]
+        return try await runExtraction(content: content, extraHeaders: [:])
+    }
+
+    /// Send a PDF receipt (e.g. an emailed invoice exported to Files) and
+    /// ask for the same structured fields. PDF support is gated behind the
+    /// `pdfs-2024-09-25` beta header.
+    func extractExpense(pdfData: Data) async throws -> ExtractedExpense {
+        let base64 = pdfData.base64EncodedString()
+        let content: [AnthropicJSONValue] = [
+            .object([
+                "type": .string("document"),
+                "source": .object([
+                    "type": .string("base64"),
+                    "media_type": .string("application/pdf"),
+                    "data": .string(base64)
+                ])
+            ]),
+            .object([
+                "type": .string("text"),
+                "text": .string(Self.extractionPrompt)
+            ])
+        ]
+        return try await runExtraction(
+            content: content,
+            extraHeaders: ["anthropic-beta": "pdfs-2024-09-25"]
+        )
+    }
+
+    // MARK: - Core
+
+    private func runExtraction(
+        content: [AnthropicJSONValue],
+        extraHeaders: [String: String]
+    ) async throws -> ExtractedExpense {
+        guard let key = AppConfig.anthropicAPIKey, !key.isEmpty else {
+            throw ReceiptExtractionError.notConfigured
+        }
+
+        // Construct the request body by hand (not via AnthropicRequest) so we
+        // can send heterogeneous content blocks. The existing AnthropicMessage
+        // wire type is restricted to text / tool_use / tool_result and would
+        // need a wider sum type to carry image/document blocks; this is a
+        // one-call surface so a hand-rolled JSON body is simpler.
+        let body: AnthropicJSONValue = .object([
+            "model": .string(Self.model),
+            "max_tokens": .int(Self.maxTokens),
+            "temperature": .double(Self.temperature),
+            "messages": .array([
+                .object([
+                    "role": .string("user"),
+                    "content": .array(content)
+                ])
+            ])
+        ])
+
+        var request = URLRequest(url: Self.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(key, forHTTPHeaderField: "x-api-key")
+        request.setValue(Self.anthropicVersion, forHTTPHeaderField: "anthropic-version")
+        for (k, v) in extraHeaders {
+            request.setValue(v, forHTTPHeaderField: k)
+        }
+        // PDF + Vision extractions can take noticeably longer than text-only
+        // requests. Give them headroom over URLSession's 60s default.
+        request.timeoutInterval = 90
+
+        do {
+            request.httpBody = try Self.encoder.encode(body)
+        } catch {
+            throw ReceiptExtractionError.parse(error)
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw ReceiptExtractionError.transport(error)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw ReceiptExtractionError.http(0, "non-HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let preview = String(data: data.prefix(800), encoding: .utf8) ?? "<non-utf8 bytes>"
+            throw ReceiptExtractionError.http(http.statusCode, preview)
+        }
+
+        let decoded: AnthropicResponse
+        do {
+            decoded = try Self.decoder.decode(AnthropicResponse.self, from: data)
+        } catch {
+            throw ReceiptExtractionError.parse(error)
+        }
+
+        // Concatenate all returned text blocks. The model usually emits one,
+        // but never assume.
+        let combinedText = decoded.content.compactMap { block -> String? in
+            if case .text(let t) = block { return t }
+            return nil
+        }.joined(separator: "\n")
+
+        guard let jsonString = Self.firstJSONBlock(in: combinedText),
+              let jsonData = jsonString.data(using: .utf8) else {
+            throw ReceiptExtractionError.noJSON
+        }
+        do {
+            return try Self.decoder.decode(ExtractedExpense.self, from: jsonData)
+        } catch {
+            throw ReceiptExtractionError.parse(error)
+        }
+    }
+
+    // MARK: - Prompt + parsing
+
+    /// Categories advertised to the model. Kept in sync with `ExpenseCategory`
+    /// display names so the model can return any of the 12 verbatim.
+    private static var categoryList: String {
+        ExpenseCategory.allCases
+            .map { "\"\($0.displayName)\"" }
+            .joined(separator: ", ")
+    }
+
+    static let extractionPrompt: String = """
+    Read this receipt and extract the expense details. Return STRICT JSON
+    inside a ```json fence and nothing else.
+
+    Schema:
+    {
+      "merchant": "...",
+      "date": "YYYY-MM-DD",
+      "total_amount": 12.34,
+      "currency": "SGD",
+      "category": "Food & Dining",
+      "items": ["..."],
+      "confidence": "high"
+    }
+
+    Rules:
+    - Any field you can't read with confidence: return null.
+    - "currency" must be an ISO 4217 code. If you genuinely cannot tell,
+      default to "SGD".
+    - "category" must be exactly one of: \(categoryList).
+    - "confidence" is one of "high", "medium", "low". Reflect how sure you
+      are about the total amount specifically.
+    - "items" is a short list of line-item names (at most 6). Skip if not
+      visible.
+    - Do not invent fields. Do not add commentary outside the JSON fence.
+    """
+
+    /// Pull the first ```json``` fenced block out of `text` and return its
+    /// raw body. Falls back to any ``` block if no language tag is present.
+    /// Returns nil if no fence is found and the text isn't already a JSON
+    /// object on its own.
+    static func firstJSONBlock(in text: String) -> String? {
+        // Preferred: ```json ... ```
+        if let range = text.range(of: "```json") {
+            let after = text[range.upperBound...]
+            if let close = after.range(of: "```") {
+                return String(after[after.startIndex..<close.lowerBound])
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+        // Bare ``` fence (no language).
+        if let open = text.range(of: "```") {
+            let after = text[open.upperBound...]
+            if let close = after.range(of: "```") {
+                let candidate = String(after[after.startIndex..<close.lowerBound])
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if candidate.hasPrefix("{") { return candidate }
+            }
+        }
+        // Raw JSON object — model occasionally drops the fence.
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("{"), let end = trimmed.range(of: "}", options: .backwards) {
+            return String(trimmed[trimmed.startIndex...end.lowerBound])
+        }
+        return nil
+    }
+}
+
+// MARK: - ExpenseCategory lookup by display name
+
+extension ExpenseCategory {
+    /// Find the category whose `displayName` matches `name` exactly. Used to
+    /// map an extracted `"Food & Dining"` string back to the enum.
+    static func matching(displayName name: String?) -> ExpenseCategory? {
+        guard let name else { return nil }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ExpenseCategory.allCases.first { $0.displayName == trimmed }
+    }
+}

--- a/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
+++ b/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
@@ -165,6 +165,72 @@ struct AssistantContextBuilder {
             }.joined(separator: "\n")
         }
 
+        // Expenses (Finance v1): up to 20 most-recent expenses from the
+        // last 30 days plus this-month and per-category SGD totals. Keeps
+        // the prompt budget reasonable while giving the model enough
+        // visibility to answer "what did I spend on groceries last week"
+        // questions and not double-log when the user repeats themselves.
+        let cal = Calendar(identifier: .gregorian)
+        let now = Date()
+        if let last30Cutoff = cal.date(byAdding: .day, value: -30, to: now) {
+            let cutoff = cal.startOfDay(for: last30Cutoff)
+            if let recent = try? context.fetch(
+                FetchDescriptor<LocalExpense>(
+                    predicate: #Predicate { $0.date >= cutoff },
+                    sortBy: [
+                        SortDescriptor(\LocalExpense.date, order: .reverse),
+                        SortDescriptor(\LocalExpense.createdAt, order: .reverse)
+                    ]
+                )
+            ), !recent.isEmpty {
+                // This-month total (calendar month).
+                let monthComps = cal.dateComponents([.year, .month], from: now)
+                let monthStart = cal.date(from: monthComps) ?? now
+                let monthRows = recent.filter { $0.date >= monthStart }
+                let monthTotal = monthRows.reduce(0.0) { $0 + $1.sgdAmount }
+
+                // Category totals this month, biggest first.
+                var byCategory: [String: Double] = [:]
+                for row in monthRows {
+                    byCategory[row.category, default: 0] += row.sgdAmount
+                }
+                let topCategories = byCategory
+                    .sorted { $0.value > $1.value }
+                    .prefix(5)
+
+                out += "\n\nEXPENSES (this month, last 30):\n"
+                out += String(format: "- This month total: SGD %.2f", monthTotal)
+                if !topCategories.isEmpty {
+                    let catLine = topCategories.map { (raw, total) -> String in
+                        let display = ExpenseCategory(rawValue: raw)?.displayName ?? raw
+                        return String(format: "%@: SGD %.2f", display, total)
+                    }.joined(separator: ", ")
+                    out += "\n- Top categories: \(catLine)"
+                }
+
+                let rows = recent.prefix(20)
+                out += "\n- Recent:"
+                for row in rows {
+                    let dayISO = Self.isoDate.string(from: row.date)
+                    let category = ExpenseCategory(rawValue: row.category)?.displayName ?? "Other"
+                    var line = "\n  - \(dayISO) · "
+                    if let merchant = row.merchant, !merchant.isEmpty {
+                        line += merchant
+                    } else if let desc = row.expenseDescription, !desc.isEmpty {
+                        line += desc
+                    } else {
+                        line += category
+                    }
+                    line += String(format: " · SGD %.2f", row.sgdAmount)
+                    if row.originalCurrency.uppercased() != "SGD" {
+                        line += String(format: " (\(row.originalCurrency.uppercased()) %.2f)", row.originalAmount)
+                    }
+                    line += " · \(category)"
+                    out += line
+                }
+            }
+        }
+
         // Personal vocabulary: words the user has explicitly taught the
         // assistant so the model can prefer them over close-sounding
         // mistranscriptions ("envisso" vs. "in visa", "Dexter" vs. "Dexter

--- a/mobile/PersonalDashboard/AI/ChatDraft.swift
+++ b/mobile/PersonalDashboard/AI/ChatDraft.swift
@@ -150,9 +150,45 @@ extension ChatDraft {
         case .deleteItineraryItem:
             return "Delete itinerary item (ID: \(dict["id"]?.stringValue ?? "?"))"
 
+        case .addExpense:
+            return Self.addExpenseSummary(dict: dict)
+
         case .unknown:
             return "Unknown action"
         }
+    }
+
+    /// Preview for `add_expense`. Format aims for the same scannable shape
+    /// the user sees on the Finance list: "Merchant · SGD 67.50 · Category".
+    private static func addExpenseSummary(dict: [String: AnthropicJSONValue]) -> String {
+        let amount = dict["original_amount"]?.doubleValue
+            ?? Double(dict["original_amount"]?.stringValue ?? "")
+            ?? 0
+        let currency = (dict["original_currency"]?.stringValue ?? "SGD")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .uppercased()
+        let cleanedCurrency = currency.isEmpty ? "SGD" : currency
+
+        let categoryRaw = (dict["category"]?.stringValue ?? "").lowercased()
+        let categoryName = ExpenseCategory(rawValue: categoryRaw)?.displayName ?? "Other"
+
+        let merchant = (dict["merchant"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let description = (dict["description"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let headline: String
+        if !merchant.isEmpty {
+            headline = merchant
+        } else if !description.isEmpty {
+            headline = description
+        } else {
+            headline = categoryName
+        }
+
+        let amountString = String(format: "%@ %.2f", cleanedCurrency, amount)
+        // If the headline is already the category, don't repeat it.
+        if headline == categoryName {
+            return "\(headline) · \(amountString)"
+        }
+        return "\(headline) · \(amountString) · \(categoryName)"
     }
 
     /// Build the preview for `edit_trip`. Falls back to a generic line if

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -73,9 +73,102 @@ struct ExecuteDraftAction {
         case .deleteTrip: return try deleteTrip(input)
         case .updateItineraryItem: return try updateItineraryItem(input)
         case .deleteItineraryItem: return try deleteItineraryItem(input)
+        case .addExpense: return try await addExpense(input)
         case .unknown:
             throw DraftExecutionError.invalidArgument(field: "action", reason: "unknown action type")
         }
+    }
+
+    // MARK: - Expenses
+
+    /// `add_expense` tool handler. Converts non-SGD amounts via FXService,
+    /// freezes the rate on the row, and persists. Source defaults to `.text`
+    /// (we'll override to `.voice` from the voice path and `.photo` /
+    /// `.receipt` in Phase B).
+    private func addExpense(_ input: [String: AnthropicJSONValue]) async throws -> DraftActionOutcome {
+        // Amount. Tolerate either JSON number or numeric string from the
+        // model — both shapes have shown up in practice.
+        let originalAmount = input["original_amount"]?.doubleValue
+            ?? Double(input["original_amount"]?.stringValue ?? "")
+            ?? 0
+        guard originalAmount > 0 else {
+            throw DraftExecutionError.invalidArgument(field: "original_amount", reason: "must be > 0")
+        }
+
+        // Category. Fallback to `.other` if the model picks something off-list.
+        let categoryRaw = (input["category"]?.stringValue ?? "").lowercased()
+        let category = ExpenseCategory(rawValue: categoryRaw) ?? .other
+
+        // Currency. Empty string = SGD.
+        let currencyRaw = trimmedString(input["original_currency"]) ?? "SGD"
+        let currency = currencyRaw.isEmpty ? "SGD" : currencyRaw.uppercased()
+
+        // Date. Empty / unparseable = today.
+        let date = parseAnyISODate(input["date"]?.stringValue) ?? Date()
+
+        let merchant = trimmedString(input["merchant"])
+        let descriptionField = trimmedString(input["description"])
+        let paymentMethod = trimmedString(input["payment_method"])
+
+        // Optional UUID override from the tool input. If the model emitted
+        // a valid UUID we use it; otherwise we generate one.
+        let providedID = trimmedString(input["id"])
+        let clientUUID: String = {
+            if let raw = providedID, UUID(uuidString: raw) != nil {
+                return raw.lowercased()
+            }
+            return UUID().uuidString.lowercased()
+        }()
+
+        // FX. SGD passes straight through; other currencies hit FXService
+        // (cached for 1 day). Failures bubble as `invalidArgument` so the
+        // chat surface shows a useful error rather than a silent zero.
+        let fx = FXService(store: store)
+        let conversion: (sgdAmount: Double, rate: Double)
+        do {
+            conversion = try await fx.convert(originalAmount, from: currency)
+        } catch {
+            throw DraftExecutionError.invalidArgument(
+                field: "original_currency",
+                reason: "couldn't fetch FX rate for \(currency): \(error.localizedDescription)"
+            )
+        }
+
+        let service = ExpenseService(store: store)
+        let row: LocalExpense
+        do {
+            row = try service.addExpense(
+                date: date,
+                category: category,
+                merchant: merchant,
+                expenseDescription: descriptionField,
+                originalAmount: originalAmount,
+                originalCurrency: currency,
+                sgdAmount: conversion.sgdAmount,
+                fxRate: conversion.rate,
+                paymentMethod: paymentMethod,
+                source: .text,
+                clientUUID: clientUUID
+            )
+        } catch {
+            throw DraftExecutionError.persistence(error)
+        }
+
+        // Build a human title for the outcome dialog. Prefer merchant,
+        // then description, then a category fallback so the App Intent's
+        // "Saved 'X'" line is never blank.
+        let title = row.merchant
+            ?? row.expenseDescription
+            ?? category.displayName
+
+        return DraftActionOutcome(
+            type: "expense",
+            action: ActionString.created,
+            id: row.clientUUID,
+            title: title,
+            dueDate: nil,
+            addedNames: nil
+        )
     }
 
     // MARK: - CREATE

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -366,6 +366,33 @@ enum ToolDefinitions {
         )
     )
 
+    // MARK: - Expenses (Finance v1)
+
+    /// Log a new expense. SGD is the home currency; the conversion happens
+    /// on-device after the tool call lands, so the LLM never needs to know
+    /// FX rates. Category is one of the 12 canonical raw values — the model
+    /// picks based on merchant + description.
+    private static let addExpense = AnthropicTool(
+        name: "add_expense",
+        description: "Log a NEW expense. Use this when the user says they spent money (e.g., \"I spent $20 on lunch at Starbucks\", \"add a 67 SGD grocery run yesterday\"). Pick the best-fitting category from the enum. If currency isn't specified, default to SGD. Date defaults to today if the user doesn't say.",
+        input_schema: object(
+            properties: [
+                "id": string("UUID string for the new expense. Generate a fresh one for every call (any valid lowercase UUID, e.g., 9b3a8e1c-2f6f-4a3b-9d2c-7e0a1b4c5d6e)."),
+                "date": string("ISO 8601 date the spend happened (e.g., 2026-05-22 or 2026-05-22T18:30:00Z). Use today's date if the user did not specify a date."),
+                "category": string("One of: food_and_dining, groceries, transport, shopping, entertainment, bills_and_utilities, health_and_wellness, travel, subscriptions, personal_care, gifts_and_donations, other. Pick the best fit based on merchant and description."),
+                "merchant": string("Merchant or vendor name (e.g., \"Starbucks\", \"FairPrice\"). Use empty string if unknown."),
+                "description": string("Short description of the expense (e.g., \"lunch with Sarah\", \"weekly groceries\"). Use empty string if none."),
+                "original_amount": .object([
+                    "type": .string("number"),
+                    "description": .string("Amount paid in the original currency. Must be greater than zero.")
+                ]),
+                "original_currency": string("ISO 4217 currency code (e.g., \"SGD\", \"USD\", \"EUR\"). Default to \"SGD\" if the user did not specify a currency."),
+                "payment_method": string("Optional payment method (e.g., \"Cash\", \"Visa **1234\"). Use empty string if unknown.")
+            ],
+            required: ["id", "date", "category", "merchant", "description", "original_amount", "original_currency", "payment_method"]
+        )
+    )
+
     // MARK: - Public surface
 
     static let allTools: [AnthropicTool] = [
@@ -389,7 +416,8 @@ enum ToolDefinitions {
         editTrip,
         deleteTrip,
         editItineraryItem,
-        deleteItineraryItem
+        deleteItineraryItem,
+        addExpense
     ]
 
     /// Subset of `allTools` excluded from the capture (Shortcut) auto-execute
@@ -430,6 +458,7 @@ enum ToolDefinitions {
         "edit_trip": .updateTrip,
         "delete_trip": .deleteTrip,
         "edit_itinerary_item": .updateItineraryItem,
-        "delete_itinerary_item": .deleteItineraryItem
+        "delete_itinerary_item": .deleteItineraryItem,
+        "add_expense": .addExpense
     ]
 }

--- a/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
+++ b/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
@@ -29,6 +29,8 @@ final class SwiftDataStore {
                 LocalKeyword.self,
                 LocalTrip.self,
                 LocalItineraryItem.self,
+                LocalExpense.self,
+                LocalFXRate.self,
             ])
             // SwiftData defaults the store URL to Application Support, but
             // on a fresh simulator that directory doesn't exist yet and
@@ -63,6 +65,8 @@ final class SwiftDataStore {
                 LocalKeyword.self,
                 LocalTrip.self,
                 LocalItineraryItem.self,
+                LocalExpense.self,
+                LocalFXRate.self,
             ])
             let configuration = ModelConfiguration(
                 schema: schema,

--- a/mobile/PersonalDashboard/Info.plist
+++ b/mobile/PersonalDashboard/Info.plist
@@ -33,10 +33,14 @@
 	<array>
 		<string>_http._tcp</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Used to capture receipts so Dexter can log expenses for you.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Dexter talks to your Mac dev server over wifi when you're on the same network.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Dexter listens to your voice so it can transcribe what you say into the chat.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Used to import a receipt photo when logging an expense.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Dexter transcribes your voice into chat messages on-device. Audio never leaves your phone.</string>
 	<key>OTA_API_URL</key>

--- a/mobile/PersonalDashboard/Models/Draft.swift
+++ b/mobile/PersonalDashboard/Models/Draft.swift
@@ -22,5 +22,6 @@ enum DraftActionType: String, Codable, Hashable, Sendable {
     case deleteTrip = "DELETE_TRIP"
     case updateItineraryItem = "UPDATE_ITINERARY_ITEM"
     case deleteItineraryItem = "DELETE_ITINERARY_ITEM"
+    case addExpense = "ADD_EXPENSE"
     case unknown = "UNKNOWN"
 }

--- a/mobile/PersonalDashboard/Models/Local/ExpenseCategory.swift
+++ b/mobile/PersonalDashboard/Models/Local/ExpenseCategory.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Twelve canonical expense categories. Raw values are the user-facing
+/// strings the LLM picks from in the `add_expense` tool schema and what
+/// gets persisted onto `LocalExpense.category`.
+///
+/// Order here is also the order used in pickers and dashboard breakdowns,
+/// so adjust with intent — the "Other" case is always last so it falls to
+/// the bottom of category lists.
+enum ExpenseCategory: String, Codable, CaseIterable, Identifiable, Hashable, Sendable {
+    case foodAndDining       = "food_and_dining"
+    case groceries           = "groceries"
+    case transport           = "transport"
+    case shopping            = "shopping"
+    case entertainment       = "entertainment"
+    case billsAndUtilities   = "bills_and_utilities"
+    case healthAndWellness   = "health_and_wellness"
+    case travel              = "travel"
+    case subscriptions       = "subscriptions"
+    case personalCare        = "personal_care"
+    case giftsAndDonations   = "gifts_and_donations"
+    case other               = "other"
+
+    var id: String { rawValue }
+
+    /// Human-readable label shown in pickers and rows.
+    var displayName: String {
+        switch self {
+        case .foodAndDining:     return "Food & Dining"
+        case .groceries:         return "Groceries"
+        case .transport:         return "Transport"
+        case .shopping:          return "Shopping"
+        case .entertainment:     return "Entertainment"
+        case .billsAndUtilities: return "Bills & Utilities"
+        case .healthAndWellness: return "Health & Wellness"
+        case .travel:            return "Travel"
+        case .subscriptions:     return "Subscriptions"
+        case .personalCare:      return "Personal Care"
+        case .giftsAndDonations: return "Gifts & Donations"
+        case .other:             return "Other"
+        }
+    }
+
+    /// SF Symbol rendered on category chips, list rows, and the +Sheet picker.
+    var sfSymbol: String {
+        switch self {
+        case .foodAndDining:     return "fork.knife"
+        case .groceries:         return "cart"
+        case .transport:         return "tram.fill"
+        case .shopping:          return "bag"
+        case .entertainment:     return "popcorn"
+        case .billsAndUtilities: return "bolt"
+        case .healthAndWellness: return "heart.text.square"
+        case .travel:            return "airplane"
+        case .subscriptions:     return "repeat"
+        case .personalCare:      return "scissors"
+        case .giftsAndDonations: return "gift"
+        case .other:             return "square.grid.2x2"
+        }
+    }
+}
+
+/// Source channel an expense came from. Drives both downstream telemetry
+/// and the source-filter chips in the Finance list. Stored as a raw string
+/// on `LocalExpense.source`.
+enum ExpenseSource: String, Codable, CaseIterable, Identifiable, Hashable, Sendable {
+    case manual    = "manual"
+    case text      = "text"
+    case voice     = "voice"
+    case photo     = "photo"
+    case receipt   = "receipt"
+    case pdf       = "pdf"
+    case recurring = "recurring"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .manual:    return "Manual"
+        case .text:      return "Text"
+        case .voice:     return "Voice"
+        case .photo:     return "Photo"
+        case .receipt:   return "Receipt"
+        case .pdf:       return "PDF"
+        case .recurring: return "Recurring"
+        }
+    }
+
+    var sfSymbol: String {
+        switch self {
+        case .manual:    return "pencil"
+        case .text:      return "text.bubble"
+        case .voice:     return "mic"
+        case .photo:     return "photo"
+        case .receipt:   return "doc.text.viewfinder"
+        case .pdf:       return "doc.text"
+        case .recurring: return "arrow.triangle.2.circlepath"
+        }
+    }
+}
+
+/// ISO 4217 currencies the user can pick from in the AddExpense sheet and
+/// that FXService knows how to fetch rates for. Order: SGD first (home
+/// currency), then the most likely travel destinations.
+enum SupportedCurrency {
+    static let all: [String] = [
+        "SGD", "USD", "EUR", "GBP", "AUD", "JPY",
+        "MYR", "INR", "CNY", "HKD", "THB", "IDR",
+        "PHP", "KRW"
+    ]
+}

--- a/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
@@ -1,0 +1,109 @@
+import Foundation
+import SwiftData
+
+/// Local-first SwiftData model for an expense (Finance v1 — issue #114).
+///
+/// Money is stored twice. `originalAmount + originalCurrency` is what the
+/// user actually paid; `sgdAmount + fxRate` is the frozen home-currency
+/// conversion captured at the moment of entry so monthly totals don't
+/// retroactively drift when FX rates move. Same `clientUUID` convention as
+/// the other local models, but stored as `String` because the AI tool
+/// surface emits and consumes UUIDs as strings.
+@Model
+final class LocalExpense {
+    /// Stable identity. Generated locally on creation. Unique within the store.
+    @Attribute(.unique) var clientUUID: String
+
+    /// User-visible spend date (the day the expense happened, not when it
+    /// was logged). Normalised to `startOfDay` so daily groupings group
+    /// cleanly across timezones.
+    var date: Date
+
+    /// `ExpenseCategory.rawValue`. Stored raw so adding a new category in
+    /// the enum doesn't require a SwiftData migration.
+    var category: String
+
+    /// Merchant / vendor (e.g. "Starbucks"). Optional.
+    var merchant: String?
+
+    /// Free-form description. Named `expenseDescription` (not `description`)
+    /// to avoid clashing with `CustomStringConvertible.description`.
+    var expenseDescription: String?
+
+    /// Amount in the original currency (what the user actually paid).
+    var originalAmount: Double
+
+    /// ISO 4217 code of the original currency (e.g. "SGD", "USD").
+    var originalCurrency: String
+
+    /// Converted SGD amount at capture time. Frozen — never recomputed.
+    /// `sgdAmount == originalAmount * fxRate`.
+    var sgdAmount: Double
+
+    /// FX rate used at capture time. SGD passthrough is `1.0`.
+    var fxRate: Double
+
+    /// Payment method label (e.g. "Visa **1234", "Cash"). Optional.
+    var paymentMethod: String?
+
+    /// Relative path inside `Documents/receipts/<uuid>.jpg`. Phase B will
+    /// write the image; Phase A always leaves this nil.
+    var receiptImagePath: String?
+
+    /// `ExpenseSource.rawValue`. Drives source-filter chips and analytics.
+    var source: String
+
+    var createdAt: Date
+
+    // MARK: - Dead-field parity with other LocalModels
+    //
+    // These are intentionally unused on Phase A. Kept so that the SwiftData
+    // schema lines up with the other local models and any future sync /
+    // migration story doesn't need a destructive change. Don't remove.
+    var needsSync: Bool
+    var version: Int
+
+    init(
+        clientUUID: String = UUID().uuidString.lowercased(),
+        date: Date = Date(),
+        category: String,
+        merchant: String? = nil,
+        expenseDescription: String? = nil,
+        originalAmount: Double,
+        originalCurrency: String,
+        sgdAmount: Double,
+        fxRate: Double,
+        paymentMethod: String? = nil,
+        receiptImagePath: String? = nil,
+        source: String,
+        createdAt: Date = Date(),
+        needsSync: Bool = false,
+        version: Int = 0
+    ) {
+        self.clientUUID = clientUUID
+        self.date = date
+        self.category = category
+        self.merchant = merchant
+        self.expenseDescription = expenseDescription
+        self.originalAmount = originalAmount
+        self.originalCurrency = originalCurrency
+        self.sgdAmount = sgdAmount
+        self.fxRate = fxRate
+        self.paymentMethod = paymentMethod
+        self.receiptImagePath = receiptImagePath
+        self.source = source
+        self.createdAt = createdAt
+        self.needsSync = needsSync
+        self.version = version
+    }
+
+    // MARK: - Convenience
+
+    var categoryEnum: ExpenseCategory {
+        ExpenseCategory(rawValue: category) ?? .other
+    }
+
+    var sourceEnum: ExpenseSource {
+        ExpenseSource(rawValue: source) ?? .manual
+    }
+}

--- a/mobile/PersonalDashboard/Models/Local/LocalFXRate.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalFXRate.swift
@@ -1,0 +1,31 @@
+import Foundation
+import SwiftData
+
+/// Cached foreign-exchange rate keyed by currency code (Finance v1).
+///
+/// One row per currency. `FXService` upserts on every fetch and reads the
+/// most recent row before going out to the network — once-per-day per
+/// currency. Stored separately from `LocalExpense` so dashboard totals
+/// don't have to recompute conversions on every aggregation.
+@Model
+final class LocalFXRate {
+    /// ISO 4217 code (e.g. "USD", "EUR"). Acts as the lookup key.
+    @Attribute(.unique) var currencyCode: String
+
+    /// How many SGD = 1 unit of `currencyCode`. SGD itself is `1.0`.
+    var rateToSGD: Double
+
+    /// Wall-clock moment we fetched (or last verified) this rate. FXService
+    /// considers anything within the same day "fresh" and skips network.
+    var fetchedOn: Date
+
+    init(
+        currencyCode: String,
+        rateToSGD: Double,
+        fetchedOn: Date = Date()
+    ) {
+        self.currencyCode = currencyCode
+        self.rateToSGD = rateToSGD
+        self.fetchedOn = fetchedOn
+    }
+}

--- a/mobile/PersonalDashboard/Services/ExpenseService.swift
+++ b/mobile/PersonalDashboard/Services/ExpenseService.swift
@@ -1,0 +1,286 @@
+import Foundation
+import SwiftData
+
+/// Errors thrown by `ExpenseService`. The few error paths only surface
+/// programming bugs (zero amount, invalid category) — UI rarely needs to
+/// branch on them.
+enum ExpenseServiceError: LocalizedError {
+    case invalidAmount
+    case persistence(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAmount:        return "Amount must be greater than zero."
+        case .persistence(let err): return err.localizedDescription
+        }
+    }
+}
+
+/// Filter criteria applied by `ExpenseService.expenses(filter:)`. All
+/// fields are optional — nil means "no constraint on this dimension".
+/// Backs both the Finance list and the future analytics surface.
+struct ExpenseFilter: Equatable {
+    var dateRange: ClosedRange<Date>?
+    var categories: Set<ExpenseCategory>?
+    var sources: Set<ExpenseSource>?
+    var searchText: String?
+
+    static let none = ExpenseFilter()
+}
+
+/// Date-window helper used by both the service and view-layer filters.
+/// Hoisted out of `ExpenseService` so the view can call it from a
+/// synchronous, non-isolated context (the service itself is `@MainActor`
+/// because it touches the shared SwiftData store).
+enum ExpenseDateRanges {
+    /// Returns (startOfMonth, end-of-last-day-of-that-month) for any
+    /// reference date.
+    static func monthBounds(for reference: Date) -> (Date, Date) {
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.year, .month], from: reference)
+        let start = cal.date(from: comps) ?? reference
+        let nextMonth = cal.date(byAdding: .month, value: 1, to: start) ?? reference
+        let end = nextMonth.addingTimeInterval(-1)
+        return (start, end)
+    }
+}
+
+/// CRUD + analytics over `LocalExpense`. Operates on the shared SwiftData
+/// context. All math is in SGD (the frozen `sgdAmount` field on each row)
+/// so totals don't drift with FX changes.
+@MainActor
+struct ExpenseService {
+    let store: SwiftDataStore
+
+    init(store: SwiftDataStore) {
+        self.store = store
+    }
+
+    static func `default`() -> ExpenseService {
+        ExpenseService(store: .shared)
+    }
+
+    // MARK: - CRUD
+
+    /// Insert a new expense. Caller is responsible for computing `sgdAmount`
+    /// + `fxRate` via `FXService.convert` before invoking this.
+    @discardableResult
+    func addExpense(
+        date: Date,
+        category: ExpenseCategory,
+        merchant: String?,
+        expenseDescription: String?,
+        originalAmount: Double,
+        originalCurrency: String,
+        sgdAmount: Double,
+        fxRate: Double,
+        paymentMethod: String?,
+        source: ExpenseSource,
+        clientUUID: String? = nil
+    ) throws -> LocalExpense {
+        guard originalAmount > 0 else { throw ExpenseServiceError.invalidAmount }
+
+        let row = LocalExpense(
+            clientUUID: clientUUID ?? UUID().uuidString.lowercased(),
+            date: Calendar.current.startOfDay(for: date),
+            category: category.rawValue,
+            merchant: merchant?.trimmedNonEmpty,
+            expenseDescription: expenseDescription?.trimmedNonEmpty,
+            originalAmount: originalAmount,
+            originalCurrency: originalCurrency.uppercased(),
+            sgdAmount: sgdAmount,
+            fxRate: fxRate,
+            paymentMethod: paymentMethod?.trimmedNonEmpty,
+            receiptImagePath: nil,
+            source: source.rawValue,
+            createdAt: Date()
+        )
+        store.context.insert(row)
+        try save()
+        return row
+    }
+
+    /// Update an existing expense in place. All fields are nullable — pass
+    /// `nil` to leave the corresponding field untouched (note: passing nil
+    /// for `merchant` / `expenseDescription` / `paymentMethod` does NOT
+    /// clear them; the AddExpense sheet always passes the current value so
+    /// there's no clearing semantic to worry about in Phase A).
+    func updateExpense(
+        _ expense: LocalExpense,
+        date: Date? = nil,
+        category: ExpenseCategory? = nil,
+        merchant: String? = nil,
+        expenseDescription: String? = nil,
+        originalAmount: Double? = nil,
+        originalCurrency: String? = nil,
+        sgdAmount: Double? = nil,
+        fxRate: Double? = nil,
+        paymentMethod: String? = nil
+    ) throws {
+        if let date {
+            expense.date = Calendar.current.startOfDay(for: date)
+        }
+        if let category {
+            expense.category = category.rawValue
+        }
+        if let merchant {
+            expense.merchant = merchant.trimmedNonEmpty
+        }
+        if let expenseDescription {
+            expense.expenseDescription = expenseDescription.trimmedNonEmpty
+        }
+        if let originalAmount {
+            guard originalAmount > 0 else { throw ExpenseServiceError.invalidAmount }
+            expense.originalAmount = originalAmount
+        }
+        if let originalCurrency {
+            expense.originalCurrency = originalCurrency.uppercased()
+        }
+        if let sgdAmount {
+            expense.sgdAmount = sgdAmount
+        }
+        if let fxRate {
+            expense.fxRate = fxRate
+        }
+        if let paymentMethod {
+            expense.paymentMethod = paymentMethod.trimmedNonEmpty
+        }
+        try save()
+    }
+
+    func deleteExpense(_ expense: LocalExpense) throws {
+        store.context.delete(expense)
+        try save()
+    }
+
+    // MARK: - Analytics
+
+    /// Total SGD spent this calendar month (start-of-month → now).
+    func monthTotal(_ reference: Date = .now) throws -> Double {
+        let (start, end) = ExpenseDateRanges.monthBounds(for: reference)
+        return try sum(in: start...end)
+    }
+
+    /// Total SGD spent in the previous calendar month. Used for the
+    /// dashboard's delta chip.
+    func previousMonthTotal(_ reference: Date = .now) throws -> Double {
+        let cal = Calendar.current
+        let prev = cal.date(byAdding: .month, value: -1, to: reference) ?? reference
+        let (start, end) = ExpenseDateRanges.monthBounds(for: prev)
+        return try sum(in: start...end)
+    }
+
+    /// Top N categories this month by SGD spent. Empty array if no expenses.
+    func topCategoriesThisMonth(limit: Int = 3) throws -> [(category: ExpenseCategory, total: Double)] {
+        let (start, end) = ExpenseDateRanges.monthBounds(for: .now)
+        let rows = try fetch(in: start...end)
+        var sums: [String: Double] = [:]
+        for row in rows {
+            sums[row.category, default: 0] += row.sgdAmount
+        }
+        return sums
+            .sorted { $0.value > $1.value }
+            .prefix(limit)
+            .map { (ExpenseCategory(rawValue: $0.key) ?? .other, $0.value) }
+    }
+
+    /// Daily totals for the last 30 calendar days (inclusive). Days with no
+    /// spend are present with `0.0` so the sparkline draws a flat segment
+    /// instead of skipping points.
+    func dailyTotalsLast30Days(reference: Date = .now) throws -> [(date: Date, total: Double)] {
+        let cal = Calendar.current
+        let end = cal.startOfDay(for: reference)
+        guard let start = cal.date(byAdding: .day, value: -29, to: end) else { return [] }
+        let endOfDay = cal.date(byAdding: .day, value: 1, to: end)!.addingTimeInterval(-1)
+        let rows = try fetch(in: start...endOfDay)
+
+        var byDay: [Date: Double] = [:]
+        for row in rows {
+            let day = cal.startOfDay(for: row.date)
+            byDay[day, default: 0] += row.sgdAmount
+        }
+        var out: [(date: Date, total: Double)] = []
+        for offset in 0..<30 {
+            if let day = cal.date(byAdding: .day, value: offset, to: start) {
+                out.append((day, byDay[day] ?? 0))
+            }
+        }
+        return out
+    }
+
+    /// Filtered list of expenses, sorted by `date` descending then
+    /// `createdAt` descending so same-day rows show insertion order with
+    /// newest at the top.
+    func expenses(filter: ExpenseFilter = .none) throws -> [LocalExpense] {
+        let descriptor = FetchDescriptor<LocalExpense>(
+            sortBy: [
+                SortDescriptor(\.date, order: .reverse),
+                SortDescriptor(\.createdAt, order: .reverse)
+            ]
+        )
+        let all = try store.context.fetch(descriptor)
+        return all.filter { Self.matches($0, filter: filter) }
+    }
+
+    // MARK: - Helpers
+
+    private func sum(in range: ClosedRange<Date>) throws -> Double {
+        try fetch(in: range).reduce(0) { $0 + $1.sgdAmount }
+    }
+
+    private func fetch(in range: ClosedRange<Date>) throws -> [LocalExpense] {
+        let lo = range.lowerBound
+        let hi = range.upperBound
+        let descriptor = FetchDescriptor<LocalExpense>(
+            predicate: #Predicate { $0.date >= lo && $0.date <= hi }
+        )
+        return try store.context.fetch(descriptor)
+    }
+
+    private static func matches(_ expense: LocalExpense, filter: ExpenseFilter) -> Bool {
+        if let range = filter.dateRange {
+            if !range.contains(expense.date) { return false }
+        }
+        if let categories = filter.categories, !categories.isEmpty {
+            guard let category = ExpenseCategory(rawValue: expense.category) else { return false }
+            if !categories.contains(category) { return false }
+        }
+        if let sources = filter.sources, !sources.isEmpty {
+            guard let source = ExpenseSource(rawValue: expense.source) else { return false }
+            if !sources.contains(source) { return false }
+        }
+        if let search = filter.searchText?.trimmedNonEmpty?.lowercased(), !search.isEmpty {
+            let merchant = expense.merchant?.lowercased() ?? ""
+            let description = expense.expenseDescription?.lowercased() ?? ""
+            if !merchant.contains(search) && !description.contains(search) {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Returns (startOfMonth, endOfMonth-end-of-last-day) for any reference date.
+    /// Shim delegates to the non-isolated `ExpenseDateRanges.monthBounds` so
+    /// existing callers don't have to change but views can call from a sync
+    /// non-isolated context.
+    static func monthBounds(for reference: Date) -> (Date, Date) {
+        ExpenseDateRanges.monthBounds(for: reference)
+    }
+
+    private func save() throws {
+        do {
+            try store.context.save()
+        } catch {
+            throw ExpenseServiceError.persistence(error)
+        }
+    }
+}
+
+private extension String {
+    /// Trim whitespace, return nil for empty. Saves a sprinkling of inline
+    /// trims on every save path.
+    var trimmedNonEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/mobile/PersonalDashboard/Services/FXService.swift
+++ b/mobile/PersonalDashboard/Services/FXService.swift
@@ -1,0 +1,164 @@
+import Foundation
+import SwiftData
+
+/// Errors thrown by `FXService` when it can't supply a rate. Surfaced into
+/// the AddExpense sheet so the user sees a real "couldn't convert" hint
+/// instead of a silent zero.
+enum FXServiceError: LocalizedError {
+    /// Network failed and we have no cached rate to fall back to.
+    case noRateAvailable(currency: String)
+    /// API returned a 2xx but with no `rates[CCY]` field.
+    case missingRateInResponse(currency: String)
+    /// Anything else (HTTP error, decode failure, etc).
+    case underlying(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .noRateAvailable(let c):
+            return "No FX rate available for \(c) and the network is unreachable."
+        case .missingRateInResponse(let c):
+            return "Rate for \(c) wasn't in the FX response."
+        case .underlying(let err):
+            return err.localizedDescription
+        }
+    }
+}
+
+/// Foreign-exchange service backing the AddExpense sheet and the AI's
+/// `add_expense` tool. Fetches rates once per day from the
+/// `@fawazahmed0/currency-api` JSON feed (free, no key, jsdelivr CDN-cached,
+/// updated daily) and caches in `LocalFXRate`.
+///
+/// Provider history: we used `exchangerate.host` originally, but the service
+/// switched to a paid/keyed model in 2024 and now returns 200 + "missing
+/// access key" for any keyless call. Fawazahmed's project is GitHub-hosted
+/// JSON updated daily by a workflow and served via jsdelivr, so there's no
+/// API key, no rate limit, and broad currency coverage (including VND, IDR,
+/// THB which some other free APIs drop).
+///
+/// Design choices:
+/// - SGD is the home currency. Rates are stored as "1 unit of foreign = N SGD"
+///   so conversion is a single multiply (`sgdAmount = amount * rateToSGD`).
+/// - Cache freshness is "same calendar day in user's timezone" — once a day
+///   is more than enough for personal expense tracking.
+/// - Offline + no cache = throw `noRateAvailable`. Offline + stale cache =
+///   return the stale value silently (it's still better than nothing for
+///   a personal app).
+@MainActor
+struct FXService {
+    let store: SwiftDataStore
+
+    init(store: SwiftDataStore) {
+        self.store = store
+    }
+
+    static func `default`() -> FXService {
+        FXService(store: .shared)
+    }
+
+    /// Get the rate "1 unit of `currencyCode` = N SGD". Cached for one day
+    /// per currency. SGD itself short-circuits to 1.0.
+    func rate(for currencyCode: String) async throws -> Double {
+        let code = currencyCode.uppercased()
+        if code == "SGD" { return 1.0 }
+
+        // Cache hit: same calendar day.
+        if let cached = try fetchCached(code: code), isSameDay(cached.fetchedOn, Date()) {
+            return cached.rateToSGD
+        }
+
+        // Cache miss or stale: try to refresh from the network.
+        do {
+            let fresh = try await fetchRemote(code: code)
+            try upsert(code: code, rateToSGD: fresh)
+            return fresh
+        } catch {
+            // Network failed. If we have ANY cached value (even stale), use
+            // it — better stale than nothing. If we have nothing, throw.
+            if let cached = try fetchCached(code: code) {
+                return cached.rateToSGD
+            }
+            if let fxError = error as? FXServiceError {
+                throw fxError
+            }
+            throw FXServiceError.noRateAvailable(currency: code)
+        }
+    }
+
+    /// Convert `amount` from `currencyCode` to SGD. Returns both the SGD
+    /// amount and the rate used (so the caller can freeze it on
+    /// `LocalExpense.fxRate`).
+    func convert(_ amount: Double, from currencyCode: String) async throws -> (sgdAmount: Double, rate: Double) {
+        let rate = try await rate(for: currencyCode)
+        return (amount * rate, rate)
+    }
+
+    // MARK: - Cache I/O
+
+    private func fetchCached(code: String) throws -> LocalFXRate? {
+        let descriptor = FetchDescriptor<LocalFXRate>(
+            predicate: #Predicate { $0.currencyCode == code }
+        )
+        return try store.context.fetch(descriptor).first
+    }
+
+    private func upsert(code: String, rateToSGD: Double) throws {
+        if let existing = try fetchCached(code: code) {
+            existing.rateToSGD = rateToSGD
+            existing.fetchedOn = Date()
+        } else {
+            store.context.insert(LocalFXRate(currencyCode: code, rateToSGD: rateToSGD))
+        }
+        try store.context.save()
+    }
+
+    private func isSameDay(_ a: Date, _ b: Date) -> Bool {
+        Calendar.current.isDate(a, inSameDayAs: b)
+    }
+
+    // MARK: - Network
+
+    /// Fetch the SGD → all-currencies rate sheet from the fawazahmed API.
+    /// The JSON shape is `{ "date": "...", "sgd": { "vnd": 20604.88, ... } }`
+    /// where each value is "1 SGD = N foreign", so we invert to get
+    /// "1 foreign = M SGD".
+    ///
+    /// We fetch the whole sheet (one HTTP request gets every currency) and
+    /// pluck the one we need. Cheaper than per-currency requests and lets
+    /// future calls hit the SwiftData cache for any currency we've ever
+    /// looked up.
+    private func fetchRemote(code: String) async throws -> Double {
+        let urlString = "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/sgd.json"
+        guard let url = URL(string: urlString) else {
+            throw FXServiceError.noRateAvailable(currency: code)
+        }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                throw FXServiceError.noRateAvailable(currency: code)
+            }
+            let decoded = try JSONDecoder().decode(FawazahmedCurrencyResponse.self, from: data)
+            let lowerCode = code.lowercased()
+            guard let foreignPerSGD = decoded.sgd[lowerCode], foreignPerSGD > 0 else {
+                throw FXServiceError.missingRateInResponse(currency: code)
+            }
+            // The API stores rates as "1 SGD = N foreign". We need the
+            // inverse: "1 foreign = M SGD" so `sgdAmount = amount * rateToSGD`.
+            return 1.0 / foreignPerSGD
+        } catch let fxError as FXServiceError {
+            throw fxError
+        } catch {
+            throw FXServiceError.underlying(error)
+        }
+    }
+}
+
+/// Subset of the `@fawazahmed0/currency-api` response. The top-level key
+/// matches the base currency (lowercased) — for our base-SGD fetch it's `sgd`,
+/// containing a dictionary of `lowercased-iso-code -> foreignPerSGD`.
+private struct FawazahmedCurrencyResponse: Decodable {
+    let sgd: [String: Double]
+}

--- a/mobile/PersonalDashboard/Services/ReceiptStorage.swift
+++ b/mobile/PersonalDashboard/Services/ReceiptStorage.swift
@@ -1,0 +1,196 @@
+import Foundation
+import UIKit
+
+/// Errors thrown by ReceiptStorage. Surface to the user when a save / delete
+/// can't complete (rare: disk full, sandbox sealed, etc.).
+enum ReceiptStorageError: LocalizedError {
+    case imageEncodingFailed
+    case fileSystem(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .imageEncodingFailed:  return "Couldn't encode the receipt image."
+        case .fileSystem(let err):  return err.localizedDescription
+        }
+    }
+}
+
+/// File-system store for receipt assets. Writes go into
+/// `Documents/receipts/<uuid>.<ext>` and only the relative path
+/// (`"receipts/<uuid>.<ext>"`) is persisted onto `LocalExpense.receiptImagePath`.
+///
+/// Why relative: the absolute container path changes on every app reinstall
+/// and across simulator runs, so the stored path would break unless we
+/// re-resolve against the Documents directory at read time. The trade-off
+/// is one `appendingPathComponent` per read; cheap.
+///
+/// All captured images are normalised to a single compressed JPEG that is
+/// safe for both on-disk storage and Anthropic Vision. The compressed bytes
+/// are returned by `compress(imageData:)` so callers can hand the same blob
+/// to Vision and to the disk save — avoids the bug where the disk got a
+/// compressed copy but Vision got the original raw HEIC (which blew past
+/// Anthropic's 5 MB base64 limit).
+@MainActor
+final class ReceiptStorage {
+    static let shared = ReceiptStorage()
+
+    private let fileManager: FileManager
+    private let directoryName = "receipts"
+    private let jpegQuality: CGFloat = 0.75
+    /// Longest-edge cap applied to every captured image. 1600 px is more than
+    /// enough resolution for receipt OCR via Anthropic Vision and keeps the
+    /// base64 payload well under Anthropic's 5 MB-per-image limit (which is
+    /// measured on the base64 string, not the raw bytes — ~33% inflation).
+    private let targetMaxEdge: CGFloat = 1600
+    /// Hard ceiling on raw JPEG bytes after compression. Stays under
+    /// Anthropic's 5 MB base64 cap with margin (5 MB / 1.34 ≈ 3.73 MB raw).
+    private let targetMaxBytes: Int = 3_500_000
+    /// JPEG quality used when the first pass still exceeds `targetMaxBytes`.
+    /// Receipts stay legible at this level.
+    private let fallbackJpegQuality: CGFloat = 0.5
+
+    private init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    // MARK: - Public API
+
+    /// Compress raw image data (HEIC, PNG, oversized JPEG, whatever) into a
+    /// JPEG that's safe to send to Anthropic Vision. ALWAYS downsizes to
+    /// `targetMaxEdge` first — captured camera photos are way overkill for
+    /// receipt OCR and the original byte-count routinely exceeds the API
+    /// cap. Use the returned data for BOTH the Vision call AND the disk save.
+    func compress(imageData: Data) throws -> Data {
+        guard let image = UIImage(data: imageData) else {
+            throw ReceiptStorageError.imageEncodingFailed
+        }
+        let resized = image.downsized(longestEdge: targetMaxEdge) ?? image
+        guard let firstPass = resized.jpegData(compressionQuality: jpegQuality) else {
+            throw ReceiptStorageError.imageEncodingFailed
+        }
+        if firstPass.count <= targetMaxBytes {
+            return firstPass
+        }
+        if let secondPass = resized.jpegData(compressionQuality: fallbackJpegQuality),
+           secondPass.count <= targetMaxBytes {
+            return secondPass
+        }
+        // Last resort: more aggressive downsize and quality drop combined.
+        if let further = resized.downsized(longestEdge: 1024),
+           let thirdPass = further.jpegData(compressionQuality: fallbackJpegQuality) {
+            return thirdPass
+        }
+        return firstPass
+    }
+
+    /// Persist a pre-compressed JPEG (typically the output of `compress(imageData:)`).
+    /// Returned path is relative.
+    func saveCompressedJpeg(_ data: Data) throws -> String {
+        try persist(data: data, ext: "jpg")
+    }
+
+    /// Legacy convenience: compress + save in one shot. Kept for callers that
+    /// don't need the compressed bytes (e.g. failure paths that just need
+    /// the receipt on disk and don't call Vision).
+    func save(imageData: Data, fileExtension: String) throws -> String {
+        _ = fileExtension // Kept for API parity; output is always .jpg.
+        let compressed = try compress(imageData: imageData)
+        return try persist(data: compressed, ext: "jpg")
+    }
+
+    /// Save raw PDF data unchanged. Returned path is relative.
+    func save(pdfData: Data) throws -> String {
+        try persist(data: pdfData, ext: "pdf")
+    }
+
+    /// Resolve a stored relative path back to an on-disk URL. Returns nil if
+    /// the file no longer exists (e.g. user reinstalled the app).
+    func load(relativePath: String) -> URL? {
+        guard !relativePath.isEmpty,
+              let url = try? absoluteURL(for: relativePath),
+              fileManager.fileExists(atPath: url.path) else {
+            return nil
+        }
+        return url
+    }
+
+    /// Delete the file at `relativePath`. Silent no-op if the file is
+    /// already gone — callers don't need to special-case missing receipts.
+    func delete(relativePath: String) throws {
+        guard !relativePath.isEmpty else { return }
+        let url = try absoluteURL(for: relativePath)
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        do {
+            try fileManager.removeItem(at: url)
+        } catch {
+            throw ReceiptStorageError.fileSystem(error)
+        }
+    }
+
+    // MARK: - Internals
+
+    private func persist(data: Data, ext: String) throws -> String {
+        let dir = try ensureDirectory()
+        let filename = "\(UUID().uuidString.lowercased()).\(ext)"
+        let url = dir.appendingPathComponent(filename)
+        do {
+            try data.write(to: url, options: [.atomic])
+        } catch {
+            throw ReceiptStorageError.fileSystem(error)
+        }
+        return "\(directoryName)/\(filename)"
+    }
+
+    private func ensureDirectory() throws -> URL {
+        let docs = try documentsDirectory()
+        let dir = docs.appendingPathComponent(directoryName, isDirectory: true)
+        if !fileManager.fileExists(atPath: dir.path) {
+            do {
+                try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+            } catch {
+                throw ReceiptStorageError.fileSystem(error)
+            }
+        }
+        return dir
+    }
+
+    private func documentsDirectory() throws -> URL {
+        do {
+            return try fileManager.url(
+                for: .documentDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        } catch {
+            throw ReceiptStorageError.fileSystem(error)
+        }
+    }
+
+    private func absoluteURL(for relativePath: String) throws -> URL {
+        let docs = try documentsDirectory()
+        return docs.appendingPathComponent(relativePath)
+    }
+}
+
+// MARK: - UIImage downsize helper
+
+private extension UIImage {
+    /// Resize so the longest edge is at most `longestEdge` points, preserving
+    /// aspect ratio. Returns nil if the source is degenerate.
+    func downsized(longestEdge: CGFloat) -> UIImage? {
+        let width = size.width
+        let height = size.height
+        let maxSide = max(width, height)
+        guard maxSide > longestEdge, maxSide > 0 else { return self }
+
+        let scale = longestEdge / maxSide
+        let newSize = CGSize(width: floor(width * scale), height: floor(height * scale))
+        guard newSize.width > 0, newSize.height > 0 else { return nil }
+
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in
+            draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Views/Chat/ChatResultCard.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatResultCard.swift
@@ -122,6 +122,8 @@ struct ChatResultCard: View {
             return "trip"
         case .updateItineraryItem, .deleteItineraryItem:
             return "item"
+        case .addExpense:
+            return "expense"
         case .unknown:
             return "action"
         }

--- a/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
+++ b/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
@@ -1,0 +1,629 @@
+import SwiftUI
+import SwiftData
+
+/// Editor target for the AddExpense / EditExpense sheet.
+///
+/// - `.new`: blank form, source defaults to `.manual`.
+/// - `.existing(uuid)`: load by clientUUID, preserve receipt + source.
+/// - `.prefilled(PrefilledExpense)`: seed fields from a scan/photo/PDF
+///   capture (receipt already saved to disk; Vision may have failed).
+enum ExpenseEditorTarget: Identifiable, Hashable {
+    case new
+    case existing(String)
+    case prefilled(PrefilledExpense)
+
+    var id: String {
+        switch self {
+        case .new:                return "new"
+        case .existing(let uuid): return "existing:\(uuid)"
+        case .prefilled(let p):   return "prefilled:\(p.receiptImagePath)"
+        }
+    }
+}
+
+/// AddExpense / EditExpense form. One sheet handles create, edit, and
+/// "create-from-scanned-receipt" keyed off `target`. FX conversion runs
+/// on save (cached so it doesn't block on the home currency).
+struct AddExpenseSheet: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    let target: ExpenseEditorTarget
+
+    @State private var amountText: String = ""
+    @State private var currency: String = "SGD"
+    @State private var category: ExpenseCategory = .other
+    @State private var date: Date = Date()
+    @State private var merchant: String = ""
+    @State private var descriptionField: String = ""
+    @State private var paymentMethod: String = ""
+
+    /// Where this expense will be tagged as having come from. Defaults to
+    /// `.manual` for `.new`; carried over from the existing row on edit;
+    /// set by `PrefilledExpense.source` on prefill.
+    @State private var source: ExpenseSource = .manual
+
+    /// Relative path under `Documents/`. Non-nil if a receipt is attached.
+    @State private var receiptImagePath: String?
+
+    /// Banner state when the user came in from a failed extraction.
+    @State private var extractionBanner: String?
+
+    /// Self-reported confidence from the model. Shown as a subtle hint when
+    /// `.low` so the user double-checks the amount.
+    @State private var extractionConfidence: ExtractedExpense.Confidence?
+
+    /// Full-size receipt viewer flag.
+    @State private var showingReceiptViewer: Bool = false
+
+    @State private var loaded: Bool = false
+    @State private var saving: Bool = false
+    @State private var errorMessage: String?
+
+    @FocusState private var amountFocused: Bool
+
+    private var isEditing: Bool {
+        if case .existing = target { return true }
+        return false
+    }
+
+    private var amountValue: Double {
+        Double(amountText.replacingOccurrences(of: ",", with: ".")) ?? 0
+    }
+
+    private var canSave: Bool {
+        amountValue > 0 && !saving
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Space.lg) {
+                        if let extractionBanner {
+                            banner(extractionBanner)
+                        }
+                        if receiptImagePath != nil {
+                            receiptThumbnail
+                        }
+                        amountField
+                        if extractionConfidence == .low {
+                            confidenceHint
+                        }
+                        categoryField
+                        dateField
+                        merchantField
+                        descriptionFieldView
+                        paymentField
+
+                        if let errorMessage {
+                            Text(errorMessage)
+                                .font(.edFootnote)
+                                .foregroundStyle(Tokens.danger)
+                                .padding(.top, Space.sm)
+                        }
+                    }
+                    .padding(Space.lg)
+                }
+            }
+            .navigationTitle(navigationTitleText)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Tokens.muted)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isEditing ? "Save" : "Add") {
+                        Task { await save() }
+                    }
+                    .disabled(!canSave)
+                    .foregroundStyle(canSave ? Tokens.ink : Tokens.muted)
+                }
+            }
+        }
+        .sheet(isPresented: $showingReceiptViewer) {
+            if let path = receiptImagePath {
+                ReceiptFullViewer(relativePath: path)
+            }
+        }
+        .onAppear { loadIfNeeded() }
+    }
+
+    private var navigationTitleText: String {
+        switch target {
+        case .new:                return "New expense"
+        case .existing:           return "Edit expense"
+        case .prefilled:          return "Review expense"
+        }
+    }
+
+    // MARK: - Banner + confidence hint
+
+    private func banner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: Space.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 13, weight: .regular))
+                .foregroundStyle(Tokens.warning)
+                .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("We saved your receipt")
+                    .font(.edBodyMedium)
+                    .foregroundStyle(Tokens.ink)
+                Text(message)
+                    .font(.edFootnote)
+                    .foregroundStyle(Tokens.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(Space.md)
+        .background(Tokens.warningSoft, in: RoundedRectangle(cornerRadius: Radius.md))
+        .paperBorder(Tokens.warning.opacity(0.35), radius: Radius.md)
+    }
+
+    private var confidenceHint: some View {
+        HStack(spacing: Space.xs) {
+            Image(systemName: "info.circle")
+                .font(.system(size: 11, weight: .regular))
+                .foregroundStyle(Tokens.muted)
+            Text("Low confidence on the total — double-check the amount.")
+                .font(.edCaption)
+                .foregroundStyle(Tokens.muted)
+        }
+        .padding(.horizontal, Space.xs)
+    }
+
+    // MARK: - Receipt thumbnail
+
+    private var receiptThumbnail: some View {
+        HStack(spacing: Space.md) {
+            ReceiptThumbnailImage(relativePath: receiptImagePath)
+                .frame(width: 64, height: 64)
+                .clipShape(RoundedRectangle(cornerRadius: Radius.sm, style: .continuous))
+                .onTapGesture { showingReceiptViewer = true }
+                .accessibilityLabel("View full receipt")
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Receipt attached")
+                    .font(.edBodyMedium)
+                    .foregroundStyle(Tokens.ink)
+                Text("Tap to view")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.muted)
+            }
+            Spacer()
+            Button {
+                removeReceipt()
+            } label: {
+                Image(systemName: "trash")
+                    .font(.system(size: 14, weight: .regular))
+                    .foregroundStyle(Tokens.danger)
+                    .padding(8)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove receipt")
+        }
+        .padding(Space.md)
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+        .paperBorder(Tokens.border, radius: Radius.md)
+    }
+
+    private func removeReceipt() {
+        guard let path = receiptImagePath else { return }
+        try? ReceiptStorage.shared.delete(relativePath: path)
+        receiptImagePath = nil
+        // If we still have the prefilled banner up, hide it — the user has
+        // chosen to start over without the receipt context.
+        extractionBanner = nil
+    }
+
+    // MARK: - Fields
+
+    private var amountField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Amount").eyebrow()
+            HStack(spacing: Space.sm) {
+                TextField("0.00", text: $amountText)
+                    .keyboardType(.decimalPad)
+                    .font(.edDisplay)
+                    .foregroundStyle(Tokens.ink)
+                    .focused($amountFocused)
+                    .padding(.vertical, Space.sm)
+                    .padding(.horizontal, Space.md)
+                    .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                    .paperBorder(Tokens.border, radius: Radius.md)
+
+                Menu {
+                    ForEach(SupportedCurrency.all, id: \.self) { code in
+                        Button(code) { currency = code }
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(currency)
+                            .font(.edBodyMedium)
+                            .foregroundStyle(Tokens.ink)
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(Tokens.muted)
+                    }
+                    .padding(.horizontal, Space.md)
+                    .frame(height: 52)
+                    .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                    .paperBorder(Tokens.border, radius: Radius.md)
+                }
+                .accessibilityLabel("Currency")
+            }
+        }
+    }
+
+    private var categoryField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Category").eyebrow()
+            Menu {
+                ForEach(ExpenseCategory.allCases) { cat in
+                    Button {
+                        category = cat
+                    } label: {
+                        Label(cat.displayName, systemImage: cat.sfSymbol)
+                    }
+                }
+            } label: {
+                HStack(spacing: Space.sm) {
+                    Image(systemName: category.sfSymbol)
+                        .font(.system(size: 14, weight: .regular))
+                        .foregroundStyle(Tokens.accentFinance)
+                        .frame(width: 24)
+                    Text(category.displayName)
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.ink)
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Tokens.muted)
+                }
+                .padding(Space.md)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                .paperBorder(Tokens.border, radius: Radius.md)
+            }
+            .accessibilityLabel("Category")
+        }
+    }
+
+    private var dateField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Date").eyebrow()
+            HStack {
+                Text("When did this happen?")
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.inkSoft)
+                Spacer()
+                DatePicker("", selection: $date, in: ...Date(), displayedComponents: .date)
+                    .labelsHidden()
+                    .tint(Tokens.accentFinance)
+            }
+            .padding(Space.md)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    private var merchantField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            HStack {
+                Text("Merchant").eyebrow()
+                Spacer()
+                Text("Optional")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            TextField("e.g. Starbucks", text: $merchant)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .padding(Space.md)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    private var descriptionFieldView: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            HStack {
+                Text("Description").eyebrow()
+                Spacer()
+                Text("Optional")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            TextField("Lunch with Sarah", text: $descriptionField)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .padding(Space.md)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    private var paymentField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            HStack {
+                Text("Payment method").eyebrow()
+                Spacer()
+                Text("Optional")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            TextField("Cash, Visa **1234, …", text: $paymentMethod)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .padding(Space.md)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func loadIfNeeded() {
+        guard !loaded else { return }
+        loaded = true
+
+        switch target {
+        case .new:
+            source = .manual
+            // Focus the amount field shortly after the sheet finishes its
+            // open animation. SwiftUI ignores focus changes made inside
+            // .onAppear on a freshly presented sheet.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                amountFocused = true
+            }
+
+        case .existing(let uuid):
+            let descriptor = FetchDescriptor<LocalExpense>(
+                predicate: #Predicate { $0.clientUUID == uuid }
+            )
+            if let existing = try? modelContext.fetch(descriptor).first {
+                amountText = formatAmountForEdit(existing.originalAmount)
+                currency = existing.originalCurrency
+                category = existing.categoryEnum
+                date = existing.date
+                merchant = existing.merchant ?? ""
+                descriptionField = existing.expenseDescription ?? ""
+                paymentMethod = existing.paymentMethod ?? ""
+                receiptImagePath = existing.receiptImagePath
+                source = existing.sourceEnum
+            }
+
+        case .prefilled(let prefill):
+            source = prefill.source
+            receiptImagePath = prefill.receiptImagePath
+            extractionBanner = prefill.extractionError
+            extractionConfidence = prefill.confidence
+
+            if let amount = prefill.amount {
+                amountText = formatAmountForEdit(amount)
+            }
+            if let cur = prefill.currency, !cur.isEmpty {
+                currency = cur.uppercased()
+            }
+            if let cat = prefill.category {
+                category = cat
+            }
+            if let d = prefill.date {
+                date = d
+            }
+            if let m = prefill.merchant {
+                merchant = m
+            }
+            if let desc = prefill.descriptionText {
+                descriptionField = desc
+            }
+            // For a successful extraction we don't auto-focus — the user is
+            // reviewing fields, not typing from scratch. For a failure we
+            // jump straight to the amount field after the sheet settles.
+            if !prefill.extractionSucceeded {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    amountFocused = true
+                }
+            }
+        }
+    }
+
+    private func save() async {
+        guard amountValue > 0 else {
+            errorMessage = "Enter an amount greater than zero."
+            return
+        }
+        saving = true
+        errorMessage = nil
+        defer { saving = false }
+
+        let store = SwiftDataStore.shared
+        let fx = FXService(store: store)
+        let service = ExpenseService(store: store)
+
+        let conversion: (sgdAmount: Double, rate: Double)
+        do {
+            conversion = try await fx.convert(amountValue, from: currency)
+        } catch {
+            errorMessage = "Couldn't convert \(currency) to SGD. Try again when online."
+            return
+        }
+
+        do {
+            switch target {
+            case .new, .prefilled:
+                let row = try service.addExpense(
+                    date: date,
+                    category: category,
+                    merchant: merchant,
+                    expenseDescription: descriptionField,
+                    originalAmount: amountValue,
+                    originalCurrency: currency,
+                    sgdAmount: conversion.sgdAmount,
+                    fxRate: conversion.rate,
+                    paymentMethod: paymentMethod,
+                    source: source
+                )
+                // ExpenseService.addExpense doesn't take receiptImagePath
+                // (Phase A signature). Set it directly and save again — the
+                // service does the same context.save() pattern.
+                if let path = receiptImagePath {
+                    row.receiptImagePath = path
+                    try modelContext.save()
+                }
+
+            case .existing(let uuid):
+                let descriptor = FetchDescriptor<LocalExpense>(
+                    predicate: #Predicate { $0.clientUUID == uuid }
+                )
+                if let existing = try modelContext.fetch(descriptor).first {
+                    try service.updateExpense(
+                        existing,
+                        date: date,
+                        category: category,
+                        merchant: merchant,
+                        expenseDescription: descriptionField,
+                        originalAmount: amountValue,
+                        originalCurrency: currency,
+                        sgdAmount: conversion.sgdAmount,
+                        fxRate: conversion.rate,
+                        paymentMethod: paymentMethod
+                    )
+                    // Persist receipt-path / source changes (e.g. user
+                    // removed the image, or scan path → manual edit).
+                    existing.receiptImagePath = receiptImagePath
+                    existing.source = source.rawValue
+                    try modelContext.save()
+                }
+            }
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Strip trailing zeros from the persisted amount so editing doesn't
+    /// show "67.500000" on load.
+    private func formatAmountForEdit(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = false
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+}
+
+// MARK: - Receipt rendering helpers
+
+/// Small inline preview of a stored receipt. Renders the image for
+/// `.jpg/.heic/.png` and a generic doc icon for `.pdf` (we don't need to
+/// rasterise a PDF for a 64pt thumbnail — the icon is enough signal).
+struct ReceiptThumbnailImage: View {
+    let relativePath: String?
+
+    var body: some View {
+        Group {
+            if let path = relativePath,
+               let url = ReceiptStorage.shared.load(relativePath: path) {
+                if isPDF(path) {
+                    pdfPlaceholder
+                } else if let image = UIImage(contentsOfFile: url.path) {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    missingPlaceholder
+                }
+            } else {
+                missingPlaceholder
+            }
+        }
+        .background(Tokens.surface2)
+    }
+
+    private func isPDF(_ path: String) -> Bool {
+        path.lowercased().hasSuffix(".pdf")
+    }
+
+    private var pdfPlaceholder: some View {
+        Image(systemName: "doc.text.fill")
+            .font(.system(size: 26, weight: .regular))
+            .foregroundStyle(Tokens.accentFinance)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var missingPlaceholder: some View {
+        Image(systemName: "photo")
+            .font(.system(size: 22, weight: .regular))
+            .foregroundStyle(Tokens.muted)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Full-screen receipt viewer. Sheet presented from AddExpenseSheet when
+/// the user taps the thumbnail. For PDFs we point Quick Look-style at the
+/// file URL via `PDFKit` would be ideal, but the simpler `Link`-to-URL
+/// flow isn't available inside a sheet; we render a placeholder with the
+/// filename instead and link the user out to Files for a real preview
+/// when needed. Images render full-size with pinch-to-zoom via the
+/// built-in `ScrollView` + `magnification`.
+struct ReceiptFullViewer: View {
+    let relativePath: String
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                if relativePath.lowercased().hasSuffix(".pdf") {
+                    pdfNote
+                } else if let url = ReceiptStorage.shared.load(relativePath: relativePath),
+                          let image = UIImage(contentsOfFile: url.path) {
+                    imageViewer(image)
+                } else {
+                    Text("Receipt is no longer available.")
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.muted)
+                }
+            }
+            .navigationTitle("Receipt")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Tokens.ink)
+                }
+            }
+        }
+    }
+
+    private func imageViewer(_ image: UIImage) -> some View {
+        ScrollView([.horizontal, .vertical], showsIndicators: false) {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+                .padding()
+        }
+    }
+
+    private var pdfNote: some View {
+        VStack(spacing: Space.md) {
+            Image(systemName: "doc.text.fill")
+                .font(.system(size: 44, weight: .regular))
+                .foregroundStyle(Tokens.accentFinance)
+            Text("PDF attached")
+                .font(.edHeading)
+                .foregroundStyle(Tokens.ink)
+            Text("Open the expense's source app to view this PDF in full.")
+                .font(.edSubheadline)
+                .foregroundStyle(Tokens.muted)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Space.xl)
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Views/Finance/CameraPicker.swift
+++ b/mobile/PersonalDashboard/Views/Finance/CameraPicker.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import UIKit
+
+/// Thin SwiftUI wrapper around `UIImagePickerController(sourceType: .camera)`.
+/// Used by the Finance "+" menu's "Scan receipt" path.
+///
+/// Returns JPEG `Data` via `onCapture(data)`; passes `nil` if the user
+/// cancels. The picker is presented as a `.fullScreenCover` from FinanceView
+/// because UIKit's camera UI is itself full-screen and doesn't play nicely
+/// with sheet detents.
+struct CameraPicker: UIViewControllerRepresentable {
+    let onCapture: (Data?) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCapture: onCapture)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        // Falls back to .photoLibrary if the device has no camera (simulator).
+        // The menu item is hidden when this is the case (see FinanceView).
+        picker.sourceType = UIImagePickerController.isSourceTypeAvailable(.camera)
+            ? .camera
+            : .photoLibrary
+        picker.allowsEditing = false
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+        // No reactive state to push down.
+    }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onCapture: (Data?) -> Void
+        /// One-shot guard. UIImagePickerController is known to deliver the
+        /// finish callback twice on some iOS versions when the user taps
+        /// "Use Photo" quickly; this stops downstream from firing twice.
+        private var fired = false
+
+        init(onCapture: @escaping (Data?) -> Void) {
+            self.onCapture = onCapture
+        }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            guard !fired else { return }
+            fired = true
+            let image = info[.originalImage] as? UIImage
+            // jpegData(0.9) here is "lossy but high quality" — ReceiptStorage
+            // will re-encode at 0.8 anyway, so the double-encode is one-time
+            // and acceptable.
+            let data = image?.jpegData(compressionQuality: 0.9)
+            picker.dismiss(animated: true) { [onCapture] in
+                onCapture(data)
+            }
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            guard !fired else { return }
+            fired = true
+            picker.dismiss(animated: true) { [onCapture] in
+                onCapture(nil)
+            }
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
+++ b/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+/// Single-row presentation of a `LocalExpense`. Tap → edit (handler passed
+/// in by the parent so we don't couple the row to a sheet binding).
+struct ExpenseRow: View {
+    let expense: LocalExpense
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: Space.md) {
+                Image(systemName: expense.categoryEnum.sfSymbol)
+                    .font(.system(size: 14, weight: .regular))
+                    .foregroundStyle(Tokens.accentFinance)
+                    .frame(width: 36, height: 36)
+                    .background(Tokens.paper2, in: Circle())
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(primaryLine)
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.ink)
+                        .lineLimit(1)
+                    if let secondary = secondaryLine {
+                        Text(secondary)
+                            .font(.edCaption)
+                            .foregroundStyle(Tokens.muted)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(FinanceDashboardBand.formatSGD(expense.sgdAmount))
+                        .font(.edBodyMedium)
+                        .monospacedDigit()
+                        .foregroundStyle(Tokens.ink)
+                    if expense.originalCurrency.uppercased() != "SGD" {
+                        Text(originalAmountLabel)
+                            .font(.edCaption)
+                            .monospacedDigit()
+                            .foregroundStyle(Tokens.mutedSoft)
+                    }
+                }
+            }
+            .padding(.horizontal, Space.md)
+            .padding(.vertical, Space.sm + 2)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+            .paperBorder(Tokens.border, radius: Radius.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var primaryLine: String {
+        if let merchant = expense.merchant?.trimmedNonEmpty {
+            return merchant
+        }
+        if let description = expense.expenseDescription?.trimmedNonEmpty {
+            return description
+        }
+        return expense.categoryEnum.displayName
+    }
+
+    /// Secondary line: category name (if not already the primary) +
+    /// description (if not already the primary).
+    private var secondaryLine: String? {
+        var pieces: [String] = []
+
+        // Always show the category as a kind of tag-line — unless the
+        // primary already IS the category fallback.
+        let isCategoryPrimary = expense.merchant?.trimmedNonEmpty == nil &&
+                                expense.expenseDescription?.trimmedNonEmpty == nil
+        if !isCategoryPrimary {
+            pieces.append(expense.categoryEnum.displayName)
+        }
+
+        // If both merchant and description exist, surface description on
+        // the secondary line. Otherwise leave it.
+        if let _ = expense.merchant?.trimmedNonEmpty,
+           let description = expense.expenseDescription?.trimmedNonEmpty {
+            pieces.append(description)
+        }
+
+        return pieces.isEmpty ? nil : pieces.joined(separator: " · ")
+    }
+
+    private var originalAmountLabel: String {
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        formatter.numberStyle = .decimal
+        let amount = formatter.string(from: NSNumber(value: expense.originalAmount)) ?? "\(expense.originalAmount)"
+        return "\(expense.originalCurrency.uppercased()) \(amount)"
+    }
+
+    private var accessibilityLabel: String {
+        var pieces: [String] = [primaryLine, FinanceDashboardBand.formatSGD(expense.sgdAmount), expense.categoryEnum.displayName]
+        if expense.originalCurrency.uppercased() != "SGD" {
+            pieces.append("\(originalAmountLabel) original")
+        }
+        return pieces.joined(separator: ", ") + ". Tap to edit."
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let t = trimmingCharacters(in: .whitespacesAndNewlines)
+        return t.isEmpty ? nil : t
+    }
+}

--- a/mobile/PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+
+/// Snapshot stats shown at the top of the Finance surface. Computed once
+/// per render from the live `expenses` array. Recomputing in-place keeps
+/// the data path simple: no service-layer caching for Phase A.
+struct FinanceDashboardStats {
+    let monthTotal: Double
+    let previousMonthTotal: Double
+    let topCategories: [(category: ExpenseCategory, total: Double)]
+    let dailyTotals: [(date: Date, total: Double)]
+
+    var deltaPercent: Double? {
+        guard previousMonthTotal > 0 else { return nil }
+        return (monthTotal - previousMonthTotal) / previousMonthTotal
+    }
+}
+
+/// Dashboard band: month total, delta vs prior month, top-3 categories,
+/// last-30-days sparkline. Card-shaped, uses the Finance accent for the
+/// secondary indicators.
+struct FinanceDashboardBand: View {
+    let stats: FinanceDashboardStats
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Space.md) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("This month").eyebrow()
+                Spacer()
+                deltaChip
+            }
+            Text(Self.formatSGD(stats.monthTotal))
+                .font(.edDisplay)
+                .foregroundStyle(Tokens.ink)
+                .tracking(-0.6)
+
+            if !stats.topCategories.isEmpty {
+                categoryBars
+                    .padding(.top, Space.xs)
+            }
+
+            sparkline
+                .frame(height: 36)
+                .padding(.top, Space.xs)
+                .accessibilityLabel("Spending over the last 30 days")
+        }
+        .padding(Space.lg)
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        .paperBorder(Tokens.border, radius: Radius.lg)
+    }
+
+    // MARK: - Delta chip
+
+    @ViewBuilder
+    private var deltaChip: some View {
+        if let delta = stats.deltaPercent {
+            let isUp = delta >= 0
+            let symbol = isUp ? "arrow.up.right" : "arrow.down.right"
+            let chipColor: Color = isUp ? Tokens.danger : Tokens.success
+            let chipBg: Color = isUp ? Tokens.dangerSoft : Tokens.successSoft
+            HStack(spacing: 4) {
+                Image(systemName: symbol)
+                    .font(.system(size: 10, weight: .semibold))
+                Text(formatDelta(delta))
+                    .font(.edFootnote)
+            }
+            .foregroundStyle(chipColor)
+            .padding(.horizontal, Space.sm)
+            .padding(.vertical, 4)
+            .background(chipBg, in: Capsule())
+        } else if stats.previousMonthTotal == 0 && stats.monthTotal > 0 {
+            Text("First month")
+                .font(.edFootnote)
+                .foregroundStyle(Tokens.muted)
+                .padding(.horizontal, Space.sm)
+                .padding(.vertical, 4)
+                .background(Tokens.paper2, in: Capsule())
+        }
+    }
+
+    private func formatDelta(_ value: Double) -> String {
+        let percent = abs(value) * 100
+        return String(format: "%.0f%%", percent)
+    }
+
+    // MARK: - Category bars
+
+    private var categoryBars: some View {
+        let maxValue = stats.topCategories.map { $0.total }.max() ?? 1
+        return VStack(alignment: .leading, spacing: Space.sm) {
+            ForEach(stats.topCategories, id: \.category) { entry in
+                categoryBar(entry: entry, max: maxValue)
+            }
+        }
+    }
+
+    private func categoryBar(entry: (category: ExpenseCategory, total: Double), max: Double) -> some View {
+        let ratio = max > 0 ? entry.total / max : 0
+        return HStack(spacing: Space.sm) {
+            Image(systemName: entry.category.sfSymbol)
+                .font(.system(size: 12, weight: .regular))
+                .foregroundStyle(Tokens.accentFinance)
+                .frame(width: 18)
+            Text(entry.category.displayName)
+                .font(.edFootnote)
+                .foregroundStyle(Tokens.inkSoft)
+                .lineLimit(1)
+                .frame(width: 110, alignment: .leading)
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Tokens.paper2)
+                    Capsule()
+                        .fill(Tokens.accentFinance.opacity(0.85))
+                        .frame(width: proxy.size.width * CGFloat(ratio))
+                }
+            }
+            .frame(height: 6)
+            Text(Self.formatSGD(entry.total))
+                .font(.edFootnote)
+                .monospacedDigit()
+                .foregroundStyle(Tokens.inkSoft)
+                .frame(width: 86, alignment: .trailing)
+        }
+    }
+
+    // MARK: - Sparkline
+
+    private var sparkline: some View {
+        GeometryReader { proxy in
+            let values = stats.dailyTotals.map { $0.total }
+            let maxValue = (values.max() ?? 0)
+            ZStack(alignment: .bottom) {
+                // Baseline.
+                Rectangle()
+                    .fill(Tokens.divider)
+                    .frame(height: 0.5)
+                if maxValue > 0, values.count > 1 {
+                    sparklinePath(values: values, size: proxy.size, maxValue: maxValue)
+                        .stroke(
+                            Tokens.accentFinance,
+                            style: StrokeStyle(lineWidth: 1.5, lineCap: .round, lineJoin: .round)
+                        )
+                    sparklineFill(values: values, size: proxy.size, maxValue: maxValue)
+                        .fill(Tokens.accentFinance.opacity(0.08))
+                } else {
+                    Text("No spending in the last 30 days")
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.mutedSoft)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+        }
+    }
+
+    private func sparklinePath(values: [Double], size: CGSize, maxValue: Double) -> Path {
+        Path { path in
+            let count = values.count
+            let step = size.width / CGFloat(count - 1)
+            for (idx, value) in values.enumerated() {
+                let x = CGFloat(idx) * step
+                let normalised = maxValue > 0 ? CGFloat(value / maxValue) : 0
+                let y = size.height - (normalised * (size.height - 2)) - 1
+                if idx == 0 {
+                    path.move(to: CGPoint(x: x, y: y))
+                } else {
+                    path.addLine(to: CGPoint(x: x, y: y))
+                }
+            }
+        }
+    }
+
+    private func sparklineFill(values: [Double], size: CGSize, maxValue: Double) -> Path {
+        Path { path in
+            let count = values.count
+            let step = size.width / CGFloat(count - 1)
+            path.move(to: CGPoint(x: 0, y: size.height))
+            for (idx, value) in values.enumerated() {
+                let x = CGFloat(idx) * step
+                let normalised = maxValue > 0 ? CGFloat(value / maxValue) : 0
+                let y = size.height - (normalised * (size.height - 2)) - 1
+                path.addLine(to: CGPoint(x: x, y: y))
+            }
+            path.addLine(to: CGPoint(x: size.width, y: size.height))
+            path.closeSubpath()
+        }
+    }
+
+    // MARK: - Formatting
+
+    static func formatSGD(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "SGD"
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        // "SGD 1,247.50" reads cleaner than "$1,247.50 SGD".
+        formatter.currencySymbol = "SGD "
+        return formatter.string(from: NSNumber(value: value)) ?? "SGD 0.00"
+    }
+}

--- a/mobile/PersonalDashboard/Views/Finance/FinanceFilterBar.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceFilterBar.swift
@@ -1,0 +1,356 @@
+import SwiftUI
+
+/// Preset windows offered in the date-range chip row. "Custom" pops a
+/// date-range picker; everything else maps to a calendar-derived range.
+enum FinanceDateRangePreset: String, CaseIterable, Identifiable, Hashable {
+    case thisMonth
+    case lastMonth
+    case last30
+    case last90
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .thisMonth: return "This month"
+        case .lastMonth: return "Last month"
+        case .last30:    return "30d"
+        case .last90:    return "90d"
+        case .custom:    return "Custom"
+        }
+    }
+}
+
+/// Aggregated filter state owned by `FinanceView`. Bound into the filter
+/// bar and read by `ExpenseService.expenses(filter:)`.
+struct FinanceFilterState: Equatable {
+    var datePreset: FinanceDateRangePreset = .thisMonth
+    var customStart: Date = Date()
+    var customEnd: Date = Date()
+    var categories: Set<ExpenseCategory> = []
+    var sources: Set<ExpenseSource> = []
+
+    /// Materialise the filter into a concrete `ExpenseFilter` honoured by
+    /// the service layer. `searchText` is appended separately by the view
+    /// because it lives on a `.searchable` binding.
+    func resolvedFilter(searchText: String?) -> ExpenseFilter {
+        var filter = ExpenseFilter()
+        filter.dateRange = resolvedDateRange()
+        if !categories.isEmpty { filter.categories = categories }
+        if !sources.isEmpty { filter.sources = sources }
+        filter.searchText = searchText
+        return filter
+    }
+
+    private func resolvedDateRange() -> ClosedRange<Date>? {
+        let cal = Calendar.current
+        let now = Date()
+        switch datePreset {
+        case .thisMonth:
+            let bounds = ExpenseDateRanges.monthBounds(for:now)
+            return bounds.0...bounds.1
+        case .lastMonth:
+            let prev = cal.date(byAdding: .month, value: -1, to: now) ?? now
+            let bounds = ExpenseDateRanges.monthBounds(for:prev)
+            return bounds.0...bounds.1
+        case .last30:
+            guard let start = cal.date(byAdding: .day, value: -30, to: now) else { return nil }
+            return cal.startOfDay(for: start)...now
+        case .last90:
+            guard let start = cal.date(byAdding: .day, value: -90, to: now) else { return nil }
+            return cal.startOfDay(for: start)...now
+        case .custom:
+            let lo = cal.startOfDay(for: min(customStart, customEnd))
+            let hi = cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: max(customStart, customEnd)))?
+                .addingTimeInterval(-1) ?? customEnd
+            return lo...hi
+        }
+    }
+}
+
+/// Horizontal scroll of chips: date range presets, category multi-select,
+/// source multi-select. Custom date range opens a sheet.
+struct FinanceFilterBar: View {
+    @Binding var state: FinanceFilterState
+
+    @State private var customDateSheetVisible: Bool = false
+    @State private var categorySheetVisible: Bool = false
+    @State private var sourceSheetVisible: Bool = false
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Space.sm) {
+                // Date range chips
+                ForEach(FinanceDateRangePreset.allCases) { preset in
+                    chip(
+                        label: preset == .custom ? customLabel : preset.displayName,
+                        icon: preset == .custom ? "calendar" : nil,
+                        selected: state.datePreset == preset,
+                        action: {
+                            if preset == .custom {
+                                customDateSheetVisible = true
+                            } else {
+                                state.datePreset = preset
+                            }
+                        }
+                    )
+                }
+
+                divider
+
+                // Category filter chip — opens multi-select sheet
+                chip(
+                    label: categorySummary,
+                    icon: "line.3.horizontal.decrease.circle",
+                    selected: !state.categories.isEmpty,
+                    action: { categorySheetVisible = true }
+                )
+
+                // Source filter chip
+                chip(
+                    label: sourceSummary,
+                    icon: "antenna.radiowaves.left.and.right",
+                    selected: !state.sources.isEmpty,
+                    action: { sourceSheetVisible = true }
+                )
+
+                if !state.categories.isEmpty || !state.sources.isEmpty {
+                    chip(
+                        label: "Clear",
+                        icon: "xmark",
+                        selected: false,
+                        action: {
+                            state.categories.removeAll()
+                            state.sources.removeAll()
+                        }
+                    )
+                }
+            }
+            .padding(.horizontal, Space.lg)
+        }
+        .sheet(isPresented: $customDateSheetVisible) {
+            CustomDateRangeSheet(start: $state.customStart, end: $state.customEnd, onApply: {
+                state.datePreset = .custom
+            })
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $categorySheetVisible) {
+            CategoryMultiSelectSheet(selection: $state.categories)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $sourceSheetVisible) {
+            SourceMultiSelectSheet(selection: $state.sources)
+                .presentationDetents([.medium])
+                .presentationDragIndicator(.visible)
+        }
+    }
+
+    private var customLabel: String {
+        if state.datePreset == .custom {
+            let fmt = DateFormatter()
+            fmt.dateFormat = "d MMM"
+            return "\(fmt.string(from: state.customStart)) – \(fmt.string(from: state.customEnd))"
+        }
+        return "Custom"
+    }
+
+    private var categorySummary: String {
+        switch state.categories.count {
+        case 0: return "Categories"
+        case 1: return state.categories.first?.displayName ?? "Categories"
+        default: return "\(state.categories.count) categories"
+        }
+    }
+
+    private var sourceSummary: String {
+        switch state.sources.count {
+        case 0: return "Sources"
+        case 1: return state.sources.first?.displayName ?? "Sources"
+        default: return "\(state.sources.count) sources"
+        }
+    }
+
+    private func chip(label: String, icon: String?, selected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 11, weight: .medium))
+                }
+                Text(label)
+                    .font(.edFootnote)
+            }
+            .foregroundStyle(selected ? Tokens.accentFg : Tokens.inkSoft)
+            .padding(.horizontal, Space.md)
+            .padding(.vertical, 6)
+            .background(selected ? Tokens.accentFinance : Tokens.surface, in: Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(selected ? Color.clear : Tokens.border, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(Tokens.divider)
+            .frame(width: 0.5, height: 20)
+            .padding(.horizontal, 2)
+    }
+}
+
+// MARK: - Custom date range sheet
+
+private struct CustomDateRangeSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var start: Date
+    @Binding var end: Date
+    let onApply: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                VStack(spacing: Space.lg) {
+                    DatePicker("From", selection: $start, in: ...Date(), displayedComponents: .date)
+                        .tint(Tokens.accentFinance)
+                    DatePicker("To", selection: $end, in: start...Date(), displayedComponents: .date)
+                        .tint(Tokens.accentFinance)
+                    Spacer()
+                }
+                .padding(Space.lg)
+            }
+            .navigationTitle("Custom range")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Tokens.muted)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Apply") {
+                        onApply()
+                        dismiss()
+                    }
+                    .foregroundStyle(Tokens.ink)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Category multi-select sheet
+
+private struct CategoryMultiSelectSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var selection: Set<ExpenseCategory>
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                List {
+                    ForEach(ExpenseCategory.allCases) { cat in
+                        Button {
+                            if selection.contains(cat) {
+                                selection.remove(cat)
+                            } else {
+                                selection.insert(cat)
+                            }
+                        } label: {
+                            HStack(spacing: Space.sm) {
+                                Image(systemName: cat.sfSymbol)
+                                    .foregroundStyle(Tokens.accentFinance)
+                                    .frame(width: 24)
+                                Text(cat.displayName)
+                                    .foregroundStyle(Tokens.ink)
+                                Spacer()
+                                if selection.contains(cat) {
+                                    Image(systemName: "checkmark")
+                                        .foregroundStyle(Tokens.accentFinance)
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .listRowBackground(Tokens.surface)
+                    }
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .background(Tokens.paper)
+            }
+            .navigationTitle("Categories")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Clear") { selection.removeAll() }
+                        .foregroundStyle(Tokens.muted)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Tokens.ink)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Source multi-select sheet
+
+private struct SourceMultiSelectSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var selection: Set<ExpenseSource>
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                List {
+                    ForEach(ExpenseSource.allCases) { source in
+                        Button {
+                            if selection.contains(source) {
+                                selection.remove(source)
+                            } else {
+                                selection.insert(source)
+                            }
+                        } label: {
+                            HStack(spacing: Space.sm) {
+                                Image(systemName: source.sfSymbol)
+                                    .foregroundStyle(Tokens.accentFinance)
+                                    .frame(width: 24)
+                                Text(source.displayName)
+                                    .foregroundStyle(Tokens.ink)
+                                Spacer()
+                                if selection.contains(source) {
+                                    Image(systemName: "checkmark")
+                                        .foregroundStyle(Tokens.accentFinance)
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .listRowBackground(Tokens.surface)
+                    }
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+                .background(Tokens.paper)
+            }
+            .navigationTitle("Sources")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Clear") { selection.removeAll() }
+                        .foregroundStyle(Tokens.muted)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Tokens.ink)
+                }
+            }
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -1,10 +1,63 @@
 import SwiftUI
+import SwiftData
+import UIKit
 
-/// Finance surface placeholder (issue #110). Mirrors the HelpCenter pattern:
-/// a routed page so the drawer entry has a real destination instead of a
-/// 404. Real content (accounts, spending, recurring bills) lands here later.
+/// Source channel for the "+" capture menu. Drives both the picker
+/// presentation flags and the downstream `ExpenseSource` we tag the
+/// resulting expense with.
+enum FinanceCaptureSource {
+    case camera
+    case photoLibrary
+    case pdf
+}
+
+/// Finance v1 surface (#114). Phase B adds receipt capture on top of the
+/// Phase A list / dashboard:
+///
+/// - The "+" button is now a menu with Scan / Photo / PDF / Manual.
+/// - Scan / Photo / PDF: capture the asset, save it under
+///   `Documents/receipts/`, ask Claude to extract structured fields, then
+///   open AddExpenseSheet with the values prefilled.
+/// - Manual: opens the blank form as before.
+/// - Receipt assets follow the expense lifecycle — deleting an expense
+///   also deletes its receipt file.
 struct FinanceView: View {
+    @Environment(\.modelContext) private var modelContext
+
     @Bindable var router: AppRouter
+
+    @Query(
+        sort: [
+            SortDescriptor(\LocalExpense.date, order: .reverse),
+            SortDescriptor(\LocalExpense.createdAt, order: .reverse)
+        ]
+    ) private var allExpenses: [LocalExpense]
+
+    @State private var filterState = FinanceFilterState()
+    @State private var searchText: String = ""
+
+    /// Identifier for the AddExpense sheet. `.new` for the + button,
+    /// `.existing(uuid)` for tap-to-edit on a row.
+    @State private var editingTarget: ExpenseEditorTarget?
+
+    /// Expense the user has swiped-to-delete and we're confirming.
+    @State private var pendingDelete: LocalExpense?
+
+    // MARK: - Capture flow state
+
+    @State private var showingCamera: Bool = false
+    @State private var showingPhotoLibrary: Bool = false
+    @State private var showingPDFPicker: Bool = false
+
+    /// On-screen overlay while Vision runs. The receipt file is already
+    /// saved before this flips on, so cancelling here just opens the
+    /// AddExpenseSheet with the receipt attached and no prefilled fields.
+    @State private var extractionInProgress: Bool = false
+
+    /// Surfaced to the user when extraction fails with no usable receipt
+    /// to attach (e.g. file save failed). Successful saves with failed
+    /// Vision fall through to AddExpenseSheet with a banner instead.
+    @State private var captureErrorMessage: String?
 
     var body: some View {
         ZStack {
@@ -17,38 +70,512 @@ struct FinanceView: View {
                         withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true }
                     }
                 )
+                content
+            }
 
-                Spacer()
+            captureMenuButton
 
-                VStack(spacing: Space.lg) {
-                    Image(systemName: "dollarsign.circle")
-                        .font(.system(size: 32, weight: .regular))
-                        .foregroundStyle(Tokens.muted)
-
-                    Rectangle()
-                        .fill(Tokens.accentFinance)
-                        .frame(width: 32, height: 2)
-
-                    VStack(spacing: Space.sm) {
-                        Text("Coming soon")
-                            .font(.edDisplay)
-                            .foregroundStyle(Tokens.ink)
-                            .multilineTextAlignment(.center)
-                            .tracking(-0.4)
-
-                        Text("Accounts, spending, and recurring bills will live here.")
-                            .font(.edBody)
-                            .foregroundStyle(Tokens.muted)
-                            .multilineTextAlignment(.center)
-                            .frame(maxWidth: 320)
-                    }
-                }
-                .padding(.horizontal, Space.xl)
-
-                Spacer()
-                Spacer()
+            if extractionInProgress {
+                extractionOverlay
             }
         }
         .activeSection(.finance)
+        .sheet(item: $editingTarget) { target in
+            AddExpenseSheet(target: target)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
+        }
+        .fullScreenCover(isPresented: $showingCamera) {
+            CameraPicker { data in
+                showingCamera = false
+                handleCaptureData(data, source: .camera)
+            }
+            .ignoresSafeArea()
+        }
+        .photoLibraryPicker(isPresented: $showingPhotoLibrary) { data in
+            handleCaptureData(data, source: .photoLibrary)
+        }
+        .pdfPicker(isPresented: $showingPDFPicker) { data in
+            handleCaptureData(data, source: .pdf)
+        }
+        .alert(
+            "Couldn't process receipt",
+            isPresented: captureErrorBinding,
+            presenting: captureErrorMessage
+        ) { _ in
+            Button("OK", role: .cancel) { captureErrorMessage = nil }
+        } message: { message in
+            Text(message)
+        }
+        .confirmationDialog(
+            "Delete this expense?",
+            isPresented: deleteDialogBinding,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let row = pendingDelete {
+                    delete(row)
+                }
+                pendingDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDelete = nil
+            }
+        } message: {
+            Text(pendingDelete.map { confirmationMessage(for: $0) } ?? "")
+        }
+    }
+
+    // MARK: - Capture menu + overlay
+
+    private var captureMenuButton: some View {
+        Menu {
+            // .camera path is hidden in the simulator (and other no-camera
+            // hardware) — the UIImagePickerController would silently fall
+            // back to .photoLibrary, which makes the two top items
+            // confusingly redundant.
+            if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                Button {
+                    startScan(.camera)
+                } label: {
+                    Label("Scan receipt", systemImage: "camera")
+                }
+            }
+            Button {
+                startScan(.photoLibrary)
+            } label: {
+                Label("Photo from library", systemImage: "photo.on.rectangle")
+            }
+            Button {
+                startScan(.pdf)
+            } label: {
+                Label("PDF from Files", systemImage: "doc.text")
+            }
+            Divider()
+            Button {
+                editingTarget = .new
+            } label: {
+                Label("Enter manually", systemImage: "pencil")
+            }
+        } label: {
+            Image(systemName: "plus")
+        }
+        .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
+        .padding(.trailing, 22)
+        .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        .accessibilityLabel("Add expense")
+    }
+
+    private var extractionOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.25).ignoresSafeArea()
+            VStack(spacing: Space.md) {
+                ProgressView()
+                    .tint(Tokens.ink)
+                Text("Reading receipt…")
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.ink)
+            }
+            .padding(.horizontal, Space.xl)
+            .padding(.vertical, Space.lg)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+        .transition(.opacity)
+        .allowsHitTesting(true)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Reading receipt")
+    }
+
+    // MARK: - Capture lifecycle
+
+    private func startScan(_ source: FinanceCaptureSource) {
+        switch source {
+        case .camera:        showingCamera = true
+        case .photoLibrary:  showingPhotoLibrary = true
+        case .pdf:           showingPDFPicker = true
+        }
+    }
+
+    /// Common entry point for all three pickers. `data == nil` is a user
+    /// cancel; we just bail. Otherwise persist + extract.
+    private func handleCaptureData(_ data: Data?, source: FinanceCaptureSource) {
+        guard let data else { return }
+        Task { await processCapturedAsset(data: data, captureSource: source) }
+    }
+
+    /// Save the asset to disk, kick off Vision, then open AddExpenseSheet
+    /// with either prefilled fields (success) or just the receipt attached
+    /// (failure). Receipt save errors bubble up to the alert; Vision errors
+    /// don't — those are non-fatal because the user can fill in the form.
+    private func processCapturedAsset(data: Data, captureSource: FinanceCaptureSource) async {
+        let storage = ReceiptStorage.shared
+        let client = AnthropicClient()
+
+        // 1. Persist the file. For images we compress ONCE here and use the
+        //    same JPEG bytes for both the disk save and the Vision call —
+        //    otherwise the original raw camera data (HEIC, multi-MB)
+        //    overflows Anthropic's 5 MB base64 limit and the API rejects it.
+        let relativePath: String
+        let expenseSource: ExpenseSource
+        let visionImageData: Data?  // nil for PDFs, otherwise the compressed JPEG
+        do {
+            switch captureSource {
+            case .camera:
+                let compressed = try storage.compress(imageData: data)
+                relativePath = try storage.saveCompressedJpeg(compressed)
+                expenseSource = .receipt
+                visionImageData = compressed
+            case .photoLibrary:
+                let compressed = try storage.compress(imageData: data)
+                relativePath = try storage.saveCompressedJpeg(compressed)
+                expenseSource = .photo
+                visionImageData = compressed
+            case .pdf:
+                relativePath = try storage.save(pdfData: data)
+                expenseSource = .pdf
+                visionImageData = nil
+            }
+        } catch {
+            captureErrorMessage = error.localizedDescription
+            return
+        }
+
+        // 2. Show progress, run Vision.
+        withAnimation(.easeInOut(duration: 0.15)) {
+            extractionInProgress = true
+        }
+        defer {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                extractionInProgress = false
+            }
+        }
+
+        do {
+            let extracted: ExtractedExpense
+            switch captureSource {
+            case .camera, .photoLibrary:
+                extracted = try await client.extractExpense(
+                    imageData: visionImageData ?? data,
+                    mediaType: "image/jpeg"
+                )
+            case .pdf:
+                extracted = try await client.extractExpense(pdfData: data)
+            }
+            let prefill = PrefilledExpense.fromExtraction(
+                extracted,
+                receiptImagePath: relativePath,
+                source: expenseSource
+            )
+            editingTarget = .prefilled(prefill)
+        } catch {
+            // Save the receipt regardless; open the form with a banner.
+            let message: String = {
+                if let typed = error as? ReceiptExtractionError {
+                    return typed.localizedDescription
+                }
+                return "We saved your receipt but couldn't read it. Fill in the details below."
+            }()
+            let prefill = PrefilledExpense.fromFailure(
+                receiptImagePath: relativePath,
+                source: expenseSource,
+                message: message
+            )
+            editingTarget = .prefilled(prefill)
+        }
+    }
+
+    private var captureErrorBinding: Binding<Bool> {
+        Binding(
+            get: { captureErrorMessage != nil },
+            set: { newValue in if !newValue { captureErrorMessage = nil } }
+        )
+    }
+
+    // MARK: - Content router
+
+    @ViewBuilder
+    private var content: some View {
+        if allExpenses.isEmpty {
+            emptyState
+        } else {
+            populatedContent
+        }
+    }
+
+    private var populatedContent: some View {
+        let filtered = filteredExpenses
+        let stats = computeStats()
+        return ScrollView {
+            VStack(spacing: Space.lg) {
+                FinanceDashboardBand(stats: stats)
+                    .padding(.horizontal, Space.lg)
+
+                searchField
+                    .padding(.horizontal, Space.lg)
+
+                FinanceFilterBar(state: $filterState)
+
+                if filtered.isEmpty {
+                    noResultsState
+                        .padding(.top, Space.xl)
+                } else {
+                    expenseList(filtered: filtered)
+                        .padding(.horizontal, Space.lg)
+                }
+
+                Color.clear.frame(height: 96)
+            }
+            .padding(.vertical, Space.lg)
+        }
+        .scrollDismissesKeyboard(.interactively)
+    }
+
+    /// Inline search input. Project convention is to avoid `.searchable`
+    /// (which needs a `NavigationStack` wrapper) and instead drop a paper
+    /// search field into the scroll view — see TasksView / NotesView for
+    /// the same pattern.
+    private var searchField: some View {
+        HStack(spacing: Space.sm) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 13, weight: .regular))
+                .foregroundStyle(Tokens.muted)
+            TextField("Search merchant or description", text: $searchText)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .autocorrectionDisabled(true)
+                .textInputAutocapitalization(.never)
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 14, weight: .regular))
+                        .foregroundStyle(Tokens.mutedSoft)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, Space.md)
+        .padding(.vertical, Space.sm)
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+        .paperBorder(Tokens.border, radius: Radius.md)
+    }
+
+    // MARK: - Expense list grouped by day
+
+    private func expenseList(filtered: [LocalExpense]) -> some View {
+        let groups = groupedByDay(filtered)
+        return VStack(spacing: Space.lg) {
+            ForEach(groups, id: \.day) { group in
+                VStack(alignment: .leading, spacing: Space.sm) {
+                    HStack {
+                        Text(dayHeader(for: group.day))
+                            .eyebrow()
+                        Spacer()
+                        Text(FinanceDashboardBand.formatSGD(group.total))
+                            .font(.edFootnote)
+                            .monospacedDigit()
+                            .foregroundStyle(Tokens.muted)
+                    }
+                    VStack(spacing: Space.xs) {
+                        ForEach(group.rows) { row in
+                            ExpenseRow(expense: row) {
+                                editingTarget = .existing(row.clientUUID)
+                            }
+                            .swipeToDeleteTrash {
+                                pendingDelete = row
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private struct DailyGroup {
+        let day: Date
+        let total: Double
+        let rows: [LocalExpense]
+    }
+
+    private func groupedByDay(_ rows: [LocalExpense]) -> [DailyGroup] {
+        let cal = Calendar.current
+        let dict = Dictionary(grouping: rows) { cal.startOfDay(for: $0.date) }
+        return dict.keys.sorted(by: >).map { day in
+            let dayRows = dict[day] ?? []
+            let total = dayRows.reduce(0) { $0 + $1.sgdAmount }
+            return DailyGroup(day: day, total: total, rows: dayRows)
+        }
+    }
+
+    private func dayHeader(for day: Date) -> String {
+        let cal = Calendar.current
+        if cal.isDateInToday(day) { return "Today" }
+        if cal.isDateInYesterday(day) { return "Yesterday" }
+
+        let formatter = DateFormatter()
+        let sameYear = cal.component(.year, from: day) == cal.component(.year, from: Date())
+        formatter.dateFormat = sameYear ? "EEE d MMM" : "EEE d MMM yyyy"
+        return formatter.string(from: day)
+    }
+
+    // MARK: - Empty states
+
+    private var emptyState: some View {
+        VStack(spacing: Space.md) {
+            Spacer()
+            Image(systemName: "dollarsign.circle")
+                .font(.system(size: 28, weight: .regular))
+                .foregroundStyle(Tokens.muted)
+            Text("No expenses yet")
+                .font(.edHeading)
+                .foregroundStyle(Tokens.ink)
+                .multilineTextAlignment(.center)
+            Text("Tap the + button to log your first expense, or say \"I spent $20 on lunch\" in chat.")
+                .font(.edSubheadline)
+                .foregroundStyle(Tokens.muted)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Space.xl)
+            Spacer()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, Space.lg)
+    }
+
+    private var noResultsState: some View {
+        VStack(spacing: Space.sm) {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 22, weight: .regular))
+                .foregroundStyle(Tokens.muted)
+            Text("No expenses match these filters")
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .multilineTextAlignment(.center)
+            Button("Reset filters") {
+                filterState.categories.removeAll()
+                filterState.sources.removeAll()
+                filterState.datePreset = .thisMonth
+                searchText = ""
+            }
+            .font(.edFootnote)
+            .foregroundStyle(Tokens.accentFinance)
+            .padding(.top, Space.xs)
+        }
+        .padding(.horizontal, Space.xl)
+    }
+
+    // MARK: - Filtering + stats
+
+    private var filteredExpenses: [LocalExpense] {
+        let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let filter = filterState.resolvedFilter(searchText: trimmed.isEmpty ? nil : trimmed)
+        return allExpenses.filter { matches($0, filter: filter) }
+    }
+
+    /// In-view filter matcher. Mirrors `ExpenseService.matches` but inlined
+    /// so we don't fetch through the service when SwiftData already gave
+    /// us the array via `@Query`.
+    private func matches(_ expense: LocalExpense, filter: ExpenseFilter) -> Bool {
+        if let range = filter.dateRange {
+            if !range.contains(expense.date) { return false }
+        }
+        if let categories = filter.categories, !categories.isEmpty {
+            if !categories.contains(expense.categoryEnum) { return false }
+        }
+        if let sources = filter.sources, !sources.isEmpty {
+            if !sources.contains(expense.sourceEnum) { return false }
+        }
+        if let search = filter.searchText?.lowercased(), !search.isEmpty {
+            let merchant = expense.merchant?.lowercased() ?? ""
+            let description = expense.expenseDescription?.lowercased() ?? ""
+            if !merchant.contains(search) && !description.contains(search) {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Stats for the dashboard band. Always uses the FULL expense set
+    /// (not the filtered list) so the band always reflects "your real
+    /// finances" — filters only narrow the list below.
+    private func computeStats() -> FinanceDashboardStats {
+        let cal = Calendar.current
+        let now = Date()
+        let (monthStart, monthEnd) = ExpenseDateRanges.monthBounds(for: now)
+        let prev = cal.date(byAdding: .month, value: -1, to: now) ?? now
+        let (prevStart, prevEnd) = ExpenseDateRanges.monthBounds(for: prev)
+
+        let monthRows = allExpenses.filter { $0.date >= monthStart && $0.date <= monthEnd }
+        let prevRows = allExpenses.filter { $0.date >= prevStart && $0.date <= prevEnd }
+
+        let monthTotal = monthRows.reduce(0) { $0 + $1.sgdAmount }
+        let prevTotal = prevRows.reduce(0) { $0 + $1.sgdAmount }
+
+        var byCategory: [ExpenseCategory: Double] = [:]
+        for row in monthRows {
+            byCategory[row.categoryEnum, default: 0] += row.sgdAmount
+        }
+        let topCategories = byCategory
+            .sorted { $0.value > $1.value }
+            .prefix(3)
+            .map { (category: $0.key, total: $0.value) }
+
+        // Daily totals for last 30 days inclusive.
+        let endOfToday = cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: now))?
+            .addingTimeInterval(-1) ?? now
+        let startSpark = cal.date(byAdding: .day, value: -29, to: cal.startOfDay(for: now)) ?? now
+        let recent30 = allExpenses.filter { $0.date >= startSpark && $0.date <= endOfToday }
+        var dailyDict: [Date: Double] = [:]
+        for row in recent30 {
+            let day = cal.startOfDay(for: row.date)
+            dailyDict[day, default: 0] += row.sgdAmount
+        }
+        var dailyTotals: [(date: Date, total: Double)] = []
+        for offset in 0..<30 {
+            if let day = cal.date(byAdding: .day, value: offset, to: startSpark) {
+                dailyTotals.append((day, dailyDict[day] ?? 0))
+            }
+        }
+
+        return FinanceDashboardStats(
+            monthTotal: monthTotal,
+            previousMonthTotal: prevTotal,
+            topCategories: topCategories,
+            dailyTotals: dailyTotals
+        )
+    }
+
+    // MARK: - Delete confirmation
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(
+            get: { pendingDelete != nil },
+            set: { newValue in if !newValue { pendingDelete = nil } }
+        )
+    }
+
+    private func confirmationMessage(for expense: LocalExpense) -> String {
+        let label = expense.merchant?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? expense.expenseDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? expense.categoryEnum.displayName
+        let amount = FinanceDashboardBand.formatSGD(expense.sgdAmount)
+        return "\(label) · \(amount)"
+    }
+
+    private func delete(_ expense: LocalExpense) {
+        // Receipt file is the expense's only off-row dependency, so its
+        // lifecycle is tied to the row. Clean up first, then the row —
+        // if the file delete fails (read-only volume, etc.) we still
+        // proceed with the SwiftData delete; the orphaned file is a
+        // bytes-wasted nuisance, not a correctness bug.
+        if let path = expense.receiptImagePath {
+            try? ReceiptStorage.shared.delete(relativePath: path)
+        }
+        modelContext.delete(expense)
+        try? modelContext.save()
     }
 }

--- a/mobile/PersonalDashboard/Views/Finance/PDFPicker.swift
+++ b/mobile/PersonalDashboard/Views/Finance/PDFPicker.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// `.fileImporter` wrapper for PDF receipts. Modelled as a ViewModifier so
+/// FinanceView drives it from a `Binding<Bool>` matching the camera and
+/// photo-library flags.
+///
+/// Reads the file with security-scoped resource access (required because
+/// the user picks from Files / iCloud Drive, which is outside the app's
+/// sandbox). Hands `Data` to `onPick`; nil on cancel or read failure.
+struct PDFPickerModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let onPick: (Data?) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .fileImporter(
+                isPresented: $isPresented,
+                allowedContentTypes: [.pdf],
+                allowsMultipleSelection: false
+            ) { result in
+                switch result {
+                case .success(let urls):
+                    guard let url = urls.first else {
+                        onPick(nil)
+                        return
+                    }
+                    onPick(Self.readSecurely(from: url))
+                case .failure:
+                    onPick(nil)
+                }
+            }
+    }
+
+    /// Read a security-scoped URL into memory. iOS gates Files/iCloud reads
+    /// behind `startAccessingSecurityScopedResource()`; skipping it returns
+    /// "operation not permitted" on physical devices.
+    private static func readSecurely(from url: URL) -> Data? {
+        let needsRelease = url.startAccessingSecurityScopedResource()
+        defer {
+            if needsRelease { url.stopAccessingSecurityScopedResource() }
+        }
+        return try? Data(contentsOf: url)
+    }
+}
+
+extension View {
+    /// Present the system file picker constrained to PDFs. Returns the raw
+    /// PDF `Data` or nil on cancel/failure.
+    func pdfPicker(
+        isPresented: Binding<Bool>,
+        onPick: @escaping (Data?) -> Void
+    ) -> some View {
+        modifier(PDFPickerModifier(isPresented: isPresented, onPick: onPick))
+    }
+}

--- a/mobile/PersonalDashboard/Views/Finance/PhotoLibraryPicker.swift
+++ b/mobile/PersonalDashboard/Views/Finance/PhotoLibraryPicker.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import PhotosUI
+
+/// `PhotosPicker` wrapper, modelled as a `.photosPicker(isPresented:)`
+/// modifier so FinanceView can drive it from a `@State` flag the same way
+/// it drives the camera and PDF pickers.
+///
+/// Loads the selected image as raw `Data` via `loadTransferable(type:)`
+/// and hands it to `onPick`. `nil` if the user cancels or the load fails.
+///
+/// Constrained to one image because the AddExpenseSheet only persists a
+/// single receipt path per expense. Multi-receipt is deferred.
+struct PhotoLibraryPickerModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let onPick: (Data?) -> Void
+
+    @State private var selection: PhotosPickerItem?
+
+    func body(content: Content) -> some View {
+        content
+            .photosPicker(
+                isPresented: $isPresented,
+                selection: $selection,
+                matching: .images,
+                photoLibrary: .shared()
+            )
+            .onChange(of: selection) { _, newValue in
+                guard let item = newValue else { return }
+                Task {
+                    let data: Data? = (try? await item.loadTransferable(type: Data.self)) ?? nil
+                    // Clear so re-selecting the same photo still re-fires
+                    // .onChange next time.
+                    await MainActor.run {
+                        selection = nil
+                        onPick(data)
+                    }
+                }
+            }
+    }
+}
+
+extension View {
+    /// Present the system photo picker constrained to a single image. The
+    /// closure receives the JPEG/HEIC `Data` or nil on cancel/failure.
+    func photoLibraryPicker(
+        isPresented: Binding<Bool>,
+        onPick: @escaping (Data?) -> Void
+    ) -> some View {
+        modifier(PhotoLibraryPickerModifier(isPresented: isPresented, onPick: onPick))
+    }
+}

--- a/mobile/PersonalDashboard/Views/Finance/PrefilledExpense.swift
+++ b/mobile/PersonalDashboard/Views/Finance/PrefilledExpense.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Pre-filled values handed to `AddExpenseSheet` when the user enters via
+/// the scan-receipt / photo / PDF flow. The sheet seeds its fields from
+/// this struct instead of either loading from SwiftData or starting blank.
+///
+/// `extractionError` is non-nil when the receipt was saved but Vision
+/// failed — the sheet shows an inline banner telling the user to fill in
+/// the details. `confidence` is informational; the UI shows a subtle hint
+/// when it's `.low` so the user double-checks the amount.
+struct PrefilledExpense: Hashable {
+    /// Path stored on the resulting expense (`"receipts/<uuid>.<ext>"`).
+    /// Always present — we save the file before Vision is even called.
+    let receiptImagePath: String
+
+    /// What channel produced this. `.photo` for library, `.receipt` for
+    /// camera, `.pdf` for Files.
+    let source: ExpenseSource
+
+    /// Whether Vision returned something usable. False -> banner +
+    /// `extractionError` text.
+    let extractionSucceeded: Bool
+
+    /// User-facing error message when extraction failed. Drives the
+    /// inline banner inside the sheet header.
+    let extractionError: String?
+
+    /// Self-reported model confidence. Surfaced as a small hint when low.
+    let confidence: ExtractedExpense.Confidence?
+
+    // MARK: - Extracted fields (any may be nil)
+
+    let amount: Double?
+    let currency: String?
+    let category: ExpenseCategory?
+    let date: Date?
+    let merchant: String?
+    let descriptionText: String?
+
+    // MARK: - Constructors
+
+    /// Successful extraction → seed every field that the model gave us.
+    static func fromExtraction(
+        _ extracted: ExtractedExpense,
+        receiptImagePath: String,
+        source: ExpenseSource
+    ) -> PrefilledExpense {
+        let parsedDate: Date? = {
+            guard let raw = extracted.date else { return nil }
+            let formatter = DateFormatter()
+            formatter.calendar = Calendar(identifier: .iso8601)
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = "yyyy-MM-dd"
+            return formatter.date(from: raw)
+        }()
+
+        let descriptionText: String? = {
+            guard let items = extracted.items, !items.isEmpty else { return nil }
+            return items.prefix(6).joined(separator: ", ")
+        }()
+
+        return PrefilledExpense(
+            receiptImagePath: receiptImagePath,
+            source: source,
+            extractionSucceeded: true,
+            extractionError: nil,
+            confidence: extracted.confidence,
+            amount: extracted.totalAmount,
+            currency: extracted.currency,
+            category: ExpenseCategory.matching(displayName: extracted.category),
+            date: parsedDate,
+            merchant: extracted.merchant,
+            descriptionText: descriptionText
+        )
+    }
+
+    /// Vision failed → carry only the receipt + the error message.
+    static func fromFailure(
+        receiptImagePath: String,
+        source: ExpenseSource,
+        message: String
+    ) -> PrefilledExpense {
+        PrefilledExpense(
+            receiptImagePath: receiptImagePath,
+            source: source,
+            extractionSucceeded: false,
+            extractionError: message,
+            confidence: nil,
+            amount: nil,
+            currency: nil,
+            category: nil,
+            date: nil,
+            merchant: nil,
+            descriptionText: nil
+        )
+    }
+}

--- a/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
+++ b/mobile/PersonalDashboard/Views/Shell/SideDrawer.swift
@@ -114,11 +114,10 @@ struct SideDrawer: View {
             // Six rows: Today, Itineraries, Finance, Vocabulary, Help center,
             // Settings. Primary surfaces (Notes, Lists, Tasks, Activity) and
             // Chat live in the bottom tab bar. Dashboard remains hidden
-            // (issue #30). Finance sits directly below Itineraries as a
-            // placeholder with a "Coming soon" pill (issue #110).
+            // (issue #30).
             DrawerRow(section: .today, router: router)
             DrawerRow(section: .itineraries, router: router)
-            DrawerRow(section: .finance, router: router, badge: "Coming soon")
+            DrawerRow(section: .finance, router: router)
             DrawerRow(section: .vocabulary, router: router)
             DrawerRow(section: .helpCenter, router: router)
             DrawerRow(section: .settings, router: router)

--- a/mobile/PersonalDashboardUITests/FinanceMenuUITest.swift
+++ b/mobile/PersonalDashboardUITests/FinanceMenuUITest.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+final class FinanceMenuUITest: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func test_finance_plus_button_shows_capture_menu() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        sleep(2)
+        attach(name: "01-landing")
+
+        let hamburger = app.buttons["Open navigation"]
+        XCTAssertTrue(hamburger.waitForExistence(timeout: 10), "Hamburger menu not found")
+        hamburger.tap()
+        sleep(1)
+        attach(name: "02-drawer-open")
+
+        let financeRow = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'Finance'")).firstMatch
+        XCTAssertTrue(financeRow.waitForExistence(timeout: 5), "Finance row not found in drawer")
+        financeRow.tap()
+        sleep(1)
+        attach(name: "03-finance-page")
+
+        let addExpense = app.buttons["Add expense"]
+        XCTAssertTrue(addExpense.waitForExistence(timeout: 5), "Add expense (+) FAB not found")
+        addExpense.tap()
+        sleep(1)
+        attach(name: "04-menu-open")
+    }
+
+    private func attach(name: String) {
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.lifetime = .keepAlways
+        attachment.name = name
+        add(attachment)
+    }
+}

--- a/mobile/ota/manifest.template.plist
+++ b/mobile/ota/manifest.template.plist
@@ -20,6 +20,8 @@
                 <string>com.akshaysharma.personaldashboard</string>
                 <key>bundle-version</key>
                 <string>__BUNDLE_VERSION__</string>
+                <key>bundle-short-version-string</key>
+                <string>__BUNDLE_SHORT_VERSION__</string>
                 <key>kind</key>
                 <string>software</string>
                 <key>title</key>

--- a/mobile/ota/ship-lan.sh
+++ b/mobile/ota/ship-lan.sh
@@ -172,9 +172,27 @@ PROFILE_EXPIRY="$(security cms -D -i "${ARCHIVE_PATH}/Products/Applications/Pers
     | plutil -extract ExpirationDate raw - 2>/dev/null | cut -d'T' -f1 || echo "unknown")"
 
 # ---- Start local HTTP server (will be reverse-proxied by cloudflared) ----
+#
+# Custom server (NOT `python3 -m http.server`) — Apple's OTA install spec
+# REQUIRES manifest.plist to be served with Content-Type: application/xml.
+# The default SimpleHTTPRequestHandler returns application/octet-stream for
+# .plist, which causes iOS to silently fail the install (200 OK fetch but no
+# plist parse, no IPA download, no upgrade). The "blue dot" appears but the
+# binary on disk never changes.
 echo "-> starting HTTP server on :${PORT}"
 cd "${OTA_DIR}"
-python3 -m http.server "${PORT}" --bind 127.0.0.1 >"${OTA_DIR}/http.log" 2>&1 &
+python3 - "${PORT}" >"${OTA_DIR}/http.log" 2>&1 <<'PYEOF' &
+import http.server, socketserver, sys
+class H(http.server.SimpleHTTPRequestHandler):
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        '.plist': 'application/xml',
+        '.ipa':   'application/octet-stream',
+    }
+port = int(sys.argv[1])
+with socketserver.TCPServer(('127.0.0.1', port), H) as srv:
+    srv.serve_forever()
+PYEOF
 HTTP_PID=$!
 
 # ---- Cloudflare quick tunnel for the install page ----
@@ -206,7 +224,8 @@ IPA_URL="${TUNNEL_URL}/app.ipa"
 MANIFEST_URL="${TUNNEL_URL}/manifest.plist"
 
 sed -e "s|__IPA_URL__|${IPA_URL}|g" \
-    -e "s|__BUNDLE_VERSION__|${SHORT_VERSION}|g" \
+    -e "s|__BUNDLE_VERSION__|${BUNDLE_VERSION}|g" \
+    -e "s|__BUNDLE_SHORT_VERSION__|${SHORT_VERSION}|g" \
     "${SCRIPT_DIR}/manifest.template.plist" > "${OTA_DIR}/manifest.plist"
 
 sed -e "s|__MANIFEST_URL__|${MANIFEST_URL}|g" \

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -57,6 +57,10 @@ targets:
         # Microphone for the audio capture that feeds it.
         NSSpeechRecognitionUsageDescription: "Dexter transcribes your voice into chat messages on-device. Audio never leaves your phone."
         NSMicrophoneUsageDescription: "Dexter listens to your voice so it can transcribe what you say into the chat."
+        # Receipt capture for Finance (issue #114, Phase B). Camera + photo
+        # library access used by AddExpense flow to extract details via Vision.
+        NSCameraUsageDescription: "Used to capture receipts so Dexter can log expenses for you."
+        NSPhotoLibraryUsageDescription: "Used to import a receipt photo when logging an expense."
         UIAppFonts:
           - Calistoga-Regular.ttf
           - Inter-Regular.ttf
@@ -77,3 +81,30 @@ targets:
         # Local Xcode-only builds (Cmd+R) inherit these as-is.
         MARKETING_VERSION: "0.1.0"
         CURRENT_PROJECT_VERSION: "1"
+
+  PersonalDashboardUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources:
+      - path: PersonalDashboardUITests
+    dependencies:
+      - target: PersonalDashboard
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.akshaysharma.personaldashboard.uitests
+        TEST_TARGET_NAME: PersonalDashboard
+        DEVELOPMENT_TEAM: "PJFPUSSNUW"
+        CODE_SIGN_STYLE: Automatic
+        SWIFT_VERSION: "5.0"
+        TARGETED_DEVICE_FAMILY: "1"
+
+schemes:
+  PersonalDashboard:
+    build:
+      targets:
+        PersonalDashboard: all
+        PersonalDashboardUITests: [test]
+    test:
+      gatherCoverageData: false
+      targets:
+        - PersonalDashboardUITests


### PR DESCRIPTION
## Summary

Finance tab goes from placeholder to a working expense tracker. Capture
expenses four ways: manual, natural language, photo of receipt, PDF of
receipt. Camera/photo/PDF runs through Anthropic Vision to prefill the
form. Multi-currency with SGD base and frozen FX rate per expense.
Dashboard band on top with month total, vs-last-month delta, top-3
categories and a 30-day sparkline. Filter chips and grouped list below.

Closes #114

## What landed

**Phase A — core tracking**
- LocalExpense + LocalFXRate SwiftData models, 12 SG-tuned categories
- ExpenseService (CRUD + analytics), FXService (daily cache, no-key
  fawazahmed/currency-api after exchangerate.host went paid)
- Dashboard band, filter chips, grouped list, search, empty state
- AddExpenseSheet (new / edit / prefilled), floating + FAB
- `add_expense` AI tool wired into both capture and chat flows

**Phase B — receipt vision**
- Menu on the FAB: Scan / Photo / PDF / Manual
- Camera + photo library + PDF pickers (security-scoped URL handling)
- AnthropicClient.extractExpense for image and PDF (uses
  `anthropic-beta: pdfs-2024-09-25` for documents)
- ReceiptStorage always downsizes to 1600px JPEG 75% and reuses the
  same compressed blob for disk save AND Vision (keeps base64 under
  Anthropic's 5MB cap)
- Prefilled flow with receipt thumbnail, "Remove image" action,
  inline banner on extraction failure

**OTA install fixes (ship-lan.sh)**
- manifest.plist `bundle-version` now uses CFBundleVersion integer
  (was the marketing string)
- python3 http.server replaced with a 10-line custom server that
  sets Content-Type: application/xml for `.plist` (default
  octet-stream made iOS silently fail the OTA install)

**Test infra**
- New PersonalDashboardUITests target with FinanceMenuUITest that
  walks the drawer → Finance → + flow and screenshots each step

## Test plan

- [x] Static build: `xcodegen generate` + `xcodebuild` clean
- [x] UI test: drawer → Finance → + menu opens with all four options
- [x] Manual expense (SGD + non-SGD) saves and shows frozen FX rate
- [x] Photo / camera / PDF picker each open the Anthropic Vision flow
- [x] Vision extraction prefills merchant / amount / currency /
      category / date on a real receipt (Vietnamese VND receipt)
- [x] VND → SGD conversion works (fawazahmed provider)
- [x] Receipt thumbnail renders, "Remove image" works
- [x] Dashboard totals + delta + top-3 categories + sparkline render
- [x] Filter chips and search narrow the list
- [x] Swipe-to-delete removes the row AND its receipt file
- [x] Side drawer "Coming soon" badge removed
- [x] Build on device (devicectl) — confirmed working
- [ ] OTA install from cellular bumps build number (regression test
      for the bundle-version + MIME fixes)

## Out of scope

Recurring bills (#115) — separate ticket, depends on this PR merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)