### PR TITLE
feat(ios): export and import all app data from Settings

### DIFF
--- a/mobile/PersonalDashboard/Services/DataArchive.swift
+++ b/mobile/PersonalDashboard/Services/DataArchive.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// Wire format for the export / import archive.
+///
+/// Keep these DTOs decoupled from `@Model` classes so future SwiftData schema
+/// changes don't force a manifest schema bump. The `schemaVersion` on
+/// `DexterArchive` is the contract — bump it when the wire format breaks
+/// backwards compatibility, and teach the importer the new version.
+enum DataArchive {
+    /// Bumped on any breaking change to the manifest shape. The importer
+    /// rejects unknown versions with a user-readable error rather than
+    /// guessing.
+    static let currentSchemaVersion = 1
+
+    /// Top-level envelope written as `manifest.json`.
+    struct Manifest: Codable {
+        var schemaVersion: Int
+        var exportedAt: Date
+        var appVersion: String
+        var data: Payload
+    }
+
+    struct Payload: Codable {
+        var tasks: [TaskDTO]
+        var notes: [NoteDTO]
+        var noteFolders: [NoteFolderDTO]
+        var lists: [ListDTO]
+        var listItems: [ListItemDTO]
+        var itineraries: [ItineraryDTO]
+        var itineraryDays: [ItineraryDayDTO]
+        var expenses: [ExpenseDTO]
+        var vocab: [VocabDTO]
+
+        static let empty = Payload(
+            tasks: [], notes: [], noteFolders: [],
+            lists: [], listItems: [],
+            itineraries: [], itineraryDays: [],
+            expenses: [], vocab: []
+        )
+    }
+
+    // MARK: - Entity DTOs
+
+    struct TaskDTO: Codable {
+        let clientUUID: UUID
+        let title: String
+        let description: String?
+        let completed: Bool
+        let dueDate: Date?
+        let tag: String?
+        let position: Int?
+        let createdAt: Date
+        let updatedAt: Date
+        let deletedAt: Date?
+    }
+
+    struct NoteDTO: Codable {
+        let clientUUID: UUID
+        let folderClientUUID: UUID?
+        let title: String?
+        let content: String?
+        let position: Int?
+        let createdAt: Date
+        let updatedAt: Date
+        let deletedAt: Date?
+    }
+
+    struct NoteFolderDTO: Codable {
+        let clientUUID: UUID
+        let name: String
+        let position: Int?
+        let createdAt: Date
+        let updatedAt: Date
+        let deletedAt: Date?
+    }
+
+    struct ListDTO: Codable {
+        let clientUUID: UUID
+        let title: String
+        let position: Int?
+        let createdAt: Date
+        let updatedAt: Date
+        let deletedAt: Date?
+    }
+
+    /// Lists store their checklist items as a JSON blob inside the
+    /// `LocalList` model. We flatten them out into separate DTOs in the
+    /// archive so the wire format reads like a normalised dump rather
+    /// than nesting opaque blobs. The importer re-attaches them by
+    /// `listClientUUID` and preserves order via `position`.
+    struct ListItemDTO: Codable {
+        let listClientUUID: UUID
+        let position: Int
+        let text: String
+        let checked: Bool
+    }
+
+    struct ItineraryDTO: Codable {
+        let clientUUID: UUID
+        let name: String
+        let startDate: Date
+        let endDate: Date
+        let notes: String
+        let createdAt: Date
+        let updatedAt: Date
+    }
+
+    /// "Itinerary day" in the manifest is a single timeline item on a trip
+    /// day — matches `LocalItineraryItem`. The plural shape mirrors the
+    /// language used on the ticket; this is the entity that holds the
+    /// per-day rows on a trip's timeline.
+    struct ItineraryDayDTO: Codable {
+        let clientUUID: UUID
+        let tripClientUUID: UUID
+        let dayDate: Date
+        let kind: String
+        let title: String
+        let notes: String
+        let startTime: Date?
+        let endDate: Date?
+        let endTime: Date?
+        let sortOrder: Int
+        let createdAt: Date
+        let updatedAt: Date
+    }
+
+    struct ExpenseDTO: Codable {
+        let clientUUID: String
+        let date: Date
+        let category: String
+        let merchant: String?
+        let expenseDescription: String?
+        let originalAmount: Double
+        let originalCurrency: String
+        let sgdAmount: Double
+        let fxRate: Double
+        let paymentMethod: String?
+        let receiptImagePath: String?
+        let source: String
+        let createdAt: Date
+    }
+
+    struct VocabDTO: Codable {
+        let clientUUID: UUID
+        let term: String
+        let notes: String
+        let createdAt: Date
+        let updatedAt: Date
+    }
+
+    // MARK: - Encoder / Decoder
+
+    /// Manifest JSON uses ISO-8601 dates (with fractional seconds) so the
+    /// archive is human-readable and survives non-Apple consumers.
+    static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}

--- a/mobile/PersonalDashboard/Services/DataExportService.swift
+++ b/mobile/PersonalDashboard/Services/DataExportService.swift
@@ -1,0 +1,250 @@
+import Foundation
+import SwiftData
+
+/// Builds a `.zip` archive containing every entity in the SwiftData store
+/// plus on-disk receipt images. Single entry point: `export(context:)`.
+///
+/// The output file is written to the system temp directory. Caller owns
+/// presenting it via the share sheet and deleting it afterwards (the OS
+/// will clean up the tmp dir eventually anyway).
+@MainActor
+final class DataExportService {
+
+    enum ExportError: LocalizedError {
+        case manifestEncodingFailed(Error)
+        case archiveWriteFailed(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .manifestEncodingFailed(let e): return "Couldn't encode manifest: \(e.localizedDescription)"
+            case .archiveWriteFailed(let e):     return "Couldn't write archive: \(e.localizedDescription)"
+            }
+        }
+    }
+
+    private let modelContext: ModelContext
+    private let receiptStorage: ReceiptStorage
+
+    init(modelContext: ModelContext, receiptStorage: ReceiptStorage = .shared) {
+        self.modelContext = modelContext
+        self.receiptStorage = receiptStorage
+    }
+
+    /// Build the archive and return its on-disk URL. Filename follows
+    /// `dexter-export-YYYY-MM-DD.zip`.
+    func export() throws -> URL {
+        let payload = try buildPayload()
+        let manifest = DataArchive.Manifest(
+            schemaVersion: DataArchive.currentSchemaVersion,
+            exportedAt: Date(),
+            appVersion: Self.appVersion,
+            data: payload
+        )
+
+        let manifestData: Data
+        do {
+            manifestData = try DataArchive.makeEncoder().encode(manifest)
+        } catch {
+            throw ExportError.manifestEncodingFailed(error)
+        }
+
+        var entries: [MiniZip.Entry] = [
+            MiniZip.Entry(name: "manifest.json", data: manifestData)
+        ]
+        entries.append(contentsOf: collectReceiptEntries(for: payload.expenses))
+
+        let url = Self.outputURL()
+        do {
+            try MiniZip.write(entries: entries, to: url)
+        } catch {
+            throw ExportError.archiveWriteFailed(error)
+        }
+        return url
+    }
+
+    // MARK: - Payload assembly
+
+    private func buildPayload() throws -> DataArchive.Payload {
+        let todos       = try modelContext.fetch(FetchDescriptor<LocalTodo>())
+        let notes       = try modelContext.fetch(FetchDescriptor<LocalNote>())
+        let folders     = try modelContext.fetch(FetchDescriptor<LocalNoteFolder>())
+        let lists       = try modelContext.fetch(FetchDescriptor<LocalList>())
+        let trips       = try modelContext.fetch(FetchDescriptor<LocalTrip>())
+        let itineraryItems = try modelContext.fetch(FetchDescriptor<LocalItineraryItem>())
+        let expenses    = try modelContext.fetch(FetchDescriptor<LocalExpense>())
+        let vocab       = try modelContext.fetch(FetchDescriptor<LocalKeyword>())
+
+        var listItems: [DataArchive.ListItemDTO] = []
+        for list in lists {
+            for (idx, item) in list.items.enumerated() {
+                listItems.append(DataArchive.ListItemDTO(
+                    listClientUUID: list.clientUUID,
+                    position: idx,
+                    text: item.text,
+                    checked: item.checked
+                ))
+            }
+        }
+
+        return DataArchive.Payload(
+            tasks: todos.map(Self.dto),
+            notes: notes.map(Self.dto),
+            noteFolders: folders.map(Self.dto),
+            lists: lists.map(Self.dto),
+            listItems: listItems,
+            itineraries: trips.map(Self.dto),
+            itineraryDays: itineraryItems.map(Self.dto),
+            expenses: expenses.map(Self.dto),
+            vocab: vocab.map(Self.dto)
+        )
+    }
+
+    /// Collect receipt files referenced by expenses. Missing files are
+    /// silently skipped — the importer treats a missing receipt the same
+    /// way the existing app does, namely the expense row still appears
+    /// but the thumbnail falls back to the empty state.
+    private func collectReceiptEntries(for expenses: [DataArchive.ExpenseDTO]) -> [MiniZip.Entry] {
+        var entries: [MiniZip.Entry] = []
+        var seenPaths = Set<String>()
+        for expense in expenses {
+            guard let relativePath = expense.receiptImagePath,
+                  !relativePath.isEmpty,
+                  seenPaths.insert(relativePath).inserted else { continue }
+            guard let url = receiptStorage.load(relativePath: relativePath),
+                  let data = try? Data(contentsOf: url) else { continue }
+            // `relativePath` is already "receipts/<uuid>.<ext>" so it maps
+            // 1:1 onto an archive entry path. Keep the same shape on the
+            // importer side so restored files land back in the right
+            // Documents subdirectory.
+            entries.append(MiniZip.Entry(name: relativePath, data: data))
+        }
+        return entries
+    }
+
+    // MARK: - DTO mapping
+
+    private static func dto(_ todo: LocalTodo) -> DataArchive.TaskDTO {
+        DataArchive.TaskDTO(
+            clientUUID: todo.clientUUID,
+            title: todo.title,
+            description: todo.todoDescription,
+            completed: todo.completed,
+            dueDate: todo.dueDate,
+            tag: todo.tag,
+            position: todo.position,
+            createdAt: todo.createdAt,
+            updatedAt: todo.updatedAt,
+            deletedAt: todo.deletedAt
+        )
+    }
+
+    private static func dto(_ note: LocalNote) -> DataArchive.NoteDTO {
+        DataArchive.NoteDTO(
+            clientUUID: note.clientUUID,
+            folderClientUUID: note.folderClientUUID,
+            title: note.title,
+            content: note.content,
+            position: note.position,
+            createdAt: note.createdAt,
+            updatedAt: note.updatedAt,
+            deletedAt: note.deletedAt
+        )
+    }
+
+    private static func dto(_ folder: LocalNoteFolder) -> DataArchive.NoteFolderDTO {
+        DataArchive.NoteFolderDTO(
+            clientUUID: folder.clientUUID,
+            name: folder.name,
+            position: folder.position,
+            createdAt: folder.createdAt,
+            updatedAt: folder.updatedAt,
+            deletedAt: folder.deletedAt
+        )
+    }
+
+    private static func dto(_ list: LocalList) -> DataArchive.ListDTO {
+        DataArchive.ListDTO(
+            clientUUID: list.clientUUID,
+            title: list.title,
+            position: list.position,
+            createdAt: list.createdAt,
+            updatedAt: list.updatedAt,
+            deletedAt: list.deletedAt
+        )
+    }
+
+    private static func dto(_ trip: LocalTrip) -> DataArchive.ItineraryDTO {
+        DataArchive.ItineraryDTO(
+            clientUUID: trip.clientUUID,
+            name: trip.name,
+            startDate: trip.startDate,
+            endDate: trip.endDate,
+            notes: trip.notes,
+            createdAt: trip.createdAt,
+            updatedAt: trip.updatedAt
+        )
+    }
+
+    private static func dto(_ item: LocalItineraryItem) -> DataArchive.ItineraryDayDTO {
+        DataArchive.ItineraryDayDTO(
+            clientUUID: item.clientUUID,
+            tripClientUUID: item.tripUUID,
+            dayDate: item.dayDate,
+            kind: item.kind,
+            title: item.title,
+            notes: item.notes,
+            startTime: item.startTime,
+            endDate: item.endDate,
+            endTime: item.endTime,
+            sortOrder: item.sortOrder,
+            createdAt: item.createdAt,
+            updatedAt: item.updatedAt
+        )
+    }
+
+    private static func dto(_ expense: LocalExpense) -> DataArchive.ExpenseDTO {
+        DataArchive.ExpenseDTO(
+            clientUUID: expense.clientUUID,
+            date: expense.date,
+            category: expense.category,
+            merchant: expense.merchant,
+            expenseDescription: expense.expenseDescription,
+            originalAmount: expense.originalAmount,
+            originalCurrency: expense.originalCurrency,
+            sgdAmount: expense.sgdAmount,
+            fxRate: expense.fxRate,
+            paymentMethod: expense.paymentMethod,
+            receiptImagePath: expense.receiptImagePath,
+            source: expense.source,
+            createdAt: expense.createdAt
+        )
+    }
+
+    private static func dto(_ keyword: LocalKeyword) -> DataArchive.VocabDTO {
+        DataArchive.VocabDTO(
+            clientUUID: keyword.clientUUID,
+            term: keyword.term,
+            notes: keyword.notes,
+            createdAt: keyword.createdAt,
+            updatedAt: keyword.updatedAt
+        )
+    }
+
+    // MARK: - Output URL / version helpers
+
+    private static func outputURL() -> URL {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        let filename = "dexter-export-\(formatter.string(from: Date())).zip"
+        return FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+    }
+
+    private static var appVersion: String {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        let build = info?["CFBundleVersion"] as? String ?? "0"
+        return "\(short) (\(build))"
+    }
+}

--- a/mobile/PersonalDashboard/Services/DataImportService.swift
+++ b/mobile/PersonalDashboard/Services/DataImportService.swift
@@ -1,0 +1,389 @@
+import Foundation
+import SwiftData
+
+/// Reads a `.zip` exported by `DataExportService` and merges it into the
+/// local store by `clientUUID`. Existing UUIDs are skipped, new UUIDs
+/// inserted. Receipt files for new expenses get restored to
+/// `Documents/receipts/<uuid>.<ext>`. Re-importing the same archive is a
+/// clean no-op.
+///
+/// Use it in two steps:
+///   1. `preview(url:)` parses + counts so the UI can show the user what
+///      will change before they commit.
+///   2. `commit(preview:)` writes the new rows + receipt files.
+///
+/// Splitting the two avoids surprise mutations from a malformed archive
+/// and lets the preview screen render counts without holding any locks.
+@MainActor
+final class DataImportService {
+
+    enum ImportError: LocalizedError {
+        case unreadable(Error)
+        case zipFailure(MiniZip.ReadError)
+        case manifestMissing
+        case manifestUnparseable(Error)
+        case unsupportedSchemaVersion(found: Int, supported: Int)
+        case commitFailed(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .unreadable(let e):
+                return "Couldn't read the file: \(e.localizedDescription)"
+            case .zipFailure(let e):
+                return e.errorDescription ?? "Couldn't read the ZIP archive."
+            case .manifestMissing:
+                return "The archive is missing manifest.json. It doesn't look like a Dexter export."
+            case .manifestUnparseable(let e):
+                return "The manifest couldn't be parsed: \(e.localizedDescription)"
+            case .unsupportedSchemaVersion(let found, let supported):
+                return "This archive uses schema version \(found), but this app supports version \(supported). Update the app to import it."
+            case .commitFailed(let e):
+                return "Couldn't save imported data: \(e.localizedDescription)"
+            }
+        }
+    }
+
+    /// Per-entity counts shown on the preview screen.
+    struct EntityCounts: Equatable {
+        var total: Int
+        var new: Int
+        var skipped: Int
+
+        static let zero = EntityCounts(total: 0, new: 0, skipped: 0)
+    }
+
+    /// Snapshot of what an import would change. Hand back to `commit(...)`
+    /// to actually mutate the store.
+    struct Preview {
+        let manifest: DataArchive.Manifest
+        let archiveURL: URL
+        let entries: [String: Data]      // path -> bytes (for receipts)
+        let counts: [Entity: EntityCounts]
+
+        var totalNew: Int {
+            Entity.allCases.reduce(0) { $0 + (counts[$1]?.new ?? 0) }
+        }
+        var hasAnythingToImport: Bool { totalNew > 0 }
+    }
+
+    /// Display-order entities for the preview. Matches the order the
+    /// user sees in the side drawer.
+    enum Entity: String, CaseIterable, Hashable, Identifiable {
+        case tasks
+        case notes
+        case noteFolders
+        case lists
+        case itineraries
+        case itineraryDays
+        case expenses
+        case vocab
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .tasks:         return "Tasks"
+            case .notes:         return "Notes"
+            case .noteFolders:   return "Note folders"
+            case .lists:         return "Lists"
+            case .itineraries:   return "Itineraries"
+            case .itineraryDays: return "Itinerary items"
+            case .expenses:      return "Expenses"
+            case .vocab:         return "Vocabulary"
+            }
+        }
+
+        var icon: String {
+            switch self {
+            case .tasks:         return "checkmark.square"
+            case .notes:         return "doc.text"
+            case .noteFolders:   return "folder"
+            case .lists:         return "list.bullet"
+            case .itineraries:   return "airplane"
+            case .itineraryDays: return "mappin.and.ellipse"
+            case .expenses:      return "dollarsign.circle"
+            case .vocab:         return "character.book.closed"
+            }
+        }
+    }
+
+    private let modelContext: ModelContext
+    private let receiptStorage: ReceiptStorage
+
+    init(modelContext: ModelContext, receiptStorage: ReceiptStorage = .shared) {
+        self.modelContext = modelContext
+        self.receiptStorage = receiptStorage
+    }
+
+    // MARK: - Preview
+
+    func preview(url: URL) throws -> Preview {
+        // Security-scoped resources: iOS hands the document picker a URL
+        // outside the app sandbox; without start/stop access the read
+        // fails silently. The export-side path lives in our own temp dir
+        // and won't need this — but `startAccessingSecurityScopedResource`
+        // is safe to call either way (returns false on non-scoped URLs).
+        let didStartScope = url.startAccessingSecurityScopedResource()
+        defer { if didStartScope { url.stopAccessingSecurityScopedResource() } }
+
+        let entries: [MiniZip.Entry]
+        do {
+            entries = try MiniZip.read(from: url)
+        } catch let error as MiniZip.ReadError {
+            throw ImportError.zipFailure(error)
+        } catch {
+            throw ImportError.unreadable(error)
+        }
+
+        var byPath: [String: Data] = [:]
+        for entry in entries { byPath[entry.name] = entry.data }
+
+        guard let manifestData = byPath["manifest.json"] else {
+            throw ImportError.manifestMissing
+        }
+
+        let manifest: DataArchive.Manifest
+        do {
+            manifest = try DataArchive.makeDecoder().decode(DataArchive.Manifest.self, from: manifestData)
+        } catch {
+            throw ImportError.manifestUnparseable(error)
+        }
+
+        guard manifest.schemaVersion == DataArchive.currentSchemaVersion else {
+            throw ImportError.unsupportedSchemaVersion(
+                found: manifest.schemaVersion,
+                supported: DataArchive.currentSchemaVersion
+            )
+        }
+
+        let counts = try computeCounts(payload: manifest.data)
+        return Preview(
+            manifest: manifest,
+            archiveURL: url,
+            entries: byPath,
+            counts: counts
+        )
+    }
+
+    private func computeCounts(payload: DataArchive.Payload) throws -> [Entity: EntityCounts] {
+        let existingTodoUUIDs       = try existingUUIDs(LocalTodo.self,           keyPath: \.clientUUID)
+        let existingNoteUUIDs       = try existingUUIDs(LocalNote.self,           keyPath: \.clientUUID)
+        let existingFolderUUIDs     = try existingUUIDs(LocalNoteFolder.self,     keyPath: \.clientUUID)
+        let existingListUUIDs       = try existingUUIDs(LocalList.self,           keyPath: \.clientUUID)
+        let existingTripUUIDs       = try existingUUIDs(LocalTrip.self,           keyPath: \.clientUUID)
+        let existingItineraryUUIDs  = try existingUUIDs(LocalItineraryItem.self,  keyPath: \.clientUUID)
+        let existingExpenseUUIDs    = try existingStringUUIDs(LocalExpense.self,  keyPath: \.clientUUID)
+        let existingVocabUUIDs      = try existingUUIDs(LocalKeyword.self,        keyPath: \.clientUUID)
+
+        return [
+            .tasks:         counts(payload.tasks.map(\.clientUUID),         existing: existingTodoUUIDs),
+            .notes:         counts(payload.notes.map(\.clientUUID),         existing: existingNoteUUIDs),
+            .noteFolders:   counts(payload.noteFolders.map(\.clientUUID),   existing: existingFolderUUIDs),
+            .lists:         counts(payload.lists.map(\.clientUUID),         existing: existingListUUIDs),
+            .itineraries:   counts(payload.itineraries.map(\.clientUUID),   existing: existingTripUUIDs),
+            .itineraryDays: counts(payload.itineraryDays.map(\.clientUUID), existing: existingItineraryUUIDs),
+            .expenses:      counts(payload.expenses.map(\.clientUUID),      existing: existingExpenseUUIDs),
+            .vocab:         counts(payload.vocab.map(\.clientUUID),         existing: existingVocabUUIDs),
+        ]
+    }
+
+    private func counts<ID: Hashable>(_ incoming: [ID], existing: Set<ID>) -> EntityCounts {
+        var new = 0
+        for id in incoming where !existing.contains(id) { new += 1 }
+        return EntityCounts(total: incoming.count, new: new, skipped: incoming.count - new)
+    }
+
+    private func existingUUIDs<M: PersistentModel>(_ model: M.Type, keyPath: KeyPath<M, UUID>) throws -> Set<UUID> {
+        let rows = try modelContext.fetch(FetchDescriptor<M>())
+        return Set(rows.map { $0[keyPath: keyPath] })
+    }
+
+    private func existingStringUUIDs<M: PersistentModel>(_ model: M.Type, keyPath: KeyPath<M, String>) throws -> Set<String> {
+        let rows = try modelContext.fetch(FetchDescriptor<M>())
+        return Set(rows.map { $0[keyPath: keyPath] })
+    }
+
+    // MARK: - Commit
+
+    /// Applies the preview's changes. Receipt files get written to disk
+    /// inside the same transaction window; if the SwiftData save fails,
+    /// the receipts written so far are rolled back so re-running the
+    /// import after the error is still a clean no-op for the rows that
+    /// did succeed.
+    func commit(preview: Preview) throws {
+        // Resolve existing UUIDs once up front. A second `fetch` after we
+        // start `insert`ing would include the new rows.
+        let existingTodoUUIDs       = try existingUUIDs(LocalTodo.self,           keyPath: \.clientUUID)
+        let existingNoteUUIDs       = try existingUUIDs(LocalNote.self,           keyPath: \.clientUUID)
+        let existingFolderUUIDs     = try existingUUIDs(LocalNoteFolder.self,     keyPath: \.clientUUID)
+        let existingListUUIDs       = try existingUUIDs(LocalList.self,           keyPath: \.clientUUID)
+        let existingTripUUIDs       = try existingUUIDs(LocalTrip.self,           keyPath: \.clientUUID)
+        let existingItineraryUUIDs  = try existingUUIDs(LocalItineraryItem.self,  keyPath: \.clientUUID)
+        let existingExpenseUUIDs    = try existingStringUUIDs(LocalExpense.self,  keyPath: \.clientUUID)
+        let existingVocabUUIDs      = try existingUUIDs(LocalKeyword.self,        keyPath: \.clientUUID)
+
+        let payload = preview.manifest.data
+        var writtenReceiptPaths: [String] = []
+
+        do {
+            for dto in payload.noteFolders where !existingFolderUUIDs.contains(dto.clientUUID) {
+                modelContext.insert(LocalNoteFolder(
+                    clientUUID: dto.clientUUID,
+                    name: dto.name,
+                    position: dto.position,
+                    createdAt: dto.createdAt,
+                    updatedAt: dto.updatedAt,
+                    deletedAt: dto.deletedAt,
+                    needsSync: false
+                ))
+            }
+
+            for dto in payload.tasks where !existingTodoUUIDs.contains(dto.clientUUID) {
+                modelContext.insert(LocalTodo(
+                    clientUUID: dto.clientUUID,
+                    title: dto.title,
+                    todoDescription: dto.description,
+                    completed: dto.completed,
+                    dueDate: dto.dueDate,
+                    tag: dto.tag,
+                    position: dto.position,
+                    createdAt: dto.createdAt,
+                    updatedAt: dto.updatedAt,
+                    deletedAt: dto.deletedAt,
+                    needsSync: false
+                ))
+            }
+
+            for dto in payload.notes where !existingNoteUUIDs.contains(dto.clientUUID) {
+                modelContext.insert(LocalNote(
+                    clientUUID: dto.clientUUID,
+                    folderClientUUID: dto.folderClientUUID,
+                    title: dto.title,
+                    content: dto.content,
+                    position: dto.position,
+                    createdAt: dto.createdAt,
+                    updatedAt: dto.updatedAt,
+                    deletedAt: dto.deletedAt,
+                    needsSync: false
+                ))
+            }
+
+            // Lists: re-attach list items by `listClientUUID` and preserve
+            // order via `position`. We only attach items for lists that
+            // are being newly inserted; lists that already exist keep
+            // their on-device items as-is (skip semantics).
+            let itemsByList: [UUID: [DataArchive.ListItemDTO]] = Dictionary(grouping: payload.listItems, by: \.listClientUUID)
+            for dto in payload.lists where !existingListUUIDs.contains(dto.clientUUID) {
+                let rawItems = (itemsByList[dto.clientUUID] ?? []).sorted { $0.position < $1.position }
+                let items = rawItems.map { ChecklistItem(text: $0.text, checked: $0.checked) }
+                modelContext.insert(LocalList(
+                    clientUUID: dto.clientUUID,
+                    title: dto.title,
+                    items: items,
+                    position: dto.position,
+                    createdAt: dto.createdAt,
+                    updatedAt: dto.updatedAt,
+                    deletedAt: dto.deletedAt,
+                    needsSync: false
+                ))
+            }
+
+            for dto in payload.itineraries where !existingTripUUIDs.contains(dto.clientUUID) {
+                modelContext.insert(LocalTrip(
+                    clientUUID: dto.clientUUID,
+                    name: dto.name,
+                    startDate: dto.startDate,
+                    endDate: dto.endDate,
+                    notes: dto.notes,
+                    createdAt: dto.createdAt,
+                    updatedAt: dto.updatedAt
+                ))
+            }
+
+            for dto in payload.itineraryDays where !existingItineraryUUIDs.contains(dto.clientUUID) {
+                let kind = ItineraryKind(rawValue: dto.kind) ?? .activity
+                modelContext.insert(LocalItineraryItem(
+                    clientUUID: dto.clientUUID,
+                    tripUUID: dto.tripClientUUID,
+                    dayDate: dto.dayDate,
+                    kind: kind,
+                    title: dto.title,
+                    notes: dto.notes,
+                    startTime: dto.startTime,
+                    endDate: dto.endDate,
+                    endTime: dto.endTime,
+                    sortOrder: dto.sortOrder,
+                    createdAt: dto.createdAt,
+                    updatedAt: dto.updatedAt
+                ))
+            }
+
+            for dto in payload.expenses where !existingExpenseUUIDs.contains(dto.clientUUID) {
+                let restoredPath = try restoreReceipt(for: dto, archiveEntries: preview.entries)
+                if let restoredPath { writtenReceiptPaths.append(restoredPath) }
+
+                modelContext.insert(LocalExpense(
+                    clientUUID: dto.clientUUID,
+                    date: dto.date,
+                    category: dto.category,
+                    merchant: dto.merchant,
+                    expenseDescription: dto.expenseDescription,
+                    originalAmount: dto.originalAmount,
+                    originalCurrency: dto.originalCurrency,
+                    sgdAmount: dto.sgdAmount,
+                    fxRate: dto.fxRate,
+                    paymentMethod: dto.paymentMethod,
+                    receiptImagePath: restoredPath ?? dto.receiptImagePath,
+                    source: dto.source,
+                    createdAt: dto.createdAt,
+                    needsSync: false,
+                    version: 0
+                ))
+            }
+
+            for dto in payload.vocab where !existingVocabUUIDs.contains(dto.clientUUID) {
+                modelContext.insert(LocalKeyword(
+                    clientUUID: dto.clientUUID,
+                    term: dto.term,
+                    notes: dto.notes,
+                    createdAt: dto.createdAt,
+                    updatedAt: dto.updatedAt
+                ))
+            }
+
+            try modelContext.save()
+            Haptics.light()
+        } catch {
+            modelContext.rollback()
+            for path in writtenReceiptPaths {
+                try? receiptStorage.delete(relativePath: path)
+            }
+            throw ImportError.commitFailed(error)
+        }
+    }
+
+    /// Restore a receipt's image bytes from the archive. Returns the
+    /// relative path now persisted on disk (e.g. `"receipts/<uuid>.jpg"`)
+    /// or `nil` if the archive didn't include the file. We honour the
+    /// stored relative path exactly so the round-trip is byte-identical:
+    /// the same path that was on `LocalExpense.receiptImagePath` at
+    /// export time is what we write back. If a different file already
+    /// occupies that path on this device (e.g. user ran the importer
+    /// after a partial reset), the existing file wins — receipts are
+    /// content-addressed by UUID, collisions on the same UUID mean the
+    /// same logical image.
+    private func restoreReceipt(
+        for expense: DataArchive.ExpenseDTO,
+        archiveEntries: [String: Data]
+    ) throws -> String? {
+        guard let relativePath = expense.receiptImagePath,
+              !relativePath.isEmpty,
+              let archivedData = archiveEntries[relativePath] else {
+            return nil
+        }
+        if receiptStorage.load(relativePath: relativePath) != nil {
+            return relativePath
+        }
+        return try receiptStorage.write(data: archivedData, relativePath: relativePath)
+    }
+}

--- a/mobile/PersonalDashboard/Services/MiniZip.swift
+++ b/mobile/PersonalDashboard/Services/MiniZip.swift
@@ -1,0 +1,318 @@
+import Foundation
+
+/// Pure-Swift ZIP reader/writer used by data export/import. Implements the
+/// "store" method only — no DEFLATE — which keeps this file dependency-free
+/// (no zlib, no SPM packages) at the cost of zero compression. Receipt JPEGs
+/// are already compressed and the manifest JSON is tiny, so store-mode is
+/// a fine fit.
+///
+/// File format reference: APPNOTE.TXT §4 (PKWARE ZIP).
+/// What's supported:
+///   - Single-file or many-file archives
+///   - UTF-8 filenames (sets bit 11 of the general-purpose flag)
+///   - CRC-32 over the uncompressed payload
+///   - End-of-central-directory record discovery via tail scan
+/// What's NOT supported (and we explicitly reject on read):
+///   - Zip64 (4 GB+ archives)
+///   - DEFLATE / any non-store compression method
+///   - Encryption
+///   - Multi-disk archives
+///
+/// Archives written here open cleanly in Finder, iOS Files, `unzip`, and
+/// `ditto -xk`. Archives read here accept anything other tools produce so
+/// long as it sticks to store-mode + UTF-8 filenames.
+enum MiniZip {
+
+    // MARK: - Errors
+
+    enum ReadError: LocalizedError {
+        case notAZipArchive
+        case truncated
+        case unsupportedCompression(method: UInt16, entry: String)
+        case unsupportedZip64
+        case unsupportedEncryption(entry: String)
+        case crcMismatch(entry: String)
+        case duplicateEntry(name: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notAZipArchive:                  return "The selected file isn't a ZIP archive."
+            case .truncated:                       return "The archive looks truncated."
+            case .unsupportedCompression(_, let e): return "Entry \(e) uses a compression method this importer doesn't support."
+            case .unsupportedZip64:                return "Zip64 archives aren't supported."
+            case .unsupportedEncryption(let e):    return "Entry \(e) is encrypted, which isn't supported."
+            case .crcMismatch(let e):              return "Entry \(e) failed its CRC check (file is corrupt)."
+            case .duplicateEntry(let n):           return "Archive has two entries called \(n)."
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    /// One uncompressed entry inside an archive.
+    struct Entry {
+        let name: String
+        let data: Data
+    }
+
+    /// Build a ZIP archive from a list of entries and write it to `url`.
+    /// Caller decides directory layout via the entry names (e.g. include
+    /// `"receipts/<uuid>.jpg"` to land the receipt in a subdirectory).
+    static func write(entries: [Entry], to url: URL) throws {
+        var archive = Data()
+        var central = Data()
+        var entryCount: UInt16 = 0
+        let dosTime = DOSTimestamp.now()
+
+        for entry in entries {
+            let nameBytes = Array(entry.name.utf8)
+            let crc = CRC32.checksum(of: entry.data)
+            let localHeaderOffset = UInt32(archive.count)
+
+            // Local file header (signature 0x04034b50)
+            archive.append(uint32: 0x04034b50)
+            archive.append(uint16: 20)                   // version needed
+            archive.append(uint16: 0x0800)               // flags: bit 11 (UTF-8 filenames)
+            archive.append(uint16: 0)                    // method: store
+            archive.append(uint16: dosTime.time)
+            archive.append(uint16: dosTime.date)
+            archive.append(uint32: crc)
+            archive.append(uint32: UInt32(entry.data.count)) // compressed size
+            archive.append(uint32: UInt32(entry.data.count)) // uncompressed size
+            archive.append(uint16: UInt16(nameBytes.count))
+            archive.append(uint16: 0)                    // extra field length
+            archive.append(contentsOf: nameBytes)
+            archive.append(entry.data)
+
+            // Central directory header (signature 0x02014b50)
+            central.append(uint32: 0x02014b50)
+            central.append(uint16: 20)                   // version made by
+            central.append(uint16: 20)                   // version needed
+            central.append(uint16: 0x0800)               // flags
+            central.append(uint16: 0)                    // method
+            central.append(uint16: dosTime.time)
+            central.append(uint16: dosTime.date)
+            central.append(uint32: crc)
+            central.append(uint32: UInt32(entry.data.count))
+            central.append(uint32: UInt32(entry.data.count))
+            central.append(uint16: UInt16(nameBytes.count))
+            central.append(uint16: 0)                    // extra field length
+            central.append(uint16: 0)                    // comment length
+            central.append(uint16: 0)                    // disk number
+            central.append(uint16: 0)                    // internal attrs
+            central.append(uint32: 0)                    // external attrs
+            central.append(uint32: localHeaderOffset)
+            central.append(contentsOf: nameBytes)
+
+            entryCount += 1
+        }
+
+        let centralOffset = UInt32(archive.count)
+        archive.append(central)
+
+        // End of central directory record (signature 0x06054b50)
+        archive.append(uint32: 0x06054b50)
+        archive.append(uint16: 0)                        // disk number
+        archive.append(uint16: 0)                        // disk with central dir start
+        archive.append(uint16: entryCount)               // entries on this disk
+        archive.append(uint16: entryCount)               // total entries
+        archive.append(uint32: UInt32(central.count))    // central directory size
+        archive.append(uint32: centralOffset)
+        archive.append(uint16: 0)                        // .ZIP file comment length
+
+        try archive.write(to: url, options: [.atomic])
+    }
+
+    /// Read every entry from a ZIP archive on disk. Throws on any
+    /// unsupported feature (Zip64, encrypted, compressed-but-not-store).
+    static func read(from url: URL) throws -> [Entry] {
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        return try read(data: data)
+    }
+
+    /// Read every entry from a ZIP archive already loaded into memory.
+    static func read(data: Data) throws -> [Entry] {
+        guard data.count >= 22 else { throw ReadError.truncated }
+        let eocd = try findEndOfCentralDirectory(in: data)
+
+        var cdOffset = Int(eocd.centralDirectoryOffset)
+        var entries: [Entry] = []
+        var seenNames = Set<String>()
+
+        for _ in 0..<eocd.entryCount {
+            guard cdOffset + 46 <= data.count else { throw ReadError.truncated }
+            let signature: UInt32 = data.readUInt32(at: cdOffset)
+            guard signature == 0x02014b50 else { throw ReadError.notAZipArchive }
+
+            let flags: UInt16 = data.readUInt16(at: cdOffset + 8)
+            let method: UInt16 = data.readUInt16(at: cdOffset + 10)
+            let crcExpected: UInt32 = data.readUInt32(at: cdOffset + 16)
+            let compressedSize: UInt32 = data.readUInt32(at: cdOffset + 20)
+            let uncompressedSize: UInt32 = data.readUInt32(at: cdOffset + 24)
+            let nameLen: UInt16 = data.readUInt16(at: cdOffset + 28)
+            let extraLen: UInt16 = data.readUInt16(at: cdOffset + 30)
+            let commentLen: UInt16 = data.readUInt16(at: cdOffset + 32)
+            let localHeaderOffset: UInt32 = data.readUInt32(at: cdOffset + 42)
+
+            let nameRange = (cdOffset + 46)..<(cdOffset + 46 + Int(nameLen))
+            guard nameRange.upperBound <= data.count else { throw ReadError.truncated }
+            let name = String(data: data.subdata(in: nameRange), encoding: .utf8)
+                ?? String(data: data.subdata(in: nameRange), encoding: .isoLatin1)
+                ?? "<unnamed>"
+
+            if (flags & 0x0001) != 0 { throw ReadError.unsupportedEncryption(entry: name) }
+            if uncompressedSize == 0xFFFFFFFF || compressedSize == 0xFFFFFFFF || localHeaderOffset == 0xFFFFFFFF {
+                throw ReadError.unsupportedZip64
+            }
+            if method != 0 { throw ReadError.unsupportedCompression(method: method, entry: name) }
+
+            // Skip past directory entries (names ending with "/"). These have
+            // zero-byte payloads and don't need round-tripping for the
+            // importer — the directory tree is implicit in the file paths.
+            let isDirectory = name.hasSuffix("/")
+            if !isDirectory {
+                let payload = try readLocalPayload(
+                    data: data,
+                    localHeaderOffset: Int(localHeaderOffset),
+                    expectedSize: Int(compressedSize),
+                    entryName: name
+                )
+                let actualCRC = CRC32.checksum(of: payload)
+                guard actualCRC == crcExpected else { throw ReadError.crcMismatch(entry: name) }
+                guard seenNames.insert(name).inserted else { throw ReadError.duplicateEntry(name: name) }
+                entries.append(Entry(name: name, data: payload))
+            }
+
+            cdOffset += 46 + Int(nameLen) + Int(extraLen) + Int(commentLen)
+        }
+
+        return entries
+    }
+
+    // MARK: - Internals
+
+    private static func readLocalPayload(
+        data: Data,
+        localHeaderOffset: Int,
+        expectedSize: Int,
+        entryName: String
+    ) throws -> Data {
+        guard localHeaderOffset + 30 <= data.count else { throw ReadError.truncated }
+        let signature: UInt32 = data.readUInt32(at: localHeaderOffset)
+        guard signature == 0x04034b50 else { throw ReadError.notAZipArchive }
+
+        let method: UInt16 = data.readUInt16(at: localHeaderOffset + 8)
+        if method != 0 { throw ReadError.unsupportedCompression(method: method, entry: entryName) }
+
+        let nameLen: UInt16 = data.readUInt16(at: localHeaderOffset + 26)
+        let extraLen: UInt16 = data.readUInt16(at: localHeaderOffset + 28)
+        let payloadStart = localHeaderOffset + 30 + Int(nameLen) + Int(extraLen)
+        let payloadEnd = payloadStart + expectedSize
+        guard payloadEnd <= data.count else { throw ReadError.truncated }
+        return data.subdata(in: payloadStart..<payloadEnd)
+    }
+
+    private struct EOCD {
+        let entryCount: UInt16
+        let centralDirectoryOffset: UInt32
+    }
+
+    /// Locate the End-Of-Central-Directory record. The signature
+    /// `0x06054b50` sits 22..65557 bytes from EOF (22 bytes minimum plus
+    /// up to 65535 bytes of optional archive comment). Scan backwards
+    /// from the tail.
+    private static func findEndOfCentralDirectory(in data: Data) throws -> EOCD {
+        let maxCommentLength = 65535
+        let minRecordSize = 22
+        let scanStart = max(0, data.count - (minRecordSize + maxCommentLength))
+        var index = data.count - minRecordSize
+        while index >= scanStart {
+            if data.readUInt32(at: index) == 0x06054b50 {
+                let entryCount: UInt16 = data.readUInt16(at: index + 10)
+                let centralSize: UInt32 = data.readUInt32(at: index + 12)
+                let centralOffset: UInt32 = data.readUInt32(at: index + 16)
+                if centralOffset == 0xFFFFFFFF || centralSize == 0xFFFFFFFF || entryCount == 0xFFFF {
+                    throw ReadError.unsupportedZip64
+                }
+                return EOCD(entryCount: entryCount, centralDirectoryOffset: centralOffset)
+            }
+            index -= 1
+        }
+        throw ReadError.notAZipArchive
+    }
+}
+
+// MARK: - CRC32
+
+private enum CRC32 {
+    static let table: [UInt32] = {
+        (0..<256).map { i -> UInt32 in
+            var c = UInt32(i)
+            for _ in 0..<8 {
+                c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1
+            }
+            return c
+        }
+    }()
+
+    static func checksum(of data: Data) -> UInt32 {
+        var c: UInt32 = 0xFFFFFFFF
+        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) in
+            guard let base = buffer.baseAddress else { return }
+            for i in 0..<buffer.count {
+                let byte = base.load(fromByteOffset: i, as: UInt8.self)
+                let index = Int((c ^ UInt32(byte)) & 0xFF)
+                c = table[index] ^ (c >> 8)
+            }
+        }
+        return c ^ 0xFFFFFFFF
+    }
+}
+
+// MARK: - Helpers
+
+private struct DOSTimestamp {
+    let date: UInt16
+    let time: UInt16
+
+    static func now() -> DOSTimestamp {
+        let cal = Calendar(identifier: .gregorian)
+        let comps = cal.dateComponents([.year, .month, .day, .hour, .minute, .second], from: Date())
+        let year = max(1980, comps.year ?? 1980)
+        let month = comps.month ?? 1
+        let day = comps.day ?? 1
+        let hour = comps.hour ?? 0
+        let minute = comps.minute ?? 0
+        let second = (comps.second ?? 0) / 2
+
+        let date = UInt16(((year - 1980) << 9) | (month << 5) | day)
+        let time = UInt16((hour << 11) | (minute << 5) | second)
+        return DOSTimestamp(date: date, time: time)
+    }
+}
+
+private extension Data {
+    mutating func append(uint16 value: UInt16) {
+        var v = value.littleEndian
+        Swift.withUnsafeBytes(of: &v) { append(contentsOf: $0) }
+    }
+
+    mutating func append(uint32 value: UInt32) {
+        var v = value.littleEndian
+        Swift.withUnsafeBytes(of: &v) { append(contentsOf: $0) }
+    }
+
+    func readUInt16(at offset: Int) -> UInt16 {
+        let lo = UInt16(self[self.startIndex + offset])
+        let hi = UInt16(self[self.startIndex + offset + 1])
+        return lo | (hi << 8)
+    }
+
+    func readUInt32(at offset: Int) -> UInt32 {
+        let b0 = UInt32(self[self.startIndex + offset])
+        let b1 = UInt32(self[self.startIndex + offset + 1])
+        let b2 = UInt32(self[self.startIndex + offset + 2])
+        let b3 = UInt32(self[self.startIndex + offset + 3])
+        return b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+    }
+}

--- a/mobile/PersonalDashboard/Services/ReceiptStorage.swift
+++ b/mobile/PersonalDashboard/Services/ReceiptStorage.swift
@@ -103,6 +103,32 @@ final class ReceiptStorage {
         try persist(data: pdfData, ext: "pdf")
     }
 
+    /// Restore a previously-exported receipt at its original relative path.
+    /// Used by the data importer to put receipts back in
+    /// `Documents/receipts/<uuid>.<ext>` without picking a new filename.
+    /// Returns the same `relativePath` it was given so callers can store it
+    /// directly onto `LocalExpense.receiptImagePath`.
+    @discardableResult
+    func write(data: Data, relativePath: String) throws -> String {
+        _ = try ensureDirectory()
+        let url: URL
+        do {
+            url = try absoluteURL(for: relativePath)
+        } catch {
+            throw ReceiptStorageError.fileSystem(error)
+        }
+        do {
+            try fileManager.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: [.atomic])
+        } catch {
+            throw ReceiptStorageError.fileSystem(error)
+        }
+        return relativePath
+    }
+
     /// Resolve a stored relative path back to an on-disk URL. Returns nil if
     /// the file no longer exists (e.g. user reinstalled the app).
     func load(relativePath: String) -> URL? {

--- a/mobile/PersonalDashboard/Views/Settings/DataExportImportView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/DataExportImportView.swift
@@ -1,0 +1,535 @@
+import SwiftUI
+import SwiftData
+import UIKit
+import UniformTypeIdentifiers
+
+/// Sheet that hosts export + import in a single surface. Two rows on the
+/// landing page; tapping one drives the corresponding flow.
+///
+/// Export is non-destructive (just builds a file and hands it to the share
+/// sheet), so no confirmation gate. Import goes through a preview screen so
+/// the user can see what will change before committing, but no
+/// type-to-confirm guard — merge by UUID is non-destructive by design.
+struct DataExportImportView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    private enum Phase {
+        case idle
+        case exporting
+        case shareReady(URL)
+        case importing
+        case importPreview(DataImportService.Preview)
+        case importCommitting(DataImportService.Preview)
+        case importSucceeded(newRowCount: Int)
+    }
+
+    @State private var phase: Phase = .idle
+    @State private var errorMessage: String? = nil
+    @State private var showFileImporter: Bool = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                content
+            }
+            .navigationTitle(navigationTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    if showsBackButton {
+                        Button {
+                            withAnimation(.easeOut(duration: 0.18)) {
+                                phase = .idle
+                                errorMessage = nil
+                            }
+                        } label: {
+                            HStack(spacing: Space.xxs) {
+                                Image(systemName: "chevron.left")
+                                Text("Back")
+                            }
+                        }
+                        .foregroundStyle(Tokens.muted)
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Tokens.muted)
+                        .disabled(isBusy)
+                }
+            }
+        }
+        .fileImporter(
+            isPresented: $showFileImporter,
+            allowedContentTypes: [.zip],
+            allowsMultipleSelection: false
+        ) { result in
+            handlePicked(result: result)
+        }
+    }
+
+    private var navigationTitle: String {
+        switch phase {
+        case .importPreview, .importCommitting: return "Import preview"
+        case .importSucceeded:                  return "Import complete"
+        default:                                 return "Export & import"
+        }
+    }
+
+    private var showsBackButton: Bool {
+        switch phase {
+        case .importPreview, .importSucceeded: return true
+        default:                                return false
+        }
+    }
+
+    private var isBusy: Bool {
+        switch phase {
+        case .exporting, .importing, .importCommitting: return true
+        default: return false
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch phase {
+        case .idle, .exporting, .shareReady, .importing:
+            idleScreen
+        case .importPreview(let preview):
+            previewScreen(preview: preview, isCommitting: false)
+        case .importCommitting(let preview):
+            previewScreen(preview: preview, isCommitting: true)
+        case .importSucceeded(let count):
+            successScreen(newRowCount: count)
+        }
+    }
+
+    // MARK: - Idle (landing) screen
+
+    private var idleScreen: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Space.xl) {
+                Text("Save a snapshot of every task, note, list, itinerary, expense, and vocab word on this device. Restore it later on a new install, or seed another phone.")
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.muted)
+                    .padding(.horizontal, Space.xs)
+
+                DataActionsCard {
+                    DataActionRow(
+                        icon: "arrow.up.doc",
+                        label: "Export all data",
+                        sublabel: "Save a .zip you can share or back up.",
+                        trailingState: exportTrailing,
+                        disabled: isBusy
+                    ) {
+                        Task { await performExport() }
+                    }
+
+                    Rectangle()
+                        .fill(Tokens.divider)
+                        .frame(height: 0.5)
+                        .padding(.leading, Space.lg)
+
+                    DataActionRow(
+                        icon: "arrow.down.doc",
+                        label: "Import data",
+                        sublabel: "Merge a Dexter export into this device.",
+                        trailingState: importTrailing,
+                        disabled: isBusy
+                    ) {
+                        showFileImporter = true
+                    }
+                }
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.edFootnote)
+                        .foregroundStyle(Tokens.danger)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(Space.md)
+                        .background(Tokens.dangerSoft, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+                }
+
+                Text("Importing only adds rows whose IDs aren't already on this device. It never overwrites anything you have here.")
+                    .font(.edFootnote)
+                    .foregroundStyle(Tokens.mutedSoft)
+                    .padding(.horizontal, Space.xs)
+
+                Spacer(minLength: Space.xl)
+            }
+            .padding(.horizontal, Space.lg)
+            .padding(.top, Space.lg)
+            .padding(.bottom, 96)
+        }
+    }
+
+    private var exportTrailing: DataActionRow.TrailingState {
+        switch phase {
+        case .exporting: return .progress
+        default:         return .chevron
+        }
+    }
+
+    private var importTrailing: DataActionRow.TrailingState {
+        switch phase {
+        case .importing: return .progress
+        default:         return .chevron
+        }
+    }
+
+    // MARK: - Import preview screen
+
+    private func previewScreen(preview: DataImportService.Preview, isCommitting: Bool) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Space.xl) {
+                VStack(alignment: .leading, spacing: Space.xs) {
+                    Text("From")
+                        .eyebrow()
+                    Text(preview.archiveURL.lastPathComponent)
+                        .font(.edBodyMedium)
+                        .foregroundStyle(Tokens.ink)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                    Text("Exported \(Self.relativeDate(preview.manifest.exportedAt)) · app v\(preview.manifest.appVersion)")
+                        .font(.edFootnote)
+                        .foregroundStyle(Tokens.muted)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(Space.lg)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+                .paperBorder()
+
+                VStack(alignment: .leading, spacing: Space.sm) {
+                    Text("What will be added")
+                        .eyebrow()
+                        .padding(.horizontal, Space.xs)
+
+                    VStack(spacing: 0) {
+                        let entities = DataImportService.Entity.allCases.enumerated().map { ($0, $1) }
+                        ForEach(entities, id: \.1.id) { idx, entity in
+                            PreviewRow(
+                                entity: entity,
+                                counts: preview.counts[entity] ?? .zero
+                            )
+                            if idx < entities.count - 1 {
+                                Rectangle()
+                                    .fill(Tokens.divider)
+                                    .frame(height: 0.5)
+                                    .padding(.leading, Space.lg)
+                            }
+                        }
+                    }
+                    .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+                    .paperBorder()
+                }
+
+                if !preview.hasAnythingToImport {
+                    Text("Everything in this archive is already on this device. Nothing new to add.")
+                        .font(.edFootnote)
+                        .foregroundStyle(Tokens.muted)
+                        .padding(.horizontal, Space.xs)
+                }
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.edFootnote)
+                        .foregroundStyle(Tokens.danger)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(Space.md)
+                        .background(Tokens.dangerSoft, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+                }
+
+                Button(action: { Task { await performImportCommit(preview: preview) } }) {
+                    HStack(spacing: Space.sm) {
+                        if isCommitting {
+                            ProgressView().tint(.white)
+                        }
+                        Text(isCommitting ? "Importing…" : commitButtonLabel(preview: preview))
+                            .font(.edBodyMedium)
+                    }
+                    .foregroundStyle(canCommit(preview: preview) ? Color.white : Tokens.mutedSoft)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 48)
+                    .background(
+                        canCommit(preview: preview) ? Tokens.ink : Tokens.paper2,
+                        in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+                    )
+                }
+                .buttonStyle(.plain)
+                .disabled(!canCommit(preview: preview) || isCommitting)
+
+                Spacer(minLength: Space.xl)
+            }
+            .padding(.horizontal, Space.lg)
+            .padding(.top, Space.lg)
+            .padding(.bottom, 96)
+        }
+    }
+
+    private func canCommit(preview: DataImportService.Preview) -> Bool {
+        preview.hasAnythingToImport
+    }
+
+    private func commitButtonLabel(preview: DataImportService.Preview) -> String {
+        let count = preview.totalNew
+        if count == 0 { return "Nothing to import" }
+        if count == 1 { return "Import 1 new row" }
+        return "Import \(count) new rows"
+    }
+
+    // MARK: - Success screen
+
+    private func successScreen(newRowCount: Int) -> some View {
+        VStack(spacing: Space.lg) {
+            Spacer()
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 56, weight: .regular))
+                .foregroundStyle(Tokens.success)
+            VStack(spacing: Space.xs) {
+                Text(newRowCount == 0 ? "Nothing new to add" : "Import complete")
+                    .font(.edTitle)
+                    .foregroundStyle(Tokens.ink)
+                Text(successDetail(newRowCount: newRowCount))
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.muted)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, Space.xl)
+            }
+            Spacer()
+            Button {
+                dismiss()
+            } label: {
+                Text("Done")
+                    .font(.edBodyMedium)
+                    .foregroundStyle(Color.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 48)
+                    .background(Tokens.ink, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, Space.lg)
+            .padding(.bottom, Space.xl)
+        }
+    }
+
+    private func successDetail(newRowCount: Int) -> String {
+        if newRowCount == 0 {
+            return "Every row in that archive was already on this device."
+        }
+        if newRowCount == 1 {
+            return "Added 1 new row. Existing rows were left untouched."
+        }
+        return "Added \(newRowCount) new rows. Existing rows were left untouched."
+    }
+
+    // MARK: - Actions
+
+    private func performExport() async {
+        errorMessage = nil
+        phase = .exporting
+        let service = DataExportService(modelContext: modelContext)
+        do {
+            let url = try service.export()
+            phase = .shareReady(url)
+            await presentShareSheet(for: url)
+            // Hand back to idle once the share sheet dismisses. The tmp
+            // file stays on disk for the OS to clean up (sharing copies
+            // it into Files / Mail / etc).
+            phase = .idle
+        } catch {
+            phase = .idle
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func handlePicked(result: Result<[URL], Error>) {
+        errorMessage = nil
+        switch result {
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            Task { await performImportPreview(url: url) }
+        }
+    }
+
+    private func performImportPreview(url: URL) async {
+        phase = .importing
+        let service = DataImportService(modelContext: modelContext)
+        do {
+            let preview = try service.preview(url: url)
+            phase = .importPreview(preview)
+        } catch {
+            phase = .idle
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func performImportCommit(preview: DataImportService.Preview) async {
+        errorMessage = nil
+        phase = .importCommitting(preview)
+        let service = DataImportService(modelContext: modelContext)
+        do {
+            try service.commit(preview: preview)
+            phase = .importSucceeded(newRowCount: preview.totalNew)
+        } catch {
+            phase = .importPreview(preview)
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func presentShareSheet(for url: URL) async {
+        guard let topController = topMostViewController() else { return }
+        let activity = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        // The iOS Share sheet doesn't surface a "did dismiss" callback we
+        // can await; use a continuation tied to the completion handler.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            activity.completionWithItemsHandler = { _, _, _, _ in
+                continuation.resume()
+            }
+            // iPad popover anchor — anchored to the topmost view's center
+            // so the popover has somewhere to attach.
+            if let popover = activity.popoverPresentationController {
+                popover.sourceView = topController.view
+                popover.sourceRect = CGRect(
+                    x: topController.view.bounds.midX,
+                    y: topController.view.bounds.midY,
+                    width: 0,
+                    height: 0
+                )
+                popover.permittedArrowDirections = []
+            }
+            topController.present(activity, animated: true)
+        }
+    }
+
+    private func topMostViewController() -> UIViewController? {
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+        guard let root = scene?.keyWindow?.rootViewController else { return nil }
+        var top = root
+        while let presented = top.presentedViewController { top = presented }
+        return top
+    }
+
+    // MARK: - Helpers
+
+    private static func relativeDate(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+// MARK: - Sub-views
+
+private struct DataActionsCard<Content: View>: View {
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(spacing: 0) {
+            content
+        }
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+        .paperBorder()
+    }
+}
+
+private struct DataActionRow: View {
+    enum TrailingState {
+        case chevron
+        case progress
+    }
+
+    let icon: String
+    let label: String
+    let sublabel: String
+    let trailingState: TrailingState
+    let disabled: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: Space.md) {
+                Image(systemName: icon)
+                    .font(.system(size: 17, weight: .regular))
+                    .foregroundStyle(disabled ? Tokens.mutedSoft : Tokens.ink)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                        .font(.edBody)
+                        .foregroundStyle(disabled ? Tokens.mutedSoft : Tokens.ink)
+                    Text(sublabel)
+                        .font(.edFootnote)
+                        .foregroundStyle(Tokens.muted)
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: Space.md)
+
+                switch trailingState {
+                case .chevron:
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundStyle(Tokens.mutedSoft)
+                case .progress:
+                    ProgressView().tint(Tokens.muted)
+                }
+            }
+            .padding(.horizontal, Space.lg)
+            .padding(.vertical, Space.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+    }
+}
+
+private struct PreviewRow: View {
+    let entity: DataImportService.Entity
+    let counts: DataImportService.EntityCounts
+
+    var body: some View {
+        HStack(spacing: Space.md) {
+            Image(systemName: entity.icon)
+                .font(.system(size: 15, weight: .regular))
+                .foregroundStyle(Tokens.muted)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entity.label)
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.ink)
+                Text(detailLine)
+                    .font(.edFootnote)
+                    .foregroundStyle(Tokens.muted)
+            }
+
+            Spacer(minLength: Space.md)
+
+            HStack(spacing: Space.xs) {
+                Text("+\(counts.new)")
+                    .font(.edBodyMedium)
+                    .monospacedDigit()
+                    .foregroundStyle(counts.new > 0 ? Tokens.success : Tokens.mutedSoft)
+            }
+        }
+        .padding(.horizontal, Space.lg)
+        .padding(.vertical, Space.md)
+    }
+
+    private var detailLine: String {
+        if counts.total == 0 { return "0 in file" }
+        return "\(counts.total) in file · \(counts.skipped) already here"
+    }
+}
+
+private extension UIWindowScene {
+    var keyWindow: UIWindow? {
+        windows.first { $0.isKeyWindow } ?? windows.first
+    }
+}

--- a/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
     @Binding var schemePref: ColorSchemePref
 
     @State private var showingResetData: Bool = false
+    @State private var showingDataTransfer: Bool = false
 
     var body: some View {
         ZStack {
@@ -14,6 +15,9 @@ struct SettingsView: View {
         .activeSection(.settings)
         .sheet(isPresented: $showingResetData) {
             ResetDataView()
+        }
+        .sheet(isPresented: $showingDataTransfer) {
+            DataExportImportView()
         }
     }
 
@@ -57,23 +61,48 @@ struct SettingsView: View {
 
     private var dataSection: some View {
         SettingsSection(title: "Data") {
-            Button {
-                showingResetData = true
-            } label: {
-                HStack(alignment: .firstTextBaseline, spacing: Space.md) {
-                    Text("Reset data…")
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.danger)
-                    Spacer(minLength: Space.md)
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 13, weight: .regular))
-                        .foregroundStyle(Tokens.mutedSoft)
+            VStack(spacing: 0) {
+                Button {
+                    showingDataTransfer = true
+                } label: {
+                    HStack(alignment: .firstTextBaseline, spacing: Space.md) {
+                        Text("Export & import…")
+                            .font(.edBody)
+                            .foregroundStyle(Tokens.ink)
+                        Spacer(minLength: Space.md)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .regular))
+                            .foregroundStyle(Tokens.mutedSoft)
+                    }
+                    .padding(.horizontal, Space.lg)
+                    .padding(.vertical, Space.md)
+                    .contentShape(Rectangle())
                 }
-                .padding(.horizontal, Space.lg)
-                .padding(.vertical, Space.md)
-                .contentShape(Rectangle())
+                .buttonStyle(.plain)
+
+                Rectangle()
+                    .fill(Tokens.divider)
+                    .frame(height: 0.5)
+                    .padding(.leading, Space.lg)
+
+                Button {
+                    showingResetData = true
+                } label: {
+                    HStack(alignment: .firstTextBaseline, spacing: Space.md) {
+                        Text("Reset data…")
+                            .font(.edBody)
+                            .foregroundStyle(Tokens.danger)
+                        Spacer(minLength: Space.md)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .regular))
+                            .foregroundStyle(Tokens.mutedSoft)
+                    }
+                    .padding(.horizontal, Space.lg)
+                    .padding(.vertical, Space.md)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
         }
     }
 


### PR DESCRIPTION
## Summary

- New "Data" section on the Settings page with `Export & import…` and the existing `Reset data…` rows. Export builds a single `.zip` of every entity in SwiftData plus on-disk receipt images, then surfaces the iOS Share sheet so the user can save anywhere. Import opens the iOS Document Picker scoped to `.zip`, shows a per-entity preview ("12 new, 312 already here"), then merges by `clientUUID` on confirm. Re-importing the same archive is a clean no-op.
- Wire format is versioned (`schemaVersion: 1`) so future breaks are explicit. Unknown versions get rejected with a user-readable error rather than guessing at migration.
- Packs the zip with a small dependency-free store-mode writer so the project stays SPM-free. CRC32 independently verified against the zlib reference vector (`123456789` → `0xCBF43926`) and the archive round-trips cleanly with `/usr/bin/unzip`.

Closes #118.

## Test plan

- [x] Static build clean for iOS device (`xcodebuild -destination 'generic/platform=iOS' build`)
- [x] Shipped to phone via `build-to-phone` (`devicectl device install`)
- [x] Captured Settings → Data → Export & import sheet → Share sheet → File picker on simulator (screenshots in the linked ticket comment)
- [x] Inspected the produced archive with `/usr/bin/unzip` — `manifest.json` shape and all 9 entity arrays present, `schemaVersion: 1`, ISO-8601 `exportedAt`, correct `appVersion`
- [x] CRC32 verified against the zlib reference vector
- [ ] **On-device walk for round-trip with real data** — see the checklist in https://github.com/akshaydotsharma/Dexter/issues/118#issuecomment-4525027203

QA evidence (screenshots, archive inspection, ticked AC) lives on the ticket comment to keep this PR body short.