### PR TITLE
feat(ios): default notes to rendered markdown everywhere

### DIFF
--- a/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
+++ b/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
@@ -360,10 +360,21 @@ private struct ActivityRow: View {
                         .foregroundStyle(Tokens.ink)
                         .lineLimit(1)
                     if let snippet = item.snippet, !snippet.isEmpty {
-                        Text(snippet)
-                            .font(.edSubheadline)
-                            .foregroundStyle(Tokens.muted)
-                            .lineLimit(1)
+                        // Note snippets carry raw markdown; render inline
+                        // and strip leading block prefixes so the row
+                        // shows the formatted preview, not `## ` or `**`.
+                        // Other types (todo, list) stay plain.
+                        if item.type == .note {
+                            Text(markdownSnippetAttributed(snippet))
+                                .font(.edSubheadline)
+                                .foregroundStyle(Tokens.muted)
+                                .lineLimit(1)
+                        } else {
+                            Text(snippet)
+                                .font(.edSubheadline)
+                                .foregroundStyle(Tokens.muted)
+                                .lineLimit(1)
+                        }
                     }
                     if item.type == .note, let parent = item.parent, !parent.isEmpty {
                         HStack(spacing: 4) {

--- a/mobile/PersonalDashboard/Views/Components/MarkdownView.swift
+++ b/mobile/PersonalDashboard/Views/Components/MarkdownView.swift
@@ -141,6 +141,50 @@ struct MarkdownView: View {
     }
 }
 
+// MARK: - Single-line snippet
+//
+// For rows where we want a one-line preview of markdown body text without
+// the raw syntax bleeding through (`**bold**`, `## Heading`, `- item`).
+// Picks the first non-empty line, strips block-level prefixes, then runs
+// the rest through Foundation's inline markdown parser so inline
+// formatting renders as styled text.
+
+func markdownSnippetAttributed(_ source: String) -> AttributedString {
+    let firstLine = source
+        .components(separatedBy: .newlines)
+        .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
+        ?? source
+    let stripped = stripMarkdownBlockPrefix(firstLine)
+    if let attr = try? AttributedString(
+        markdown: stripped,
+        options: AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace,
+            failurePolicy: .returnPartiallyParsedIfPossible
+        )
+    ) {
+        return attr
+    }
+    return AttributedString(stripped)
+}
+
+private func stripMarkdownBlockPrefix(_ line: String) -> String {
+    var s = line.trimmingCharacters(in: .whitespaces)
+    while s.hasPrefix("#") { s.removeFirst() }
+    s = s.trimmingCharacters(in: .whitespaces)
+    if s.hasPrefix("> ") { s.removeFirst(2) }
+    else if s == ">" { s = "" }
+    if s.hasPrefix("- ") || s.hasPrefix("* ") || s.hasPrefix("+ ") { s.removeFirst(2) }
+    else if let dot = s.firstIndex(of: "."),
+            s[s.startIndex..<dot].allSatisfy({ $0.isNumber }),
+            s.distance(from: s.startIndex, to: dot) >= 1 {
+        let after = s.index(after: dot)
+        if after < s.endIndex, s[after] == " " {
+            s = String(s[s.index(after: after)...])
+        }
+    }
+    return s
+}
+
 // MARK: - Block model
 
 enum MarkdownBlock: Hashable {

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -464,7 +464,7 @@ private struct NoteDetailContent: View {
     @State private var content: String = ""
     @State private var folderId: UUID?
     @State private var hasLoaded = false
-    @State private var mode: NoteEditMode = .edit
+    @State private var mode: NoteEditMode = .preview
     @FocusState private var contentFocused: Bool
 
     enum NoteEditMode { case edit, preview }

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -391,10 +391,17 @@ private struct NoteRow: View {
                     .font(.edBodyMedium)
                     .foregroundStyle(Tokens.ink)
                     .lineLimit(1)
-                Text(hasBody ? trimmedBody : "No additional text")
-                    .font(.edSubheadline)
-                    .foregroundStyle(hasBody ? Tokens.muted : Tokens.mutedSoft)
-                    .lineLimit(1)
+                if hasBody {
+                    Text(NoteRow.snippetAttributed(trimmedBody))
+                        .font(.edSubheadline)
+                        .foregroundStyle(Tokens.muted)
+                        .lineLimit(1)
+                } else {
+                    Text("No additional text")
+                        .font(.edSubheadline)
+                        .foregroundStyle(Tokens.mutedSoft)
+                        .lineLimit(1)
+                }
                 Text(note.updatedAt, style: .relative)
                     .font(.edCaption)
                     .foregroundStyle(Tokens.mutedSoft)
@@ -407,6 +414,50 @@ private struct NoteRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+
+    // Produce a one-line preview of the note body with inline markdown
+    // applied (so `**bold**` renders bold, links lose the URL, etc.) and
+    // block-level prefixes on the first line stripped (`#`, `-`, `>`,
+    // `1.`) so the snippet doesn't lead with `## ` or `- `.
+    fileprivate static func snippetAttributed(_ source: String) -> AttributedString {
+        let firstLine = source
+            .components(separatedBy: .newlines)
+            .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
+            ?? source
+        let stripped = stripBlockPrefix(firstLine)
+        if let attr = try? AttributedString(
+            markdown: stripped,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace,
+                failurePolicy: .returnPartiallyParsedIfPossible
+            )
+        ) {
+            return attr
+        }
+        return AttributedString(stripped)
+    }
+
+    private static func stripBlockPrefix(_ line: String) -> String {
+        var s = line.trimmingCharacters(in: .whitespaces)
+        // Heading hashes (#, ##, ###...)
+        while s.hasPrefix("#") { s.removeFirst() }
+        s = s.trimmingCharacters(in: .whitespaces)
+        // Blockquote
+        if s.hasPrefix("> ") { s.removeFirst(2) }
+        else if s == ">" { s = "" }
+        // Unordered list marker
+        if s.hasPrefix("- ") || s.hasPrefix("* ") || s.hasPrefix("+ ") { s.removeFirst(2) }
+        // Ordered list marker: digits + "." + " "
+        else if let dot = s.firstIndex(of: "."),
+                s[s.startIndex..<dot].allSatisfy({ $0.isNumber }),
+                s.distance(from: s.startIndex, to: dot) >= 1 {
+            let after = s.index(after: dot)
+            if after < s.endIndex, s[after] == " " {
+                s = String(s[s.index(after: after)...])
+            }
+        }
+        return s
     }
 }
 

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -392,7 +392,7 @@ private struct NoteRow: View {
                     .foregroundStyle(Tokens.ink)
                     .lineLimit(1)
                 if hasBody {
-                    Text(NoteRow.snippetAttributed(trimmedBody))
+                    Text(markdownSnippetAttributed(trimmedBody))
                         .font(.edSubheadline)
                         .foregroundStyle(Tokens.muted)
                         .lineLimit(1)
@@ -416,49 +416,6 @@ private struct NoteRow: View {
         .buttonStyle(.plain)
     }
 
-    // Produce a one-line preview of the note body with inline markdown
-    // applied (so `**bold**` renders bold, links lose the URL, etc.) and
-    // block-level prefixes on the first line stripped (`#`, `-`, `>`,
-    // `1.`) so the snippet doesn't lead with `## ` or `- `.
-    fileprivate static func snippetAttributed(_ source: String) -> AttributedString {
-        let firstLine = source
-            .components(separatedBy: .newlines)
-            .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty })
-            ?? source
-        let stripped = stripBlockPrefix(firstLine)
-        if let attr = try? AttributedString(
-            markdown: stripped,
-            options: AttributedString.MarkdownParsingOptions(
-                interpretedSyntax: .inlineOnlyPreservingWhitespace,
-                failurePolicy: .returnPartiallyParsedIfPossible
-            )
-        ) {
-            return attr
-        }
-        return AttributedString(stripped)
-    }
-
-    private static func stripBlockPrefix(_ line: String) -> String {
-        var s = line.trimmingCharacters(in: .whitespaces)
-        // Heading hashes (#, ##, ###...)
-        while s.hasPrefix("#") { s.removeFirst() }
-        s = s.trimmingCharacters(in: .whitespaces)
-        // Blockquote
-        if s.hasPrefix("> ") { s.removeFirst(2) }
-        else if s == ">" { s = "" }
-        // Unordered list marker
-        if s.hasPrefix("- ") || s.hasPrefix("* ") || s.hasPrefix("+ ") { s.removeFirst(2) }
-        // Ordered list marker: digits + "." + " "
-        else if let dot = s.firstIndex(of: "."),
-                s[s.startIndex..<dot].allSatisfy({ $0.isNumber }),
-                s.distance(from: s.startIndex, to: dot) >= 1 {
-            let after = s.index(after: dot)
-            if after < s.endIndex, s[after] == " " {
-                s = String(s[s.index(after: after)...])
-            }
-        }
-        return s
-    }
 }
 
 private struct NewFolderSheet: View {

--- a/mobile/PersonalDashboard/Views/Today/TodayView.swift
+++ b/mobile/PersonalDashboard/Views/Today/TodayView.swift
@@ -347,10 +347,13 @@ private struct TodayNoteRow: View {
         .padding(.vertical, Space.md)
     }
 
-    private var displayTitle: String {
-        if let t = note.title, !t.isEmpty { return t }
-        if let c = note.content, !c.isEmpty { return String(c.prefix(60)) }
-        return "Untitled note"
+    // When the note has no title, fall back to a one-line snippet of the
+    // body with inline markdown rendered and block prefixes stripped so
+    // the row doesn't lead with `## ` or `- `.
+    private var displayTitle: AttributedString {
+        if let t = note.title, !t.isEmpty { return AttributedString(t) }
+        if let c = note.content, !c.isEmpty { return markdownSnippetAttributed(c) }
+        return AttributedString("Untitled note")
     }
 
     private func relativeTime(_ date: Date) -> String {


### PR DESCRIPTION
## Summary
Notes were showing raw markdown (`**bold**`, `## Heading`, `- item`) in several surfaces. This PR makes the rendered/formatted view the default everywhere a note preview appears.

- **Notes list (`NoteRow`)**: body snippet now renders inline markdown and strips block prefixes on the first non-empty line.
- **Note detail (`NoteDetailContent`)**: opens in preview mode by default. Pencil → editor; eye → preview.
- **Activity timeline (`ActivityRow`)**: snippet for `.note` items renders markdown; todo/list snippets stay plain.
- **Today's notes card (`TodayNoteRow`)**: when a note has no title, the body-fallback line is rendered instead of shown raw.
- **Chat draft cards (`ChatResultCard`)**: already used `MarkdownView` for body previews — no change needed.

The snippet helper lives next to `MarkdownView` as a top-level `markdownSnippetAttributed(_:)`. It picks the first non-empty line, strips block-level markers (`#`, `-`, `*`, `+`, `>`, `1.`), then parses inline syntax via Foundation's `AttributedString(markdown: .inlineOnlyPreservingWhitespace)`.

Closes #120

## Test plan
- [ ] **Notes detail**: open an existing note, lands in rendered preview. Tap pencil → editor + keyboard accessory; tap eye → preview, edits persist.
- [ ] **Notes list**: a note with body `## Plan\nDetails` previews as "Plan". A note containing `**urgent**` shows the word bold inline. Empty notes still show "No additional text".
- [ ] **Activity**: create or edit a note with markdown body, switch to Activity. The row's snippet renders inline; no literal `**` / `##` / `- `.
- [ ] **Today's notes card**: a titleless note with markdown body shows the rendered first-line snippet instead of the raw 60-char slice.

Installed to iPhone via ship-lan + devicectl on commits e155c98 → 6357b3d.