### PR TITLE
feat(ios): richer Shortcut capture sheet + Go-to-app deep link

### DIFF
--- a/mobile/PersonalDashboard/App/DeepLinkBus.swift
+++ b/mobile/PersonalDashboard/App/DeepLinkBus.swift
@@ -1,0 +1,24 @@
+import Foundation
+import SwiftUI
+
+/// Single point of contact between deep-link sources (URL scheme, App
+/// Intents) and the app's router. Both `DexterDeepLink.handle(_:router:)`
+/// and `OpenDexterIntent.perform()` write into this bus; the root view
+/// observes it and drains the pending payload into `AppRouter`.
+///
+/// Using a singleton ObservableObject (instead of e.g. NotificationCenter)
+/// keeps the contract typed and lets SwiftUI rerender naturally on
+/// `.onChange(of:)`.
+@MainActor
+final class DeepLinkBus: ObservableObject {
+    static let shared = DeepLinkBus()
+
+    enum Pending: Equatable {
+        case focus(sectionRaw: String, id: UUID?)
+        case activity
+    }
+
+    @Published var pending: Pending?
+
+    private init() {}
+}

--- a/mobile/PersonalDashboard/App/DexterDeepLink.swift
+++ b/mobile/PersonalDashboard/App/DexterDeepLink.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Parser + handler for the `dexter://` URL scheme.
+///
+/// Two routes are supported today:
+///   - `dexter://focus/<section>/<uuid>` — push a section onto the router
+///     stack and stash an `ActivityFocus` so the destination view scrolls /
+///     pulses the matching row.
+///   - `dexter://activity` — open the Activity timeline.
+///
+/// Unknown URLs are logged and ignored — never crash. The Shortcut snippet
+/// view is the primary caller, but the scheme is registered globally so
+/// any future deep-link source (notifications, share sheet, etc.) routes
+/// through the same code path.
+enum DexterDeepLink {
+
+    @MainActor
+    static func handle(_ url: URL, router: AppRouter) {
+        // Accept both authority-style (dexter://focus/...) and path-style
+        // URLs. `URLComponents` normalises both via `host` + `path`.
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              url.scheme?.lowercased() == "dexter" else {
+            log("ignored — wrong scheme", url: url)
+            return
+        }
+
+        let host = components.host?.lowercased() ?? ""
+        // Path begins with "/", strip it before splitting.
+        let pathParts = components.path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+
+        switch host {
+        case "activity":
+            router.go(to: .activity)
+
+        case "focus":
+            // Expected: focus/<section>/<uuid>
+            guard pathParts.count >= 2 else {
+                log("focus missing components", url: url)
+                return
+            }
+            let sectionRaw = pathParts[0].lowercased()
+            let uuidRaw = pathParts[1]
+            guard let section = AppSection(rawValue: sectionRaw) else {
+                log("unknown section '\(sectionRaw)'", url: url)
+                return
+            }
+            guard let id = UUID(uuidString: uuidRaw) else {
+                // No focus to set, but the section itself is still a useful
+                // landing — better than dropping the tap on the floor.
+                log("invalid uuid; opening section without focus", url: url)
+                router.go(to: section)
+                return
+            }
+            router.focus = ActivityFocus(section: section, id: id, isFolder: false)
+            router.go(to: section)
+
+        default:
+            log("unknown host '\(host)'", url: url)
+        }
+    }
+
+    private static func log(_ message: String, url: URL) {
+        #if DEBUG
+        print("[DexterDeepLink] \(message): \(url.absoluteString)")
+        #endif
+    }
+}

--- a/mobile/PersonalDashboard/Info.plist
+++ b/mobile/PersonalDashboard/Info.plist
@@ -20,6 +20,17 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.akshaysharma.personaldashboard.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>dexter</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
@@ -117,9 +117,9 @@ struct CaptureResultSnippetView: View {
         Link(destination: url) {
             HStack(spacing: Space.xs) {
                 Text(deepLinkLabel)
-                    .font(.headline)
+                    .font(.system(size: 15, weight: .semibold))
                 Image(systemName: "arrow.up.right")
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(.system(size: 12, weight: .semibold))
             }
             .foregroundStyle(Color.white)
         }

--- a/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
@@ -5,19 +5,24 @@ import SwiftUI
 ///
 /// The dialog above the snippet already names what was added (e.g.
 /// *"Added task 'Buy milk' — due May 24"* or *"Logged expense 'Cab'"*),
-/// so the snippet stops echoing titles. Its job is to elevate the
-/// "Open in Dexter" CTA and, for multi-action captures, give the user a
-/// quick visual sense of what types of things were touched.
+/// so the snippet stops echoing titles. Its job is to offer a quiet
+/// "Go to app" hyperlink and, for multi-action captures, give the user
+/// a quick visual sense of what types of things were touched.
+///
+/// Design rationale: an actual button (filled, bordered, or otherwise)
+/// reads as a competing CTA next to the system "Done" button that
+/// Shortcuts owns at the bottom of the sheet. A plain hyperlink in
+/// system blue is a soft secondary affordance — it sits below the
+/// dialog without fighting the primary dismissal action.
 ///
 /// Snippet runtime constraints (iOS App Intents):
 ///   - The view runs outside the main app process. Arbitrary `Button(action:)`
 ///     closures are ignored — only `Link(destination:)` reliably hands
 ///     control back to the host app.
 ///   - The snippet has no knowledge of the Shortcuts host appearance and
-///     does NOT reliably inherit it. `Color.primary` and `Material` both
-///     resolve unpredictably — they were producing dark text on dark
-///     chrome. We instead use the Dexter paper/ink tokens as fixed RGB so
-///     the card has its own internal contrast regardless of host theme.
+///     does NOT reliably inherit it. We pick colors that read on both
+///     light and dark chrome (system blue for the link, accent tints
+///     for the type circles).
 ///   - Animations, gestures, and `@Environment` values from the main app
 ///     are not in scope.
 struct CaptureResultSnippetView: View {
@@ -26,38 +31,23 @@ struct CaptureResultSnippetView: View {
     static let maxVisibleCircles: Int = 4
 
     let items: [ExecutedDraft]
-    /// Where the "Open in Dexter" button points. `nil` hides the entire
-    /// card — used for clarification / error / unrecoverable-id cases.
+    /// Where the "Go to app" hyperlink points. `nil` hides the entire
+    /// snippet — used for clarification / error / unrecoverable-id cases.
     let deepLink: URL?
-    /// Label rendered on the deep-link button. Defaults to "Open in Dexter"
-    /// but kept as a parameter to make future variations easy.
+    /// Label rendered on the hyperlink. Defaults to "Go to app" but
+    /// kept as a parameter to make future variations easy.
     let deepLinkLabel: String
 
     var body: some View {
         if let url = deepLink {
-            card(url: url)
+            VStack(alignment: .leading, spacing: Space.sm) {
+                contextRow
+                hyperlink(url: url)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         } else {
             EmptyView()
         }
-    }
-
-    @ViewBuilder
-    private func card(url: URL) -> some View {
-        VStack(alignment: .leading, spacing: Space.sm) {
-            contextRow
-            ctaButton(url: url)
-        }
-        .padding(.horizontal, Space.md)
-        .padding(.vertical, Space.md)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .fill(Tokens.paper)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(Tokens.border, lineWidth: 1)
-        )
     }
 
     // MARK: - Context row
@@ -110,22 +100,21 @@ struct CaptureResultSnippetView: View {
 
     // MARK: - CTA
 
+    /// Plain hyperlink — no button chrome, no card. Reads as a soft
+    /// affordance below the dialog so it doesn't compete visually with
+    /// the system Done button at the bottom of the Shortcuts sheet.
+    /// Uses iOS system blue (set explicitly because snippet views don't
+    /// inherit the host's accent color reliably).
     @ViewBuilder
-    private func ctaButton(url: URL) -> some View {
+    private func hyperlink(url: URL) -> some View {
         Link(destination: url) {
             HStack(spacing: Space.xs) {
                 Text(deepLinkLabel)
-                    .font(.edBody.weight(.semibold))
+                    .font(.edBody.weight(.medium))
                 Image(systemName: "arrow.up.right")
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: 12, weight: .semibold))
             }
-            .foregroundStyle(Tokens.accentFg)
-            .frame(maxWidth: .infinity)
-            .frame(height: 48)
-            .background(
-                RoundedRectangle(cornerRadius: Radius.pill, style: .continuous)
-                    .fill(Tokens.ink)
-            )
+            .foregroundStyle(Color.blue)
         }
     }
 

--- a/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
@@ -27,6 +27,10 @@ struct CaptureResultSnippetView: View {
     let deepLinkLabel: String
 
     var body: some View {
+        // Transparent — sits directly on the Shortcuts result chrome so the
+        // snippet blends with the host bubble instead of stacking another card
+        // on top. Uses system primary/secondary colors so text stays legible
+        // on either light or dark host appearance.
         VStack(alignment: .leading, spacing: Space.md) {
             VStack(alignment: .leading, spacing: Space.sm) {
                 ForEach(Array(visibleRows.enumerated()), id: \.offset) { _, row in
@@ -37,7 +41,7 @@ struct CaptureResultSnippetView: View {
                             .frame(width: 20, alignment: .center)
                         Text(row.label)
                             .font(.edBody)
-                            .foregroundStyle(Tokens.ink)
+                            .foregroundStyle(Color.primary)
                             .lineLimit(2)
                             .truncationMode(.tail)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -47,7 +51,7 @@ struct CaptureResultSnippetView: View {
                 if overflowCount > 0 {
                     Text("+\(overflowCount) more")
                         .font(.edFootnote)
-                        .foregroundStyle(Tokens.muted)
+                        .foregroundStyle(Color.secondary)
                         .padding(.leading, 20 + Space.sm)
                 }
             }
@@ -60,23 +64,20 @@ struct CaptureResultSnippetView: View {
                         Image(systemName: "arrow.up.right")
                             .font(.system(size: 11, weight: .semibold))
                     }
-                    .foregroundStyle(Tokens.accentFg)
+                    // Adapts: white text in light mode, black in dark — the
+                    // inverse of the background, so contrast is preserved
+                    // whichever appearance the Shortcuts host renders in.
+                    .foregroundStyle(Color(.systemBackground))
                     .padding(.horizontal, Space.md)
                     .padding(.vertical, Space.sm)
                     .background(
                         RoundedRectangle(cornerRadius: Radius.pill, style: .continuous)
-                            .fill(Tokens.ink)
+                            .fill(Color.primary)
                     )
                 }
             }
         }
-        .padding(Space.lg)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
-                .fill(Tokens.surface)
-        )
-        .paperBorder()
     }
 
     // MARK: - Row derivation
@@ -111,6 +112,7 @@ struct CaptureResultSnippetView: View {
             case "folder":         return "folder"
             case "trip":           return "suitcase"
             case "itinerary_item": return "airplane"
+            case "expense":        return "creditcard"
             default:               return "sparkles"
             }
         }
@@ -123,7 +125,8 @@ struct CaptureResultSnippetView: View {
             case "folder":         return Tokens.accentNotes
             case "trip",
                  "itinerary_item": return Tokens.accentItineraries
-            default:               return Tokens.ink
+            case "expense":        return Tokens.accentFinance
+            default:               return Color.primary
             }
         }
 
@@ -149,6 +152,7 @@ struct CaptureResultSnippetView: View {
             case "folder":         return "Folder"
             case "trip":           return "Trip"
             case "itinerary_item": return "Itinerary item"
+            case "expense":        return "Expense"
             default:               return "Item"
             }
         }

--- a/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
@@ -1,165 +1,199 @@
 import SwiftUI
 
 /// Rendered next to the dialog in the Shortcuts result sheet after a
-/// `CaptureToDashboardIntent` run. Lists what was applied (icon + title per
-/// row, grouped visually by the dialog string above) and offers a single
-/// deep-link back into the app.
+/// `CaptureToDashboardIntent` run.
+///
+/// The dialog above the snippet already names what was added (e.g.
+/// *"Added task 'Buy milk' — due May 24"* or *"Logged expense 'Cab'"*),
+/// so the snippet stops echoing titles. Its job is to elevate the
+/// "Open in Dexter" CTA and, for multi-action captures, give the user a
+/// quick visual sense of what types of things were touched.
 ///
 /// Snippet runtime constraints (iOS App Intents):
 ///   - The view runs outside the main app process. Arbitrary `Button(action:)`
-///     closures are ignored — only `Link(destination:)` reliably hands control
-///     back to the host app.
-///   - Animations, gestures, and `@Environment` values from the main app are
-///     not in scope. Stick to static layout (`VStack`, `HStack`, `Text`,
-///     `Image(systemName:)`) plus `Link`.
-///   - Tokens (colours, spacing, fonts) are reused from the main app design
-///     system so the result sheet matches the in-app surfaces.
+///     closures are ignored — only `Link(destination:)` reliably hands
+///     control back to the host app.
+///   - The snippet has no knowledge of the Shortcuts host appearance and
+///     does NOT reliably inherit it. `Color.primary` and `Material` both
+///     resolve unpredictably — they were producing dark text on dark
+///     chrome. We instead use the Dexter paper/ink tokens as fixed RGB so
+///     the card has its own internal contrast regardless of host theme.
+///   - Animations, gestures, and `@Environment` values from the main app
+///     are not in scope.
 struct CaptureResultSnippetView: View {
-    /// Up to N rows shown explicitly; the rest are summarised as "+N more".
-    static let maxVisibleRows: Int = 3
+    /// Up to N circles shown explicitly in the multi-action row; the rest
+    /// collapse into a `+N` chip.
+    static let maxVisibleCircles: Int = 4
 
     let items: [ExecutedDraft]
-    /// Where the "Open in Dexter" button points. `nil` hides the button —
-    /// used for clarification / error cases and for unrecoverable id parses.
+    /// Where the "Open in Dexter" button points. `nil` hides the entire
+    /// card — used for clarification / error / unrecoverable-id cases.
     let deepLink: URL?
-    /// Label rendered on the deep-link button. Always "Open in Dexter" today,
-    /// kept as a parameter to make future variations (e.g. "Open list") easy.
+    /// Label rendered on the deep-link button. Defaults to "Open in Dexter"
+    /// but kept as a parameter to make future variations easy.
     let deepLinkLabel: String
 
     var body: some View {
-        // Transparent — sits directly on the Shortcuts result chrome so the
-        // snippet blends with the host bubble instead of stacking another card
-        // on top. Uses system primary/secondary colors so text stays legible
-        // on either light or dark host appearance.
-        VStack(alignment: .leading, spacing: Space.md) {
-            VStack(alignment: .leading, spacing: Space.sm) {
-                ForEach(Array(visibleRows.enumerated()), id: \.offset) { _, row in
-                    HStack(alignment: .firstTextBaseline, spacing: Space.sm) {
-                        Image(systemName: row.symbol)
-                            .font(.system(size: 15, weight: .regular))
-                            .foregroundStyle(row.tint)
-                            .frame(width: 20, alignment: .center)
-                        Text(row.label)
-                            .font(.edBody)
-                            .foregroundStyle(Color.primary)
-                            .lineLimit(2)
-                            .truncationMode(.tail)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                }
-
-                if overflowCount > 0 {
-                    Text("+\(overflowCount) more")
-                        .font(.edFootnote)
-                        .foregroundStyle(Color.secondary)
-                        .padding(.leading, 20 + Space.sm)
-                }
-            }
-
-            if let url = deepLink {
-                Link(destination: url) {
-                    HStack(spacing: Space.xs) {
-                        Text(deepLinkLabel)
-                            .font(.edFootnote)
-                        Image(systemName: "arrow.up.right")
-                            .font(.system(size: 11, weight: .semibold))
-                    }
-                    // Adapts: white text in light mode, black in dark — the
-                    // inverse of the background, so contrast is preserved
-                    // whichever appearance the Shortcuts host renders in.
-                    .foregroundStyle(Color(.systemBackground))
-                    .padding(.horizontal, Space.md)
-                    .padding(.vertical, Space.sm)
-                    .background(
-                        RoundedRectangle(cornerRadius: Radius.pill, style: .continuous)
-                            .fill(Color.primary)
-                    )
-                }
-            }
+        if let url = deepLink {
+            card(url: url)
+        } else {
+            EmptyView()
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    // MARK: - Row derivation
+    @ViewBuilder
+    private func card(url: URL) -> some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            contextRow
+            ctaButton(url: url)
+        }
+        .padding(.horizontal, Space.md)
+        .padding(.vertical, Space.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Tokens.paper)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(Tokens.border, lineWidth: 1)
+        )
+    }
 
-    private var visibleRows: [Row] {
-        items.prefix(Self.maxVisibleRows).map(Row.init(executed:))
+    // MARK: - Context row
+
+    /// `EmptyView` for the common single-create case — the dialog already
+    /// names the item and a context row would be redundant. Rendered for
+    /// multi-action and `items_added` where the icons add information the
+    /// dialog can't show visually.
+    @ViewBuilder
+    private var contextRow: some View {
+        if isItemsAddedSingle, let only = items.first {
+            HStack(spacing: Space.sm) {
+                typeCircle(for: only)
+                Text(itemsAddedLabel(for: only))
+                    .font(.edFootnote)
+                    .foregroundStyle(Tokens.muted)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        } else if items.count > 1 {
+            HStack(spacing: Space.xs) {
+                ForEach(Array(visibleCircles.enumerated()), id: \.offset) { _, item in
+                    typeCircle(for: item)
+                }
+                if overflowCount > 0 {
+                    Text("+\(overflowCount)")
+                        .font(.edFootnote.weight(.semibold))
+                        .foregroundStyle(Tokens.muted)
+                        .padding(.leading, Space.xxs)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    /// Filled accent circle (20pt) with a white SF Symbol inside. The
+    /// per-type icon is the only signal in the multi-action row, so the
+    /// symbol choices matter — they have to read at 20pt.
+    @ViewBuilder
+    private func typeCircle(for item: ExecutedDraft) -> some View {
+        ZStack {
+            Circle()
+                .fill(TypeStyle.tint(for: item.type))
+            Image(systemName: TypeStyle.symbol(for: item.type))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Tokens.accentFg)
+        }
+        .frame(width: 20, height: 20)
+    }
+
+    // MARK: - CTA
+
+    @ViewBuilder
+    private func ctaButton(url: URL) -> some View {
+        Link(destination: url) {
+            HStack(spacing: Space.xs) {
+                Text(deepLinkLabel)
+                    .font(.edBody.weight(.semibold))
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .foregroundStyle(Tokens.accentFg)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(
+                RoundedRectangle(cornerRadius: Radius.pill, style: .continuous)
+                    .fill(Tokens.ink)
+            )
+        }
+    }
+
+    // MARK: - Derivations
+
+    /// `items_added` capturing N items into a single list/trip is rendered
+    /// as a *single* tinted destination circle plus a muted "N items added"
+    /// label — not as multiple circles, because the items live as a row
+    /// inside one container.
+    private var isItemsAddedSingle: Bool {
+        items.count == 1 && items[0].action == "items_added"
+    }
+
+    private var visibleCircles: [ExecutedDraft] {
+        Array(items.prefix(Self.maxVisibleCircles))
     }
 
     private var overflowCount: Int {
-        max(0, items.count - Self.maxVisibleRows)
+        max(0, items.count - Self.maxVisibleCircles)
     }
 
-    /// One row in the snippet. The mapping from `ExecutedDraft` to icon /
-    /// label is centralised here so the dialog string and the snippet stay
-    /// visually consistent.
-    fileprivate struct Row {
-        let symbol: String
-        let tint: Color
-        let label: String
-
-        init(executed: ExecutedDraft) {
-            self.symbol = Self.symbol(for: executed.type)
-            self.tint = Self.tint(for: executed.type)
-            self.label = Self.label(for: executed)
+    /// "milk, eggs, bread" → "3 items added". Falls back to "Items added"
+    /// when the count can't be derived.
+    private func itemsAddedLabel(for item: ExecutedDraft) -> String {
+        guard let raw = item.addedNames?.trimmingCharacters(in: .whitespaces), !raw.isEmpty else {
+            return "Items added"
         }
+        let count = raw
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .count
+        if count <= 1 { return "Item added" }
+        return "\(count) items added"
+    }
+}
 
-        private static func symbol(for type: String) -> String {
-            switch type {
-            case "todo":           return "checkmark.square"
-            case "note":           return "doc.text"
-            case "list":           return "list.bullet"
-            case "folder":         return "folder"
-            case "trip":           return "suitcase"
-            case "itinerary_item": return "airplane"
-            case "expense":        return "creditcard"
-            default:               return "sparkles"
-            }
+/// Type-to-style mapping centralised so dialog formatting (in the intent)
+/// and the snippet view stay visually in sync.
+private enum TypeStyle {
+    static func symbol(for type: String) -> String {
+        switch type {
+        case "todo":           return "checkmark"
+        case "note":           return "note.text"
+        case "list":           return "list.bullet"
+        case "folder":         return "folder.fill"
+        case "trip":           return "suitcase.fill"
+        case "itinerary_item": return "airplane"
+        case "expense":        return "creditcard.fill"
+        default:               return "sparkle"
         }
+    }
 
-        private static func tint(for type: String) -> Color {
-            switch type {
-            case "todo":           return Tokens.accentTasks
-            case "note":           return Tokens.accentNotes
-            case "list":           return Tokens.accentLists
-            case "folder":         return Tokens.accentNotes
-            case "trip",
-                 "itinerary_item": return Tokens.accentItineraries
-            case "expense":        return Tokens.accentFinance
-            default:               return Color.primary
-            }
-        }
-
-        /// Compact label per row. For `items_added` we prefer the names that
-        /// were appended over the list/trip title — that's the new information.
-        /// Everything else just uses the title.
-        private static func label(for executed: ExecutedDraft) -> String {
-            if executed.action == "items_added", let names = executed.addedNames, !names.isEmpty {
-                if let parent = executed.title, !parent.isEmpty {
-                    return "\(names) → \(parent)"
-                }
-                return names
-            }
-            let title = executed.title?.trimmingCharacters(in: .whitespaces) ?? ""
-            return title.isEmpty ? defaultLabel(for: executed) : title
-        }
-
-        private static func defaultLabel(for executed: ExecutedDraft) -> String {
-            switch executed.type {
-            case "todo":           return "Task"
-            case "note":           return "Note"
-            case "list":           return "List"
-            case "folder":         return "Folder"
-            case "trip":           return "Trip"
-            case "itinerary_item": return "Itinerary item"
-            case "expense":        return "Expense"
-            default:               return "Item"
-            }
+    static func tint(for type: String) -> Color {
+        switch type {
+        case "todo":           return Tokens.accentTasks
+        case "note":           return Tokens.accentNotes
+        case "list":           return Tokens.accentLists
+        case "folder":         return Tokens.accentNotes
+        case "trip",
+             "itinerary_item": return Tokens.accentItineraries
+        case "expense":        return Tokens.accentFinance
+        default:               return Tokens.ink
         }
     }
 }
 
-#Preview("Single task") {
+#Preview("Single create (no context row)") {
     CaptureResultSnippetView(
         items: [
             ExecutedDraft(type: "todo", action: "created", id: "x", title: "Buy milk", dueDate: nil, addedNames: nil)
@@ -168,7 +202,7 @@ struct CaptureResultSnippetView: View {
         deepLinkLabel: "Open in Dexter"
     )
     .padding()
-    .background(Tokens.paper)
+    .background(Color.black)
 }
 
 #Preview("Multi action") {
@@ -177,12 +211,25 @@ struct CaptureResultSnippetView: View {
             ExecutedDraft(type: "todo", action: "created", id: "a", title: "Call John", dueDate: nil, addedNames: nil),
             ExecutedDraft(type: "note", action: "created", id: "b", title: "Book ideas", dueDate: nil, addedNames: nil),
             ExecutedDraft(type: "list", action: "items_added", id: "c", title: "Groceries", dueDate: nil, addedNames: "milk, eggs"),
-            ExecutedDraft(type: "todo", action: "completed", id: "d", title: "Pay rent", dueDate: nil, addedNames: nil),
-            ExecutedDraft(type: "todo", action: "created", id: "e", title: "Email Sara", dueDate: nil, addedNames: nil)
+            ExecutedDraft(type: "expense", action: "created", id: "d", title: "Cab", dueDate: nil, addedNames: nil),
+            ExecutedDraft(type: "todo", action: "created", id: "e", title: "Email Sara", dueDate: nil, addedNames: nil),
+            ExecutedDraft(type: "note", action: "created", id: "f", title: "Travel ideas", dueDate: nil, addedNames: nil)
         ],
         deepLink: URL(string: "dexter://activity"),
         deepLinkLabel: "Open in Dexter"
     )
     .padding()
-    .background(Tokens.paper)
+    .background(Color.black)
+}
+
+#Preview("Items added to a list") {
+    CaptureResultSnippetView(
+        items: [
+            ExecutedDraft(type: "list", action: "items_added", id: "list-1", title: "Groceries", dueDate: nil, addedNames: "milk, eggs, bread")
+        ],
+        deepLink: URL(string: "dexter://focus/lists/00000000-0000-0000-0000-000000000000"),
+        deepLinkLabel: "Open in Dexter"
+    )
+    .padding()
+    .background(Color.black)
 }

--- a/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+
+/// Rendered next to the dialog in the Shortcuts result sheet after a
+/// `CaptureToDashboardIntent` run. Lists what was applied (icon + title per
+/// row, grouped visually by the dialog string above) and offers a single
+/// deep-link back into the app.
+///
+/// Snippet runtime constraints (iOS App Intents):
+///   - The view runs outside the main app process. Arbitrary `Button(action:)`
+///     closures are ignored — only `Link(destination:)` reliably hands control
+///     back to the host app.
+///   - Animations, gestures, and `@Environment` values from the main app are
+///     not in scope. Stick to static layout (`VStack`, `HStack`, `Text`,
+///     `Image(systemName:)`) plus `Link`.
+///   - Tokens (colours, spacing, fonts) are reused from the main app design
+///     system so the result sheet matches the in-app surfaces.
+struct CaptureResultSnippetView: View {
+    /// Up to N rows shown explicitly; the rest are summarised as "+N more".
+    static let maxVisibleRows: Int = 3
+
+    let items: [ExecutedDraft]
+    /// Where the "Open in Dexter" button points. `nil` hides the button —
+    /// used for clarification / error cases and for unrecoverable id parses.
+    let deepLink: URL?
+    /// Label rendered on the deep-link button. Always "Open in Dexter" today,
+    /// kept as a parameter to make future variations (e.g. "Open list") easy.
+    let deepLinkLabel: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Space.md) {
+            VStack(alignment: .leading, spacing: Space.sm) {
+                ForEach(Array(visibleRows.enumerated()), id: \.offset) { _, row in
+                    HStack(alignment: .firstTextBaseline, spacing: Space.sm) {
+                        Image(systemName: row.symbol)
+                            .font(.system(size: 15, weight: .regular))
+                            .foregroundStyle(row.tint)
+                            .frame(width: 20, alignment: .center)
+                        Text(row.label)
+                            .font(.edBody)
+                            .foregroundStyle(Tokens.ink)
+                            .lineLimit(2)
+                            .truncationMode(.tail)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+
+                if overflowCount > 0 {
+                    Text("+\(overflowCount) more")
+                        .font(.edFootnote)
+                        .foregroundStyle(Tokens.muted)
+                        .padding(.leading, 20 + Space.sm)
+                }
+            }
+
+            if let url = deepLink {
+                Link(destination: url) {
+                    HStack(spacing: Space.xs) {
+                        Text(deepLinkLabel)
+                            .font(.edFootnote)
+                        Image(systemName: "arrow.up.right")
+                            .font(.system(size: 11, weight: .semibold))
+                    }
+                    .foregroundStyle(Tokens.accentFg)
+                    .padding(.horizontal, Space.md)
+                    .padding(.vertical, Space.sm)
+                    .background(
+                        RoundedRectangle(cornerRadius: Radius.pill, style: .continuous)
+                            .fill(Tokens.ink)
+                    )
+                }
+            }
+        }
+        .padding(Space.lg)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
+                .fill(Tokens.surface)
+        )
+        .paperBorder()
+    }
+
+    // MARK: - Row derivation
+
+    private var visibleRows: [Row] {
+        items.prefix(Self.maxVisibleRows).map(Row.init(executed:))
+    }
+
+    private var overflowCount: Int {
+        max(0, items.count - Self.maxVisibleRows)
+    }
+
+    /// One row in the snippet. The mapping from `ExecutedDraft` to icon /
+    /// label is centralised here so the dialog string and the snippet stay
+    /// visually consistent.
+    fileprivate struct Row {
+        let symbol: String
+        let tint: Color
+        let label: String
+
+        init(executed: ExecutedDraft) {
+            self.symbol = Self.symbol(for: executed.type)
+            self.tint = Self.tint(for: executed.type)
+            self.label = Self.label(for: executed)
+        }
+
+        private static func symbol(for type: String) -> String {
+            switch type {
+            case "todo":           return "checkmark.square"
+            case "note":           return "doc.text"
+            case "list":           return "list.bullet"
+            case "folder":         return "folder"
+            case "trip":           return "suitcase"
+            case "itinerary_item": return "airplane"
+            default:               return "sparkles"
+            }
+        }
+
+        private static func tint(for type: String) -> Color {
+            switch type {
+            case "todo":           return Tokens.accentTasks
+            case "note":           return Tokens.accentNotes
+            case "list":           return Tokens.accentLists
+            case "folder":         return Tokens.accentNotes
+            case "trip",
+                 "itinerary_item": return Tokens.accentItineraries
+            default:               return Tokens.ink
+            }
+        }
+
+        /// Compact label per row. For `items_added` we prefer the names that
+        /// were appended over the list/trip title — that's the new information.
+        /// Everything else just uses the title.
+        private static func label(for executed: ExecutedDraft) -> String {
+            if executed.action == "items_added", let names = executed.addedNames, !names.isEmpty {
+                if let parent = executed.title, !parent.isEmpty {
+                    return "\(names) → \(parent)"
+                }
+                return names
+            }
+            let title = executed.title?.trimmingCharacters(in: .whitespaces) ?? ""
+            return title.isEmpty ? defaultLabel(for: executed) : title
+        }
+
+        private static func defaultLabel(for executed: ExecutedDraft) -> String {
+            switch executed.type {
+            case "todo":           return "Task"
+            case "note":           return "Note"
+            case "list":           return "List"
+            case "folder":         return "Folder"
+            case "trip":           return "Trip"
+            case "itinerary_item": return "Itinerary item"
+            default:               return "Item"
+            }
+        }
+    }
+}
+
+#Preview("Single task") {
+    CaptureResultSnippetView(
+        items: [
+            ExecutedDraft(type: "todo", action: "created", id: "x", title: "Buy milk", dueDate: nil, addedNames: nil)
+        ],
+        deepLink: URL(string: "dexter://focus/tasks/00000000-0000-0000-0000-000000000000"),
+        deepLinkLabel: "Open in Dexter"
+    )
+    .padding()
+    .background(Tokens.paper)
+}
+
+#Preview("Multi action") {
+    CaptureResultSnippetView(
+        items: [
+            ExecutedDraft(type: "todo", action: "created", id: "a", title: "Call John", dueDate: nil, addedNames: nil),
+            ExecutedDraft(type: "note", action: "created", id: "b", title: "Book ideas", dueDate: nil, addedNames: nil),
+            ExecutedDraft(type: "list", action: "items_added", id: "c", title: "Groceries", dueDate: nil, addedNames: "milk, eggs"),
+            ExecutedDraft(type: "todo", action: "completed", id: "d", title: "Pay rent", dueDate: nil, addedNames: nil),
+            ExecutedDraft(type: "todo", action: "created", id: "e", title: "Email Sara", dueDate: nil, addedNames: nil)
+        ],
+        deepLink: URL(string: "dexter://activity"),
+        deepLinkLabel: "Open in Dexter"
+    )
+    .padding()
+    .background(Tokens.paper)
+}

--- a/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
@@ -117,9 +117,9 @@ struct CaptureResultSnippetView: View {
         Link(destination: url) {
             HStack(spacing: Space.xs) {
                 Text(deepLinkLabel)
-                    .font(.title3.weight(.semibold))
+                    .font(.headline)
                 Image(systemName: "arrow.up.right")
-                    .font(.system(size: 16, weight: .semibold))
+                    .font(.system(size: 14, weight: .semibold))
             }
             .foregroundStyle(Color.white)
         }

--- a/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
@@ -31,18 +31,22 @@ struct CaptureResultSnippetView: View {
     static let maxVisibleCircles: Int = 4
 
     let items: [ExecutedDraft]
-    /// Where the "Go to app" hyperlink points. `nil` hides the entire
-    /// snippet — used for clarification / error / unrecoverable-id cases.
-    let deepLink: URL?
-    /// Label rendered on the hyperlink. Defaults to "Go to app" but
+    /// Intent that fires when the user taps "Go to app". `nil` hides the
+    /// affordance — used for clarification / error / unrecoverable-id
+    /// cases. Using a `Button(intent:)` (rather than a `Link(destination:)`)
+    /// is the iOS-blessed snippet-view pattern: it's treated as a discrete
+    /// affordance instead of the intent's implied primary action, which
+    /// is what was causing the system "Done" button to auto-open the app.
+    let openIntent: OpenDexterIntent?
+    /// Label rendered on the affordance. Defaults to "Go to app" but
     /// kept as a parameter to make future variations easy.
-    let deepLinkLabel: String
+    let actionLabel: String
 
     var body: some View {
-        if let url = deepLink {
+        if let intent = openIntent {
             VStack(spacing: Space.md) {
                 contextRow
-                hyperlink(url: url)
+                actionButton(intent: intent)
             }
             // Centered so the tap target sits in the thumb-reachable
             // middle of the sheet, and so the affordance reads as
@@ -104,25 +108,31 @@ struct CaptureResultSnippetView: View {
 
     // MARK: - CTA
 
-    /// Plain hyperlink — no button chrome, no card. Reads as a soft
-    /// affordance below the dialog so it doesn't compete visually with
-    /// the system Done button at the bottom of the Shortcuts sheet.
+    /// Plain hyperlink-styled `Button(intent:)` — no button chrome,
+    /// no card. Reads as a soft affordance below the dialog so it
+    /// doesn't compete visually with the system Done button at the
+    /// bottom of the Shortcuts sheet.
     ///
-    /// Sized close to the system dialog text so it doesn't disappear
-    /// under it, and rendered in white because the Shortcuts result
-    /// sheet on iOS 26 always uses a dark frosted host (system blue
-    /// reads as too utilitarian against that material).
+    /// Rendered in white because the Shortcuts result sheet on iOS 26
+    /// always uses a dark frosted host; system blue reads as too
+    /// utilitarian against that material. Sized close to the system
+    /// dialog text so it doesn't disappear under it.
+    ///
+    /// `.plain` button style strips the default tinted background so
+    /// only the text + chevron show — the button stays an affordance,
+    /// not a CTA pill.
     @ViewBuilder
-    private func hyperlink(url: URL) -> some View {
-        Link(destination: url) {
+    private func actionButton(intent: OpenDexterIntent) -> some View {
+        Button(intent: intent) {
             HStack(spacing: Space.xs) {
-                Text(deepLinkLabel)
-                    .font(.system(size: 15, weight: .semibold))
+                Text(actionLabel)
+                    .font(.system(size: 16, weight: .semibold))
                 Image(systemName: "arrow.up.right")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: 13, weight: .semibold))
             }
             .foregroundStyle(Color.white)
         }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Derivations
@@ -194,8 +204,8 @@ private enum TypeStyle {
         items: [
             ExecutedDraft(type: "todo", action: "created", id: "x", title: "Buy milk", dueDate: nil, addedNames: nil)
         ],
-        deepLink: URL(string: "dexter://focus/tasks/00000000-0000-0000-0000-000000000000"),
-        deepLinkLabel: "Open in Dexter"
+        openIntent: OpenDexterIntent(section: "tasks", id: "00000000-0000-0000-0000-000000000000"),
+        actionLabel: "Go to app"
     )
     .padding()
     .background(Color.black)
@@ -211,8 +221,8 @@ private enum TypeStyle {
             ExecutedDraft(type: "todo", action: "created", id: "e", title: "Email Sara", dueDate: nil, addedNames: nil),
             ExecutedDraft(type: "note", action: "created", id: "f", title: "Travel ideas", dueDate: nil, addedNames: nil)
         ],
-        deepLink: URL(string: "dexter://activity"),
-        deepLinkLabel: "Open in Dexter"
+        openIntent: OpenDexterIntent(section: "activity", id: nil),
+        actionLabel: "Go to app"
     )
     .padding()
     .background(Color.black)
@@ -223,8 +233,8 @@ private enum TypeStyle {
         items: [
             ExecutedDraft(type: "list", action: "items_added", id: "list-1", title: "Groceries", dueDate: nil, addedNames: "milk, eggs, bread")
         ],
-        deepLink: URL(string: "dexter://focus/lists/00000000-0000-0000-0000-000000000000"),
-        deepLinkLabel: "Open in Dexter"
+        openIntent: OpenDexterIntent(section: "lists", id: "00000000-0000-0000-0000-000000000000"),
+        actionLabel: "Go to app"
     )
     .padding()
     .background(Color.black)

--- a/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureResultSnippetView.swift
@@ -40,11 +40,16 @@ struct CaptureResultSnippetView: View {
 
     var body: some View {
         if let url = deepLink {
-            VStack(alignment: .leading, spacing: Space.sm) {
+            VStack(spacing: Space.md) {
                 contextRow
                 hyperlink(url: url)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            // Centered so the tap target sits in the thumb-reachable
+            // middle of the sheet, and so the affordance reads as
+            // intentional rather than wedged against the left edge.
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, Space.lg)
+            .padding(.vertical, Space.md)
         } else {
             EmptyView()
         }
@@ -63,7 +68,7 @@ struct CaptureResultSnippetView: View {
                 typeCircle(for: only)
                 Text(itemsAddedLabel(for: only))
                     .font(.edFootnote)
-                    .foregroundStyle(Tokens.muted)
+                    .foregroundStyle(Color.white.opacity(0.7))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -75,10 +80,9 @@ struct CaptureResultSnippetView: View {
                 if overflowCount > 0 {
                     Text("+\(overflowCount)")
                         .font(.edFootnote.weight(.semibold))
-                        .foregroundStyle(Tokens.muted)
+                        .foregroundStyle(Color.white.opacity(0.7))
                         .padding(.leading, Space.xxs)
                 }
-                Spacer(minLength: 0)
             }
         }
     }
@@ -103,18 +107,21 @@ struct CaptureResultSnippetView: View {
     /// Plain hyperlink — no button chrome, no card. Reads as a soft
     /// affordance below the dialog so it doesn't compete visually with
     /// the system Done button at the bottom of the Shortcuts sheet.
-    /// Uses iOS system blue (set explicitly because snippet views don't
-    /// inherit the host's accent color reliably).
+    ///
+    /// Sized close to the system dialog text so it doesn't disappear
+    /// under it, and rendered in white because the Shortcuts result
+    /// sheet on iOS 26 always uses a dark frosted host (system blue
+    /// reads as too utilitarian against that material).
     @ViewBuilder
     private func hyperlink(url: URL) -> some View {
         Link(destination: url) {
             HStack(spacing: Space.xs) {
                 Text(deepLinkLabel)
-                    .font(.edBody.weight(.medium))
+                    .font(.title3.weight(.semibold))
                 Image(systemName: "arrow.up.right")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.system(size: 16, weight: .semibold))
             }
-            .foregroundStyle(Color.blue)
+            .foregroundStyle(Color.white)
         }
     }
 

--- a/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
@@ -68,7 +68,7 @@ struct CaptureToDashboardIntent: AppIntent {
                 view: CaptureResultSnippetView(
                     items: items,
                     deepLink: deepLink,
-                    deepLinkLabel: "Open in Dexter"
+                    deepLinkLabel: "Go to app"
                 )
             )
         case .needsClarification:

--- a/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
@@ -1,5 +1,6 @@
 import AppIntents
 import Foundation
+import SwiftUI
 
 /// Adds a task / note / list to the personal dashboard from a free-text or
 /// dictated phrase, without opening the app.
@@ -10,10 +11,11 @@ import Foundation
 ///
 /// The on-device pipeline applies tool calls directly to SwiftData and
 /// reports outcomes:
-///   - executed actions -> dialog summarises what was applied.
+///   - executed actions -> dialog summarises what was applied, snippet view
+///     lists each item with an icon and a deep-link back into the app.
 ///   - LLM follow-up question -> dialog surfaces the question, nothing
-///     persisted.
-///   - failure -> dialog surfaces a brief error.
+///     persisted, no snippet.
+///   - failure -> dialog surfaces a brief error, no snippet.
 struct CaptureToDashboardIntent: AppIntent {
     static var title: LocalizedStringResource = "Capture to Dexter"
     static var description = IntentDescription(
@@ -22,7 +24,9 @@ struct CaptureToDashboardIntent: AppIntent {
 
     /// Stay backgrounded so the side button feels instant and the user
     /// doesn't lose their current context. Action Button + Shortcut +
-    /// Show Notification is the intended runtime path.
+    /// Show Notification is the intended runtime path. The result snippet
+    /// renders inline in the Shortcuts sheet; the "Open in Dexter" Link
+    /// inside it is the only way the user jumps into the app.
     static var openAppWhenRun: Bool = false
 
     /// The free-text phrase to capture. When invoked from a Shortcut with
@@ -40,7 +44,7 @@ struct CaptureToDashboardIntent: AppIntent {
         Summary("Capture \(\.$input) to Dexter")
     }
 
-    func perform() async throws -> some IntentResult & ProvidesDialog {
+    func perform() async throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             return .result(dialog: "Nothing to capture.")
@@ -56,8 +60,17 @@ struct CaptureToDashboardIntent: AppIntent {
 
         switch response.status {
         case .executed:
-            let summary = Self.executedDialog(for: response.executed ?? [])
-            return .result(dialog: IntentDialog(stringLiteral: summary))
+            let items = response.executed ?? []
+            let summary = Self.executedDialog(for: items)
+            let deepLink = Self.deepLink(for: items)
+            return .result(
+                dialog: IntentDialog(stringLiteral: summary),
+                view: CaptureResultSnippetView(
+                    items: items,
+                    deepLink: deepLink,
+                    deepLinkLabel: "Open in Dexter"
+                )
+            )
         case .needsClarification:
             let q = response.followUpQuestion ?? "I need a bit more detail."
             return .result(dialog: IntentDialog(stringLiteral: q))
@@ -69,20 +82,111 @@ struct CaptureToDashboardIntent: AppIntent {
 
     // MARK: - Dialog formatting
 
-    /// Build the dialog string from the list of applied actions. Single
-    /// action gets a focused sentence; multiple actions get a tally.
-    private static func executedDialog(for items: [ExecutedDraft]) -> String {
+    /// Build the dialog string from the list of applied actions.
+    ///
+    /// - Single action keeps the focused sentence (e.g. *Added task "Buy milk" — due May 24*).
+    /// - Multi-action lists items by title, grouped by action verb, up to
+    ///   `multiActionVisibleLimit`. Anything beyond that collapses to
+    ///   "and N more" so the dialog stays one or two lines.
+    /// - Empty / malformed inputs fall back to "Done." so the dialog never
+    ///   reads blank.
+    static func executedDialog(for items: [ExecutedDraft]) -> String {
         guard !items.isEmpty else { return "Done." }
         if items.count == 1 {
             return sentence(for: items[0])
         }
-        // Multi-action: short summary by type.
-        let creates = items.filter { $0.action == "created" }.count
-        let updates = items.filter {
-            $0.action == "updated" || $0.action == "completed" || $0.action == "reopened" ||
-            $0.action == "items_added" || $0.action == "item_updated" || $0.action == "item_removed"
-        }.count
-        let deletes = items.filter { $0.action == "deleted" }.count
+        return multiActionSentence(for: items)
+    }
+
+    /// Soft cap on titles named in the multi-action dialog. The snippet view
+    /// renders the full list visually; the dialog stays terse so it reads
+    /// well when Shortcuts speaks it (Siri, AirPods announcement).
+    private static let multiActionVisibleLimit: Int = 3
+
+    private static func multiActionSentence(for items: [ExecutedDraft]) -> String {
+        // Bucket items by the verb we'd use in the dialog. Order matters —
+        // "Added X" reads first, then "Updated Y", then "Deleted Z".
+        var added: [String] = []
+        var updated: [String] = []
+        var deleted: [String] = []
+
+        for item in items {
+            guard let phrase = phrase(for: item) else { continue }
+            switch verbBucket(for: item.action) {
+            case .added:   added.append(phrase)
+            case .updated: updated.append(phrase)
+            case .deleted: deleted.append(phrase)
+            }
+        }
+
+        var clauses: [String] = []
+        if let clause = clause(verb: "Added", titles: added) { clauses.append(clause) }
+        if let clause = clause(verb: "Updated", titles: updated) { clauses.append(clause) }
+        if let clause = clause(verb: "Deleted", titles: deleted) { clauses.append(clause) }
+
+        guard !clauses.isEmpty else {
+            // No phrases survived — fall back to the legacy tally so the
+            // user still gets a count even if titles were all empty.
+            return legacyTally(for: items)
+        }
+        return clauses.joined(separator: ". ") + "."
+    }
+
+    private enum VerbBucket { case added, updated, deleted }
+
+    private static func verbBucket(for action: String) -> VerbBucket {
+        switch action {
+        case "created", "items_added":
+            return .added
+        case "deleted":
+            return .deleted
+        default:
+            // updated, completed, reopened, item_updated, item_removed, ...
+            return .updated
+        }
+    }
+
+    /// Short noun phrase used inside the dialog (e.g. *"Buy milk"*,
+    /// *milk, eggs to "Groceries"*). `nil` if the item has no usable title.
+    private static func phrase(for item: ExecutedDraft) -> String? {
+        if item.action == "items_added", let names = item.addedNames, !names.isEmpty {
+            if let parent = item.title, !parent.isEmpty {
+                return "\(names) to \"\(parent)\""
+            }
+            return names
+        }
+        guard let title = item.title?.trimmingCharacters(in: .whitespaces), !title.isEmpty else {
+            return nil
+        }
+        return "\"\(title)\""
+    }
+
+    private static func clause(verb: String, titles: [String]) -> String? {
+        guard !titles.isEmpty else { return nil }
+        let visible = Array(titles.prefix(multiActionVisibleLimit))
+        let overflow = titles.count - visible.count
+        var joined: String
+        switch visible.count {
+        case 1:
+            joined = visible[0]
+        case 2:
+            joined = "\(visible[0]) and \(visible[1])"
+        default:
+            // Oxford comma joins for 3+ items so it reads cleanly when spoken.
+            let head = visible.dropLast().joined(separator: ", ")
+            joined = "\(head), and \(visible.last!)"
+        }
+        if overflow > 0 {
+            joined += " and \(overflow) more"
+        }
+        return "\(verb) \(joined)"
+    }
+
+    /// Fallback when every item lacked a usable title.
+    private static func legacyTally(for items: [ExecutedDraft]) -> String {
+        let creates = items.filter { verbBucket(for: $0.action) == .added }.count
+        let updates = items.filter { verbBucket(for: $0.action) == .updated }.count
+        let deletes = items.filter { verbBucket(for: $0.action) == .deleted }.count
         var parts: [String] = []
         if creates > 0 { parts.append("\(creates) added") }
         if updates > 0 { parts.append("\(updates) updated") }
@@ -151,4 +255,46 @@ struct CaptureToDashboardIntent: AppIntent {
         f.timeStyle = .short
         return f
     }()
+
+    // MARK: - Deep-link routing
+
+    /// Decide where the snippet's "Open in Dexter" button points.
+    ///
+    /// Rules:
+    ///  - Single item with a parseable UUID → `dexter://focus/<section>/<uuid>`.
+    ///    `items_added` is a single deep-link too (the `id` IS the parent
+    ///    list/trip UUID per `ExecuteDraftAction`).
+    ///  - Multiple items (regardless of section mix) → `dexter://activity`.
+    ///  - Single item with an unparseable id → `nil` (snippet hides the
+    ///    button rather than landing the user on a broken focus).
+    static func deepLink(for items: [ExecutedDraft]) -> URL? {
+        guard !items.isEmpty else { return nil }
+        if items.count > 1 {
+            return URL(string: "dexter://activity")
+        }
+        let item = items[0]
+        guard let section = sectionPathComponent(for: item.type) else {
+            return URL(string: "dexter://activity")
+        }
+        guard UUID(uuidString: item.id) != nil else {
+            // Defensive: don't render a button that would crash or land on
+            // garbage. Snippet view handles `nil` by hiding the button.
+            return nil
+        }
+        return URL(string: "dexter://focus/\(section)/\(item.id)")
+    }
+
+    /// Map the `ExecutedDraft.type` string to the URL path component used in
+    /// `dexter://focus/<section>/...`. Matches `AppSection.rawValue` so the
+    /// receiver can `AppSection(rawValue:)` on the way back in.
+    private static func sectionPathComponent(for type: String) -> String? {
+        switch type {
+        case "todo":                       return AppSection.tasks.rawValue
+        case "note":                       return AppSection.notes.rawValue
+        case "list":                       return AppSection.lists.rawValue
+        case "trip", "itinerary_item":     return AppSection.itineraries.rawValue
+        case "folder":                     return AppSection.notes.rawValue
+        default:                           return nil
+        }
+    }
 }

--- a/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
@@ -62,13 +62,13 @@ struct CaptureToDashboardIntent: AppIntent {
         case .executed:
             let items = response.executed ?? []
             let summary = Self.executedDialog(for: items)
-            let deepLink = Self.deepLink(for: items)
+            let openIntent = Self.openIntent(for: items)
             return .result(
                 dialog: IntentDialog(stringLiteral: summary),
                 view: CaptureResultSnippetView(
                     items: items,
-                    deepLink: deepLink,
-                    deepLinkLabel: "Go to app"
+                    openIntent: openIntent,
+                    actionLabel: "Go to app"
                 )
             )
         case .needsClarification:
@@ -259,37 +259,43 @@ struct CaptureToDashboardIntent: AppIntent {
         return f
     }()
 
-    // MARK: - Deep-link routing
+    // MARK: - Open-app routing
 
-    /// Decide where the snippet's "Open in Dexter" button points.
+    /// Decide where the snippet's "Go to app" button takes the user.
     ///
     /// Rules:
-    ///  - Single item with a parseable UUID → `dexter://focus/<section>/<uuid>`.
-    ///    `items_added` is a single deep-link too (the `id` IS the parent
-    ///    list/trip UUID per `ExecuteDraftAction`).
-    ///  - Multiple items (regardless of section mix) → `dexter://activity`.
+    ///  - Single item with a parseable UUID → focus that section + row.
+    ///    `items_added` is single too (the `id` IS the parent list/trip
+    ///    UUID per `ExecuteDraftAction`).
+    ///  - Multiple items (regardless of section mix) → Activity feed.
     ///  - Single item with an unparseable id → `nil` (snippet hides the
-    ///    button rather than landing the user on a broken focus).
-    static func deepLink(for items: [ExecutedDraft]) -> URL? {
+    ///    affordance rather than landing the user on a broken focus).
+    ///
+    /// Returns an `OpenDexterIntent` instead of a URL so the snippet
+    /// view can wire it into a `Button(intent:)` — the iOS-blessed
+    /// pattern for snippet-view actions. Using `Link(destination:)`
+    /// with our own URL scheme caused the system "Done" button to
+    /// auto-open the app, because iOS treated the Link as the intent's
+    /// implied primary action.
+    static func openIntent(for items: [ExecutedDraft]) -> OpenDexterIntent? {
         guard !items.isEmpty else { return nil }
         if items.count > 1 {
-            return URL(string: "dexter://activity")
+            return OpenDexterIntent(section: AppSection.activity.rawValue, id: nil)
         }
         let item = items[0]
         guard let section = sectionPathComponent(for: item.type) else {
-            return URL(string: "dexter://activity")
+            return OpenDexterIntent(section: AppSection.activity.rawValue, id: nil)
         }
         guard UUID(uuidString: item.id) != nil else {
-            // Defensive: don't render a button that would crash or land on
+            // Defensive: don't render an affordance that would land on
             // garbage. Snippet view handles `nil` by hiding the button.
             return nil
         }
-        return URL(string: "dexter://focus/\(section)/\(item.id)")
+        return OpenDexterIntent(section: section, id: item.id)
     }
 
-    /// Map the `ExecutedDraft.type` string to the URL path component used in
-    /// `dexter://focus/<section>/...`. Matches `AppSection.rawValue` so the
-    /// receiver can `AppSection(rawValue:)` on the way back in.
+    /// Map the `ExecutedDraft.type` string to the section path component.
+    /// Matches `AppSection.rawValue` so the receiver can rehydrate it.
     private static func sectionPathComponent(for type: String) -> String? {
         switch type {
         case "todo":                       return AppSection.tasks.rawValue

--- a/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
@@ -211,6 +211,8 @@ struct CaptureToDashboardIntent: AppIntent {
             return "Added list\(titleClause)."
         case ("folder", "created"):
             return "Added folder\(titleClause)."
+        case ("expense", "created"):
+            return "Logged expense\(titleClause)."
 
         case ("todo", "completed"):
             return "Marked task\(titleClause) complete."
@@ -245,6 +247,7 @@ struct CaptureToDashboardIntent: AppIntent {
         case "note": return "note"
         case "list": return "list"
         case "folder": return "folder"
+        case "expense": return "expense"
         default: return type
         }
     }
@@ -294,6 +297,7 @@ struct CaptureToDashboardIntent: AppIntent {
         case "list":                       return AppSection.lists.rawValue
         case "trip", "itinerary_item":     return AppSection.itineraries.rawValue
         case "folder":                     return AppSection.notes.rawValue
+        case "expense":                    return AppSection.finance.rawValue
         default:                           return nil
         }
     }

--- a/mobile/PersonalDashboard/Intents/OpenDexterIntent.swift
+++ b/mobile/PersonalDashboard/Intents/OpenDexterIntent.swift
@@ -1,0 +1,62 @@
+import AppIntents
+import Foundation
+
+/// Lightweight App Intent that opens Dexter and routes the user to a
+/// specific section / item.
+///
+/// Why this exists rather than a plain `Link(destination: dexter://...)`
+/// inside the Shortcut result snippet:
+///   - A snippet `Link` whose URL scheme matches the host app can be
+///     auto-fired by iOS Shortcuts when the user taps the system "Done"
+///     button, causing Done to open the app instead of dismissing the
+///     sheet. Apple's idiomatic snippet-view pattern is `Button(intent:)`,
+///     which is treated as a discrete affordance rather than the
+///     intent's "implied primary action".
+///   - Concentrating the route here means the snippet view doesn't need
+///     to know how to construct deep-link URLs.
+///
+/// The `dexter://` URL scheme is preserved for external callers
+/// (Safari paste, share sheet, future notifications) and is still
+/// handled in `DexterDeepLink.handle(_:router:)`.
+struct OpenDexterIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Dexter"
+
+    static var description = IntentDescription(
+        "Opens Dexter and jumps to the relevant section.",
+        categoryName: "Navigation"
+    )
+
+    /// Forces the app into the foreground when the intent runs.
+    /// `perform()` then executes inside the host app's process so we
+    /// can mutate the in-app router state directly.
+    static var openAppWhenRun: Bool = true
+
+    /// Hidden from the Shortcuts library — this intent exists to back
+    /// the snippet button, not as a user-facing shortcut.
+    static var isDiscoverable: Bool = false
+
+    /// `AppSection.rawValue` — `tasks`, `notes`, `lists`, `finance`,
+    /// `itineraries`, `activity`, etc.
+    @Parameter(title: "Section")
+    var section: String
+
+    /// Optional UUID string. When present, the destination view will
+    /// focus the matching row via `AppRouter.focus`. Empty / nil means
+    /// land on the section's index.
+    @Parameter(title: "Identifier", default: "")
+    var rawIdentifier: String
+
+    init() {}
+
+    init(section: String, id: String?) {
+        self.section = section
+        self.rawIdentifier = id ?? ""
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let id = rawIdentifier.isEmpty ? nil : UUID(uuidString: rawIdentifier)
+        DeepLinkBus.shared.pending = .focus(sectionRaw: section, id: id)
+        return .result()
+    }
+}

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -99,6 +99,12 @@ struct ContentView: View {
                 .ignoresSafeArea()
                 .allowsHitTesting(!router.drawerOpen)
         }
+        // Deep links from the Shortcut capture result snippet ("Open in
+        // Dexter") and any future external entry points. Schemes are
+        // registered in mobile/project.yml under CFBundleURLTypes.
+        .onOpenURL { url in
+            DexterDeepLink.handle(url, router: router)
+        }
     }
 
     private var edgeOpenGesture: some Gesture {

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -109,8 +109,19 @@ struct ContentView: View {
         // inside the Shortcut snippet view). The intent runs in the app
         // process with `openAppWhenRun = true`, parks the destination on
         // DeepLinkBus, and this observer drains it into the router.
+        //
+        // Dismiss the keyboard first: chat is the root and its input may
+        // be focused when the app foregrounds, which leaves the keyboard
+        // covering the bottom of the destination surface and pushes the
+        // floating "+" FAB up to mid-screen (issue #126 device QA).
         .onReceive(DeepLinkBus.shared.$pending.compactMap { $0 }) { pending in
             DeepLinkBus.shared.pending = nil
+            UIApplication.shared.sendAction(
+                #selector(UIResponder.resignFirstResponder),
+                to: nil,
+                from: nil,
+                for: nil
+            )
             switch pending {
             case .focus(let sectionRaw, let id):
                 guard let section = AppSection(rawValue: sectionRaw) else { return }

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -105,6 +105,23 @@ struct ContentView: View {
         .onOpenURL { url in
             DexterDeepLink.handle(url, router: router)
         }
+        // Internal deep links from `OpenDexterIntent` (Button(intent:)
+        // inside the Shortcut snippet view). The intent runs in the app
+        // process with `openAppWhenRun = true`, parks the destination on
+        // DeepLinkBus, and this observer drains it into the router.
+        .onReceive(DeepLinkBus.shared.$pending.compactMap { $0 }) { pending in
+            DeepLinkBus.shared.pending = nil
+            switch pending {
+            case .focus(let sectionRaw, let id):
+                guard let section = AppSection(rawValue: sectionRaw) else { return }
+                if let id {
+                    router.focus = ActivityFocus(section: section, id: id, isFolder: false)
+                }
+                router.go(to: section)
+            case .activity:
+                router.go(to: .activity)
+            }
+        }
     }
 
     private var edgeOpenGesture: some Gesture {

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -52,6 +52,15 @@ targets:
         # silently fails and the prompt never appears.
         NSBonjourServices:
           - _http._tcp
+        # Deep-link scheme used by the Shortcut capture result snippet
+        # ("Open in Dexter" button) and any future external entry points.
+        # Routes are parsed in ContentView.onOpenURL:
+        #   dexter://focus/<section>/<uuid>  — open a section and focus a row
+        #   dexter://activity                — open the Activity timeline
+        CFBundleURLTypes:
+          - CFBundleURLName: com.akshaysharma.personaldashboard.deeplink
+            CFBundleURLSchemes:
+              - dexter
         # Voice input in chat (issue #83). On-device only — audio never
         # leaves the phone. Both keys are required: Speech for transcription,
         # Microphone for the audio capture that feeds it.


### PR DESCRIPTION
## Summary

- Shortcut capture result sheet now describes what was applied: single-action keeps the focused sentence (e.g. *Added task 'Buy milk' — due May 24*), multi-action lists items by title grouped by verb (e.g. *Added 'Buy milk' and 'Book ideas'*) instead of a bare tally.
- A SwiftUI snippet view renders alongside the dialog with a quiet *Go to app ↗* affordance. Multi-action and `items_added` captures also surface tinted accent circles (one per item type) so the user can scan what was created beyond the dialog text.
- Tapping *Go to app* fires `OpenDexterIntent` (`Button(intent:)`) which foregrounds Dexter and routes to the relevant section/row via `AppRouter` + `ActivityFocus`. Dialog stays backgrounded — the capture flow remains rapid-capture.
- `dexter://` URL scheme is registered and routed in `ContentView.onOpenURL` for external callers (Safari paste, future notifications, share sheet).
- Keyboard is dismissed on deep-link arrival so the destination surface renders cleanly and the floating "+" FAB stays anchored to the bottom-right.

## Why Button(intent:) instead of Link(destination:)

A snippet `Link` whose URL scheme matches the host app is treated by iOS Shortcuts as the intent's implied primary action — tapping the system "Done" button auto-fires the Link and opens Dexter instead of dismissing the sheet. `Button(intent:)` is treated as a discrete affordance and side-steps that behavior.

## Acceptance criteria — verified on device

- [x] Single task capture → sheet shows *Added task 'X'* with the *Go to app* affordance; tap opens Tasks
- [x] Single note capture → sheet shows note row + affordance; tap opens Notes
- [x] Multi-action capture → sheet lists all items in the dialog + accent circles in the snippet; tap opens Activity
- [x] `add_to_list` capture → sheet shows single destination circle + *N items added* label; tap opens the list
- [x] Clarification-needed capture → sheet shows the question, no affordance
- [x] Error path → sheet shows the error, no affordance
- [x] Cold-launch via `dexter://focus/tasks/<uuid>` from Safari foregrounds Dexter on Tasks
- [x] Capture intent stays backgrounded (`openAppWhenRun = false`); app does NOT auto-open
- [x] Tapping system **Done** dismisses the sheet — does NOT open Dexter
- [x] Tapping **Go to app** opens Dexter without the keyboard up; FAB stays anchored

## Test plan

- [x] iOS device QA across the AC matrix above
- [x] `xcodebuild build` passes (static)
- [ ] Smoke test on reviewer's device after merge

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)