### PR TITLE
feat(ios): auto-move ticked list items to bottom

### DIFF
--- a/mobile/PersonalDashboard/Models/Checklist.swift
+++ b/mobile/PersonalDashboard/Models/Checklist.swift
@@ -1,15 +1,22 @@
 import Foundation
 
-struct ChecklistItem: Codable, Hashable, Sendable {
+struct ChecklistItem: Codable, Hashable, Sendable, Identifiable {
+    /// Stable per-item identity. Used by SwiftUI ForEach so that toggle-driven
+    /// reorders (active items first, completed at the bottom) animate cleanly
+    /// instead of cross-fading on index changes. Items persisted before this
+    /// field existed get a fresh UUID at decode time — see `init(from:)`.
+    var id: UUID
     var text: String
     var checked: Bool
 
-    init(text: String, checked: Bool = false) {
+    init(id: UUID = UUID(), text: String, checked: Bool = false) {
+        self.id = id
         self.text = text
         self.checked = checked
     }
 
     private enum CodingKeys: String, CodingKey {
+        case id
         case text
         case checked
         case completed
@@ -17,6 +24,10 @@ struct ChecklistItem: Codable, Hashable, Sendable {
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        // Old persisted JSON has no `id` field. Generate one on the fly so
+        // existing lists keep loading instead of throwing. Same defensive
+        // shape LocalList.decode already uses (fallback to [] on failure).
+        self.id = (try? c.decodeIfPresent(UUID.self, forKey: .id)) ?? UUID()
         self.text = try c.decode(String.self, forKey: .text)
         // Server uses either "checked" or "completed" depending on the row.
         if let v = try c.decodeIfPresent(Bool.self, forKey: .checked) {
@@ -30,6 +41,7 @@ struct ChecklistItem: Codable, Hashable, Sendable {
 
     func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
         try c.encode(text, forKey: .text)
         try c.encode(checked, forKey: .checked)
     }

--- a/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import SwiftData
+import SwiftUI
 
 @Observable
 @MainActor
@@ -83,7 +84,32 @@ final class ListsViewModel {
               index < lists[listIndex].items.count else { return }
         var snapshot = lists[listIndex]
         snapshot.items[index].checked.toggle()
-        lists[listIndex] = snapshot
+
+        // Auto-reorder: completed items sink to the bottom in the order they were
+        // completed; un-completing pops back to the bottom of the active section.
+        // Manual drag-to-reorder still wins for the next toggle: after a drag,
+        // the next time the user toggles an item, this reasserts the grouping.
+        let nowChecked = snapshot.items[index].checked
+        var item = snapshot.items.remove(at: index)
+        if nowChecked {
+            // Append to the end so it lands below items completed earlier.
+            snapshot.items.append(item)
+        } else {
+            // Drop just before the first checked item, or at the end if none.
+            let insertAt = snapshot.items.firstIndex(where: { $0.checked }) ?? snapshot.items.count
+            // Defensive: ensure the item's flag truly reflects the new state.
+            item.checked = false
+            snapshot.items.insert(item, at: insertAt)
+        }
+
+        // Animate the visible mutation. The setter on `lists` is what SwiftUI
+        // observes; wrapping the assignment in withAnimation makes the
+        // identity-keyed ForEach lift the row to its new slot rather than
+        // cross-fade in place. The async update() that follows is disk + DTO
+        // only — by the time it returns the UI is already animating.
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+            lists[listIndex] = snapshot
+        }
         await update(snapshot)
     }
 

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -334,7 +334,12 @@ private struct ListDetailContent: View {
                                 .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
                         }
 
-                        ForEach(Array(list.items.enumerated()), id: \.offset) { index, item in
+                        // Keyed by item.id (UUID) — not array offset — so the
+                        // checked-to-bottom reorder animates as a move rather
+                        // than a cross-fade. The per-iteration `index` is still
+                        // the row's current array position, which is what the
+                        // view-model methods take.
+                        ForEach(Array(list.items.enumerated()), id: \.element.id) { index, item in
                             ItemRow(
                                 item: item,
                                 onToggle: {


### PR DESCRIPTION
## Summary

- Ticking a checklist item now animates the row down to the bottom of the list; unticking pops it back to the bottom of the active section.
- Active items stay in their manual order, completed items sit underneath in the order they were completed (most recently completed last).
- Manual drag-to-reorder still works inside each section.

## Implementation notes

- `ChecklistItem` gains a stable `id: UUID` (Identifiable). Decoding is defensive: persisted JSON written before this change has no `id` field, so we generate a fresh UUID at decode time instead of throwing. Existing lists keep loading.
- `ListsView` `ForEach` is re-keyed from `\.offset` to `\.element.id`, so SwiftUI treats the reorder as a row move and animates it cleanly.
- `ListsViewModel.toggleItem` flips `checked`, then `remove(at:) + append` (checked) or `insert(at: firstChecked)` (unchecked). The visible mutation runs inside `withAnimation(.spring(response: 0.4, dampingFraction: 0.85))` so the move plays as a spring instead of a cross-fade.
- AI tool input schemas, import/export, and existing call sites are untouched — they all use the `(text:checked:)` initialiser, which keeps working since `id` defaults to `UUID()`.

Closes #132

## Test plan

- [x] Clean static build: `xcodegen generate && xcodebuild -project PersonalDashboard.xcodeproj -scheme PersonalDashboard -destination 'generic/platform=iOS' -configuration Debug build` succeeds with no new warnings.
- [x] Shipped to device via `build-to-phone` skill (`devicectl device install` over wifi).
- [ ] Device QA: open an existing list, tick an item — row slides to bottom. Untick — row slides back above the checked items.
- [ ] Device QA: with multiple checked items, ticking adds the new one *below* the existing checked items (preserves completion order).
- [ ] Device QA: with no checked items, unticking the only checked item leaves it at index 0.
- [ ] Device QA: Hold-to-reorder still works on both active and checked rows.
- [ ] Device QA: single-tap on row text still enters rename mode; swipe-to-delete still works; AI capture-into-list still works.
- [ ] Device QA: existing lists (created before this PR) load without data loss.