### PR TITLE
feat(ios): automatic local backup to iCloud Drive

### DIFF
--- a/mobile/PersonalDashboard/App/PersonalDashboardApp.swift
+++ b/mobile/PersonalDashboard/App/PersonalDashboardApp.swift
@@ -28,9 +28,24 @@ struct PersonalDashboardApp: App {
         }
         .modelContainer(SwiftDataStore.shared.container)
         .onChange(of: scenePhase) { _, newPhase in
-            // Re-fetch when the app returns to the foreground (#143).
+            // Re-fetch email when the app returns to the foreground (#143).
             if newPhase == .active {
                 Task { await EmailIngestCoordinator.shared.runForegroundFetch() }
+            }
+            // Opt-in automatic backup (#141). Fires on becoming active (covers
+            // cold launch and foregrounding) and on entering background (catches
+            // edits made during the session). Cheap and non-blocking: the
+            // service no-ops fast when backup is off, no folder is set, or the
+            // interval hasn't elapsed. Background time is limited, so the active
+            // hook is the primary path.
+            switch newPhase {
+            case .active, .background:
+                Task { @MainActor in
+                    try? BackupService(modelContext: SwiftDataStore.shared.context)
+                        .runBackupIfDue(force: false)
+                }
+            default:
+                break
             }
         }
     }

--- a/mobile/PersonalDashboard/Services/BackupService.swift
+++ b/mobile/PersonalDashboard/Services/BackupService.swift
@@ -1,0 +1,198 @@
+import Foundation
+import SwiftData
+
+/// Writes an automatic, opt-in backup of the SwiftData store into a folder
+/// the user picked in iCloud Drive (or anywhere the document picker grants
+/// access to). We never touch CloudKit / iCloud entitlements — free
+/// personal-team signing doesn't allow them. Instead the user grants access
+/// to a folder via the document picker, we persist a SECURITY-SCOPED
+/// BOOKMARK, and write a single rolling `.zip` into it. iOS syncs that folder
+/// to iCloud transparently.
+///
+/// All reads/writes of the bookmarked URL are wrapped in
+/// `startAccessingSecurityScopedResource()` / `stopAccessingSecurityScopedResource()`
+/// and the write goes through `NSFileCoordinator` so iCloud doesn't see a
+/// half-written file.
+@MainActor
+final class BackupService {
+
+    enum BackupError: LocalizedError {
+        case noFolderSelected
+        case folderAccessDenied
+        case bookmarkResolveFailed(Error)
+        case exportFailed(Error)
+        case writeFailed(Error)
+
+        var errorDescription: String? {
+            switch self {
+            case .noFolderSelected:
+                return "Pick a backup folder first."
+            case .folderAccessDenied:
+                return "Couldn't access the backup folder. Pick it again to re-grant access."
+            case .bookmarkResolveFailed(let e):
+                return "Couldn't open the backup folder: \(e.localizedDescription)"
+            case .exportFailed(let e):
+                return (e as? LocalizedError)?.errorDescription ?? "Couldn't build the backup: \(e.localizedDescription)"
+            case .writeFailed(let e):
+                return "Couldn't save the backup: \(e.localizedDescription)"
+            }
+        }
+    }
+
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Folder bookmark
+
+    /// Persist a security-scoped bookmark for a folder the user just picked.
+    /// `pickedURL` comes straight from the document picker and is still
+    /// access-scoped at call time, so we open a scope to mint the bookmark.
+    /// Returns the folder's display name for the UI.
+    @discardableResult
+    func saveFolder(_ pickedURL: URL) throws -> String {
+        let didStart = pickedURL.startAccessingSecurityScopedResource()
+        defer { if didStart { pickedURL.stopAccessingSecurityScopedResource() } }
+
+        let bookmark = try pickedURL.bookmarkData(
+            options: [],
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        )
+        BackupSettings.folderBookmark = bookmark
+        BackupSettings.folderName = pickedURL.lastPathComponent
+        return pickedURL.lastPathComponent
+    }
+
+    /// Resolve the stored bookmark back into a usable URL, refreshing it if
+    /// iOS has marked it stale. The caller is responsible for opening a
+    /// security scope on the returned URL before reading/writing.
+    private func resolveFolderURL() throws -> URL {
+        guard let bookmark = BackupSettings.folderBookmark else {
+            throw BackupError.noFolderSelected
+        }
+        var isStale = false
+        let url: URL
+        do {
+            url = try URL(
+                resolvingBookmarkData: bookmark,
+                options: [],
+                relativeTo: nil,
+                bookmarkDataIsStale: &isStale
+            )
+        } catch {
+            throw BackupError.bookmarkResolveFailed(error)
+        }
+
+        if isStale {
+            // Re-mint the bookmark while we still have a resolved URL so the
+            // next launch doesn't fail. Needs a scope to read the URL.
+            let didStart = url.startAccessingSecurityScopedResource()
+            defer { if didStart { url.stopAccessingSecurityScopedResource() } }
+            if let refreshed = try? url.bookmarkData(
+                options: [],
+                includingResourceValuesForKeys: nil,
+                relativeTo: nil
+            ) {
+                BackupSettings.folderBookmark = refreshed
+            }
+        }
+        return url
+    }
+
+    // MARK: - Run
+
+    /// Run a backup if it's due (or always when `force` is true). Builds the
+    /// zip via `DataExportService`, then writes it into the bookmarked folder
+    /// through `NSFileCoordinator`. On success, updates `lastBackupAt` /
+    /// `lastFileName` and clears any prior error.
+    ///
+    /// Throws on a forced run so the UI can surface the failure. A non-forced
+    /// run that isn't due returns quietly without throwing.
+    @discardableResult
+    func runBackupIfDue(force: Bool) throws -> Bool {
+        if !force && !BackupSettings.isDue() {
+            return false
+        }
+        guard BackupSettings.folderBookmark != nil else {
+            if force { throw BackupError.noFolderSelected }
+            return false
+        }
+
+        // 1. Build the archive into the system temp dir.
+        let tempURL: URL
+        do {
+            tempURL = try DataExportService(modelContext: modelContext).export()
+        } catch {
+            recordError(BackupError.exportFailed(error))
+            throw BackupError.exportFailed(error)
+        }
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // 2. Resolve the destination folder and write atomically.
+        let folderURL: URL
+        do {
+            folderURL = try resolveFolderURL()
+        } catch {
+            recordError(error)
+            throw error
+        }
+
+        let didStart = folderURL.startAccessingSecurityScopedResource()
+        defer { if didStart { folderURL.stopAccessingSecurityScopedResource() } }
+
+        do {
+            try writeCoordinated(from: tempURL, intoFolder: folderURL)
+        } catch {
+            recordError(BackupError.writeFailed(error))
+            throw BackupError.writeFailed(error)
+        }
+
+        // 3. Record success.
+        BackupSettings.lastBackupAt = Date()
+        BackupSettings.lastFileName = BackupSettings.fileName
+        BackupSettings.lastError = nil
+        return true
+    }
+
+    /// Coordinated atomic write: stage the bytes into the destination folder
+    /// under a temporary name, then `replaceItemAt` so iCloud never observes
+    /// a partially written `Dexter-Backup.zip`.
+    private func writeCoordinated(from sourceURL: URL, intoFolder folderURL: URL) throws {
+        let destURL = folderURL.appendingPathComponent(BackupSettings.fileName)
+
+        var coordinatorError: NSError?
+        var thrownError: Error?
+        let coordinator = NSFileCoordinator()
+
+        coordinator.coordinate(
+            writingItemAt: destURL,
+            options: .forReplacing,
+            error: &coordinatorError
+        ) { coordinatedURL in
+            do {
+                let data = try Data(contentsOf: sourceURL)
+                let stagingURL = folderURL.appendingPathComponent(".\(BackupSettings.fileName).tmp")
+                try? FileManager.default.removeItem(at: stagingURL)
+                try data.write(to: stagingURL, options: .atomic)
+
+                if FileManager.default.fileExists(atPath: coordinatedURL.path) {
+                    _ = try FileManager.default.replaceItemAt(coordinatedURL, withItemAt: stagingURL)
+                } else {
+                    try FileManager.default.moveItem(at: stagingURL, to: coordinatedURL)
+                }
+            } catch {
+                thrownError = error
+            }
+        }
+
+        if let coordinatorError { throw coordinatorError }
+        if let thrownError { throw thrownError }
+    }
+
+    private func recordError(_ error: Error) {
+        BackupSettings.lastError = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+    }
+}

--- a/mobile/PersonalDashboard/Services/BackupSettings.swift
+++ b/mobile/PersonalDashboard/Services/BackupSettings.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// How often an automatic backup runs when the app is opened.
+///
+/// The cadence is best-effort: iOS won't reliably wake a closed app on a
+/// timer, so `daily` / `weekly` fire the next time the app becomes active
+/// after the interval has elapsed (see `BackupSettings.isDue(...)`).
+enum BackupFrequency: String, CaseIterable, Identifiable {
+    case everyLaunch
+    case daily
+    case weekly
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .everyLaunch: return "Every launch"
+        case .daily:       return "Daily"
+        case .weekly:      return "Weekly"
+        }
+    }
+
+    /// Minimum elapsed time since the last backup before another is due.
+    /// `everyLaunch` returns 0 so a backup runs every time it's triggered.
+    var minimumInterval: TimeInterval {
+        switch self {
+        case .everyLaunch: return 0
+        case .daily:       return 24 * 60 * 60
+        case .weekly:      return 7 * 24 * 60 * 60
+        }
+    }
+}
+
+/// Single source of truth for the backup feature's persisted settings.
+///
+/// Backed by `UserDefaults` so both SwiftUI (`@AppStorage`, keyed by the
+/// same strings) and the non-View `BackupService` read and write the same
+/// values. The View owns the live bindings; the service reads the snapshot
+/// when a scene-phase or manual trigger fires.
+enum BackupSettings {
+    enum Key {
+        static let enabled         = "backup.enabled"
+        static let frequency       = "backup.frequency"
+        static let folderBookmark  = "backup.folderBookmark"
+        static let folderName      = "backup.folderName"
+        static let lastBackupAt    = "backup.lastBackupAt"
+        static let lastFileName    = "backup.lastFileName"
+        static let lastError       = "backup.lastError"
+    }
+
+    /// Rolling backup file name. One file per folder, overwritten each run,
+    /// so the iCloud-synced folder never accumulates stale snapshots.
+    static let fileName = "Dexter-Backup.zip"
+
+    private static var defaults: UserDefaults { .standard }
+
+    // MARK: - Typed accessors
+
+    static var enabled: Bool {
+        get { defaults.bool(forKey: Key.enabled) }
+        set { defaults.set(newValue, forKey: Key.enabled) }
+    }
+
+    static var frequency: BackupFrequency {
+        get { BackupFrequency(rawValue: defaults.string(forKey: Key.frequency) ?? "") ?? .daily }
+        set { defaults.set(newValue.rawValue, forKey: Key.frequency) }
+    }
+
+    static var folderBookmark: Data? {
+        get { defaults.data(forKey: Key.folderBookmark) }
+        set { defaults.set(newValue, forKey: Key.folderBookmark) }
+    }
+
+    static var folderName: String? {
+        get { defaults.string(forKey: Key.folderName) }
+        set { defaults.set(newValue, forKey: Key.folderName) }
+    }
+
+    static var lastBackupAt: Date? {
+        get {
+            let t = defaults.double(forKey: Key.lastBackupAt)
+            return t > 0 ? Date(timeIntervalSince1970: t) : nil
+        }
+        set { defaults.set(newValue?.timeIntervalSince1970 ?? 0, forKey: Key.lastBackupAt) }
+    }
+
+    static var lastFileName: String? {
+        get { defaults.string(forKey: Key.lastFileName) }
+        set { defaults.set(newValue, forKey: Key.lastFileName) }
+    }
+
+    static var lastError: String? {
+        get { defaults.string(forKey: Key.lastError) }
+        set { defaults.set(newValue, forKey: Key.lastError) }
+    }
+
+    // MARK: - Derived
+
+    /// Whether a non-forced run should proceed: enabled, a folder is set,
+    /// and enough time has passed since the last successful backup.
+    static func isDue(now: Date = Date()) -> Bool {
+        guard enabled, folderBookmark != nil else { return false }
+        guard let last = lastBackupAt else { return true }
+        return now.timeIntervalSince(last) >= frequency.minimumInterval
+    }
+}

--- a/mobile/PersonalDashboard/Views/Settings/BackupSettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/BackupSettingsView.swift
@@ -1,0 +1,406 @@
+import SwiftUI
+import SwiftData
+import UniformTypeIdentifiers
+
+/// Opt-in automatic local backup. The user picks a folder (typically in
+/// iCloud Drive); we persist a security-scoped bookmark and write a single
+/// rolling `Dexter-Backup.zip` into it on a best-effort cadence. iOS syncs
+/// that folder to iCloud transparently, so this works on free personal-team
+/// signing with no iCloud entitlement.
+///
+/// Restore reuses the existing import flow (`DataExportImportView`), which
+/// merges a `.zip` by UUID and never overwrites anything already here.
+struct BackupSettingsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    @AppStorage(BackupSettings.Key.enabled)   private var enabled: Bool = false
+    @AppStorage(BackupSettings.Key.frequency) private var frequencyRaw: String = BackupFrequency.daily.rawValue
+    @AppStorage(BackupSettings.Key.folderName) private var folderName: String = ""
+
+    @State private var showFolderPicker: Bool = false
+    @State private var showRestore: Bool = false
+    @State private var isBackingUp: Bool = false
+    @State private var errorMessage: String? = nil
+    @State private var successMessage: String? = nil
+
+    /// Mirror of `BackupSettings.lastBackupAt`, surfaced as state so the
+    /// status line refreshes after a manual "Back up now".
+    @State private var lastBackupAt: Date? = BackupSettings.lastBackupAt
+    @State private var lastFileName: String? = BackupSettings.lastFileName
+
+    private var frequency: Binding<BackupFrequency> {
+        Binding(
+            get: { BackupFrequency(rawValue: frequencyRaw) ?? .daily },
+            set: { frequencyRaw = $0.rawValue }
+        )
+    }
+
+    private var hasFolder: Bool { !folderName.isEmpty && BackupSettings.folderBookmark != nil }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                content
+            }
+            .navigationTitle("Backup")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Tokens.muted)
+                        .disabled(isBackingUp)
+                }
+            }
+        }
+        .fileImporter(
+            isPresented: $showFolderPicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            handleFolderPicked(result)
+        }
+        .sheet(isPresented: $showRestore) {
+            DataExportImportView()
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Space.xl) {
+                Text("Keep a copy of everything on this device in a folder you choose. Point it at iCloud Drive and your backup rides along to the cloud automatically.")
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.muted)
+                    .padding(.horizontal, Space.xs)
+
+                automaticCard
+
+                if enabled {
+                    actionsCard
+                }
+
+                if let errorMessage {
+                    feedback(errorMessage, tint: Tokens.danger, background: Tokens.dangerSoft)
+                }
+                if let successMessage {
+                    feedback(successMessage, tint: Tokens.success, background: Tokens.successSoft)
+                }
+
+                restoreCard
+
+                Text("Daily and weekly backups are best-effort. iOS won't reliably wake a closed app on a timer, so a scheduled backup runs the next time you open Dexter after that interval has passed.")
+                    .font(.edFootnote)
+                    .foregroundStyle(Tokens.mutedSoft)
+                    .padding(.horizontal, Space.xs)
+
+                Spacer(minLength: Space.xl)
+            }
+            .padding(.horizontal, Space.lg)
+            .padding(.top, Space.lg)
+            .padding(.bottom, 96)
+        }
+    }
+
+    // MARK: - Automatic backup card
+
+    private var automaticCard: some View {
+        VStack(spacing: 0) {
+            // Toggle row
+            HStack(spacing: Space.md) {
+                Image(systemName: "arrow.clockwise.icloud")
+                    .font(.system(size: 17, weight: .regular))
+                    .foregroundStyle(Tokens.ink)
+                    .frame(width: 24)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Automatic iCloud backup")
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.ink)
+                    Text("Write a snapshot to your chosen folder.")
+                        .font(.edFootnote)
+                        .foregroundStyle(Tokens.muted)
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: Space.md)
+
+                Toggle("", isOn: $enabled)
+                    .labelsHidden()
+                    .tint(Tokens.accent(for: .settings))
+            }
+            .padding(.horizontal, Space.lg)
+            .padding(.vertical, Space.md)
+
+            if enabled {
+                divider
+
+                // Folder row
+                Button {
+                    showFolderPicker = true
+                } label: {
+                    HStack(spacing: Space.md) {
+                        Image(systemName: "folder")
+                            .font(.system(size: 17, weight: .regular))
+                            .foregroundStyle(Tokens.ink)
+                            .frame(width: 24)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Backup location")
+                                .font(.edBody)
+                                .foregroundStyle(Tokens.ink)
+                            Text(hasFolder ? folderName : "Choose a folder")
+                                .font(.edFootnote)
+                                .foregroundStyle(hasFolder ? Tokens.muted : Tokens.mutedSoft)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+
+                        Spacer(minLength: Space.md)
+
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .regular))
+                            .foregroundStyle(Tokens.mutedSoft)
+                    }
+                    .padding(.horizontal, Space.lg)
+                    .padding(.vertical, Space.md)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                divider
+
+                // Frequency row
+                VStack(alignment: .leading, spacing: Space.md) {
+                    Text("Frequency")
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.ink)
+                    FrequencyPicker(value: frequency)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, Space.lg)
+                .padding(.vertical, Space.md)
+            }
+        }
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+        .paperBorder()
+    }
+
+    // MARK: - Actions card (back up now + status)
+
+    private var actionsCard: some View {
+        VStack(spacing: 0) {
+            Button {
+                Task { await backUpNow() }
+            } label: {
+                HStack(spacing: Space.md) {
+                    Image(systemName: "tray.and.arrow.up")
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundStyle(hasFolder ? Tokens.ink : Tokens.mutedSoft)
+                        .frame(width: 24)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Back up now")
+                            .font(.edBody)
+                            .foregroundStyle(hasFolder ? Tokens.ink : Tokens.mutedSoft)
+                        Text(statusLine)
+                            .font(.edFootnote)
+                            .foregroundStyle(Tokens.muted)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+
+                    Spacer(minLength: Space.md)
+
+                    if isBackingUp {
+                        ProgressView().tint(Tokens.muted)
+                    } else {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .regular))
+                            .foregroundStyle(Tokens.mutedSoft)
+                    }
+                }
+                .padding(.horizontal, Space.lg)
+                .padding(.vertical, Space.md)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!hasFolder || isBackingUp)
+        }
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+        .paperBorder()
+    }
+
+    // MARK: - Restore card
+
+    private var restoreCard: some View {
+        VStack(spacing: 0) {
+            Button {
+                showRestore = true
+            } label: {
+                HStack(spacing: Space.md) {
+                    Image(systemName: "arrow.down.doc")
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundStyle(Tokens.ink)
+                        .frame(width: 24)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Restore from backup…")
+                            .font(.edBody)
+                            .foregroundStyle(Tokens.ink)
+                        Text("Merge a .zip back in. Nothing already here is overwritten.")
+                            .font(.edFootnote)
+                            .foregroundStyle(Tokens.muted)
+                            .lineLimit(2)
+                    }
+
+                    Spacer(minLength: Space.md)
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundStyle(Tokens.mutedSoft)
+                }
+                .padding(.horizontal, Space.lg)
+                .padding(.vertical, Space.md)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+        .paperBorder()
+    }
+
+    // MARK: - Feedback
+
+    private func feedback(_ message: String, tint: Color, background: Color) -> some View {
+        Text(message)
+            .font(.edFootnote)
+            .foregroundStyle(tint)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Space.md)
+            .background(background, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+    }
+
+    private var statusLine: String {
+        guard let lastBackupAt else { return "Not backed up yet." }
+        let when = Self.relativeDate(lastBackupAt)
+        if let lastFileName, !lastFileName.isEmpty {
+            return "Last backed up \(when) · \(lastFileName)"
+        }
+        return "Last backed up \(when)"
+    }
+
+    // MARK: - Actions
+
+    private func handleFolderPicked(_ result: Result<[URL], Error>) {
+        errorMessage = nil
+        successMessage = nil
+        switch result {
+        case .failure(let error):
+            errorMessage = error.localizedDescription
+        case .success(let urls):
+            guard let url = urls.first else { return }
+            let service = BackupService(modelContext: modelContext)
+            do {
+                let name = try service.saveFolder(url)
+                folderName = name
+                Haptics.light()
+            } catch {
+                errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            }
+        }
+    }
+
+    private func backUpNow() async {
+        errorMessage = nil
+        successMessage = nil
+        isBackingUp = true
+        defer { isBackingUp = false }
+
+        let service = BackupService(modelContext: modelContext)
+        do {
+            try service.runBackupIfDue(force: true)
+            lastBackupAt = BackupSettings.lastBackupAt
+            lastFileName = BackupSettings.lastFileName
+            successMessage = "Backed up to \(folderName)."
+            Haptics.light()
+        } catch {
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            Haptics.destructive()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func relativeDate(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}
+
+// MARK: - Frequency picker
+
+/// Segmented control matching the app's `ThemePicker` style: a pill track
+/// with the selected option lifted onto a surface chip.
+private struct FrequencyPicker: View {
+    @Binding var value: BackupFrequency
+
+    var body: some View {
+        HStack(spacing: Space.xs) {
+            ForEach(BackupFrequency.allCases) { option in
+                FrequencyOption(
+                    option: option,
+                    isSelected: value == option,
+                    onTap: {
+                        withAnimation(.easeOut(duration: 0.15)) { value = option }
+                    }
+                )
+            }
+        }
+        .padding(Space.xs)
+        .background(Tokens.paper2, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+    }
+}
+
+private struct FrequencyOption: View {
+    let option: BackupFrequency
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Text(option.label)
+                .font(.edFootnote)
+                .foregroundStyle(isSelected ? Tokens.ink : Tokens.muted)
+                .frame(maxWidth: .infinity)
+                .frame(height: 36)
+                .background(
+                    Group {
+                        if isSelected {
+                            RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                                .fill(Tokens.surface)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                                        .stroke(Tokens.border, lineWidth: 0.5)
+                                )
+                        }
+                    }
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Shared divider
+
+private extension BackupSettingsView {
+    var divider: some View {
+        Rectangle()
+            .fill(Tokens.divider)
+            .frame(height: 0.5)
+            .padding(.leading, Space.lg)
+    }
+}

--- a/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
@@ -7,6 +7,7 @@ struct SettingsView: View {
     @State private var showingResetData: Bool = false
     @State private var showingDataTransfer: Bool = false
     @State private var showingEmailInbox: Bool = false
+    @State private var showingBackup: Bool = false
 
     var body: some View {
         ZStack {
@@ -22,6 +23,9 @@ struct SettingsView: View {
         }
         .sheet(isPresented: $showingEmailInbox) {
             EmailInboxView()
+        }
+        .sheet(isPresented: $showingBackup) {
+            BackupSettingsView()
         }
     }
 
@@ -99,6 +103,29 @@ struct SettingsView: View {
                 } label: {
                     HStack(alignment: .firstTextBaseline, spacing: Space.md) {
                         Text("Export & import…")
+                            .font(.edBody)
+                            .foregroundStyle(Tokens.ink)
+                        Spacer(minLength: Space.md)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 13, weight: .regular))
+                            .foregroundStyle(Tokens.mutedSoft)
+                    }
+                    .padding(.horizontal, Space.lg)
+                    .padding(.vertical, Space.md)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                Rectangle()
+                    .fill(Tokens.divider)
+                    .frame(height: 0.5)
+                    .padding(.leading, Space.lg)
+
+                Button {
+                    showingBackup = true
+                } label: {
+                    HStack(alignment: .firstTextBaseline, spacing: Space.md) {
+                        Text("Backup…")
                             .font(.edBody)
                             .foregroundStyle(Tokens.ink)
                         Spacer(minLength: Space.md)


### PR DESCRIPTION
## Summary

Opt-in automatic backup that writes the existing `.zip` snapshot into a folder the user picks in iCloud Drive. The document picker grants folder access and iOS syncs the folder to iCloud, so this needs no iCloud entitlement and no paid Apple Developer Program. It works on the current free personal-team signing.

Closes #141.

## What's new

- **BackupSettings** (UserDefaults-backed): enable flag, `BackupFrequency` (every launch / daily / weekly), folder bookmark + name, last-backup metadata, and the `isDue` derivation.
- **BackupService** (`@MainActor`): mints and resolves a security-scoped bookmark (refreshing if stale), builds the zip via the existing `DataExportService`, and writes it through `NSFileCoordinator` with an atomic staged replace so iCloud never observes a half-written file.
- **BackupSettingsView**: Settings screen with the enable toggle, folder picker, frequency control, "Back up now", last-backup status, a "Restore from backup…" entry that reuses the existing import flow, and a plain-language note that daily/weekly cadence is best-effort (iOS won't wake a closed app on a timer).
- **Scene-phase hook** in the app entry fires `runBackupIfDue(force: false)` on becoming active and on entering background.

## Design constraint

CloudKit / iCloud KV / iCloud Documents all require the paid Apple Developer Program, which this app does not have. Writing a file into a user-granted iCloud Drive folder is the only path that ships on free signing. The cadence is opportunistic by necessity and the UI says so.

## Test plan

- [x] Clean `xcodebuild` for `generic/platform=iOS`.
- [x] Installed to device (Flightmode 2.0) via `devicectl`.
- [x] Device QA: enable backup, pick an iCloud Drive folder, "Back up now" writes `Dexter-Backup.zip` (visible in Files), folder choice survives relaunch, toggle on-state reads correctly in dark mode after the accent fix.
- [ ] Restore-after-reinstall is the one flow left to exercise opportunistically; merge-by-UUID import is unchanged and already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)