### PR TITLE
feat(ios): add Google Maps link to itinerary items

### DIFF
--- a/mobile/PersonalDashboard/AI/EmailToItinerary.swift
+++ b/mobile/PersonalDashboard/AI/EmailToItinerary.swift
@@ -449,6 +449,7 @@ struct EmailToItinerary {
         - notes: confirmation number, address, times, and any other useful detail from the email. Keep it factual.
         - start_time: full ISO 8601 datetime with timezone when the email gives a clear time; otherwise omit.
         - For stays only: end_date (check-out) is required; end_time optional.
+        - google_maps_link: if the email or attachment contains an explicit Google Maps URL for the location (maps.app.goo.gl, goo.gl/maps, google.com/maps, maps.google.com), copy it verbatim into this field. Do NOT invent, guess, or construct a link from an address; omit the field when no real link is present.
 
         Be conservative. A wrong auto-add is worse than a miss — when the destination or dates are ambiguous, add nothing and explain in one sentence.
         \(contextBlock)

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -786,6 +786,13 @@ struct ExecuteDraftAction {
                 endTimeValue = parseAnyISODate(dict["end_time"]?.stringValue)
             }
 
+            // Optional Google Maps link. A bare/empty value or the "null"
+            // sentinel both store as empty (the UI still offers a search
+            // fallback). We don't validate the URL here.
+            let mapsRaw = (dict["google_maps_link"]?.stringValue ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let mapsLink = mapsRaw == "null" ? "" : mapsRaw
+
             let maxForDay = existing
                 .filter { cal.isDate($0.dayDate, inSameDayAs: dayStart) }
                 .map { $0.sortOrder }
@@ -801,6 +808,7 @@ struct ExecuteDraftAction {
                 endDate: endDateValue,
                 endTime: endTimeValue,
                 sortOrder: maxForDay + 1,
+                googleMapsLink: mapsLink,
                 createdAt: now,
                 updatedAt: now
             )
@@ -951,6 +959,16 @@ struct ExecuteDraftAction {
                 row.endTime = nil; changed = true
             } else if !trimmed.isEmpty, let parsed = parseAnyISODate(trimmed) {
                 row.endTime = parsed; changed = true
+            }
+        }
+        // google_maps_link: same empty/"null"/value tri-state as notes.
+        // Empty = keep, "null" = clear, anything else = set verbatim.
+        if let raw = input["google_maps_link"]?.stringValue {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == "null" {
+                row.googleMapsLink = ""; changed = true
+            } else if !trimmed.isEmpty {
+                row.googleMapsLink = trimmed; changed = true
             }
         }
         // If the kind isn't stay any more, clear the stay-only fields so the

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -296,6 +296,10 @@ enum ToolDefinitions {
             "end_time": .object([
                 "type": .string("string"),
                 "description": .string("STAY ONLY, OPTIONAL: check-out time as a full ISO 8601 datetime with timezone (e.g., 2026-06-17T11:00:00-04:00). The DATE portion MUST match end_date. Set this when the user mentions a check-out time; otherwise omit.")
+            ]),
+            "google_maps_link": .object([
+                "type": .string("string"),
+                "description": .string("OPTIONAL Google Maps URL for the location (e.g., https://maps.app.goo.gl/abc or https://www.google.com/maps/place/...). Extract it ONLY if the source explicitly contains one; do NOT invent or guess a link. Omit (or use empty string) when there is no link.")
             ])
         ]),
         "required": .array([.string("day_date"), .string("kind"), .string("title"), .string("notes")])
@@ -353,7 +357,7 @@ enum ToolDefinitions {
 
     private static let editItineraryItem = AnthropicTool(
         name: "edit_itinerary_item",
-        description: "Edit an EXISTING itinerary item's day, kind, title, notes, start time, or (for stays) check-out date / time. Requires the item UUID. IMPORTANT: At least one field must actually change. Use empty string for fields to keep unchanged. Use the literal string \"null\" for notes, start_time, end_date, or end_time to CLEAR them. day_date, kind, and title cannot be cleared.",
+        description: "Edit an EXISTING itinerary item's day, kind, title, notes, start time, (for stays) check-out date / time, or Google Maps link. Requires the item UUID. IMPORTANT: At least one field must actually change. Use empty string for fields to keep unchanged. Use the literal string \"null\" for notes, start_time, end_date, end_time, or google_maps_link to CLEAR them. day_date, kind, and title cannot be cleared.",
         input_schema: object(
             properties: [
                 "id": string("The UUID of the existing itinerary item to edit (from EXISTING TRIPS context)."),
@@ -363,7 +367,8 @@ enum ToolDefinitions {
                 "notes": string("New notes. Use empty string to keep unchanged, or the literal \"null\" to clear."),
                 "start_time": string("New start time as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T19:00:00-04:00). The date portion should match day_date. Use empty string to keep unchanged, or the literal \"null\" to clear (make the item untimed)."),
                 "end_date": string("STAY ONLY: new check-out date in ISO 8601 (e.g., 2026-06-17). Must be > day_date. Use empty string to keep unchanged, or the literal \"null\" to clear."),
-                "end_time": string("STAY ONLY: new check-out time as a full ISO 8601 datetime with timezone (e.g., 2026-06-17T11:00:00-04:00). The date portion should match end_date. Use empty string to keep unchanged, or the literal \"null\" to clear.")
+                "end_time": string("STAY ONLY: new check-out time as a full ISO 8601 datetime with timezone (e.g., 2026-06-17T11:00:00-04:00). The date portion should match end_date. Use empty string to keep unchanged, or the literal \"null\" to clear."),
+                "google_maps_link": string("New Google Maps URL for the location. Use empty string to keep unchanged, or the literal \"null\" to clear.")
             ],
             required: ["id", "day_date", "kind", "title", "notes"]
         )

--- a/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
@@ -95,6 +95,14 @@ final class LocalItineraryItem {
     /// found or for non-email items. Additive: existing rows keep "".
     var sourceConfirmation: String = ""
 
+    /// Optional Google Maps URL for this item's location (#144). Populated when
+    /// a forwarded booking email contains a maps link, or pasted manually in
+    /// the editor. Empty when none. Stored with a default so adding it to an
+    /// existing install is a safe lightweight migration (no data loss). Read
+    /// via `mapsURL`; the timeline shows a tappable "MAP" chip only when this
+    /// resolves to a non-nil URL.
+    var googleMapsLink: String = ""
+
     var createdAt: Date
     var updatedAt: Date
 
@@ -109,6 +117,7 @@ final class LocalItineraryItem {
         endDate: Date? = nil,
         endTime: Date? = nil,
         sortOrder: Int = 0,
+        googleMapsLink: String = "",
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -122,6 +131,7 @@ final class LocalItineraryItem {
         self.endDate = endDate
         self.endTime = endTime
         self.sortOrder = sortOrder
+        self.googleMapsLink = googleMapsLink
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -132,5 +142,24 @@ final class LocalItineraryItem {
     var kindEnum: ItineraryKind {
         get { ItineraryKind(rawValue: kind) ?? .activity }
         set { kind = newValue.rawValue }
+    }
+
+    /// `true` when a real maps link has been stored. The maps pin only renders
+    /// for items where this is true: no link means no pin (and no fallback
+    /// search).
+    var hasExplicitMapsLink: Bool {
+        mapsURL != nil
+    }
+
+    /// The stored Google Maps URL, coercing a bare host (e.g.
+    /// "maps.app.goo.gl/…") into an https URL. `nil` when no link is saved or
+    /// the stored string can't form a URL.
+    var mapsURL: URL? {
+        let stored = googleMapsLink.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stored.isEmpty else { return nil }
+        if let url = URL(string: stored), url.scheme != nil {
+            return url
+        }
+        return URL(string: "https://\(stored)")
     }
 }

--- a/mobile/PersonalDashboard/Services/DataArchive.swift
+++ b/mobile/PersonalDashboard/Services/DataArchive.swift
@@ -120,6 +120,9 @@ enum DataArchive {
         let endDate: Date?
         let endTime: Date?
         let sortOrder: Int
+        /// Optional in the archive so exports written before this field existed
+        /// still decode (missing key -> nil -> "" on import).
+        let googleMapsLink: String?
         let createdAt: Date
         let updatedAt: Date
     }

--- a/mobile/PersonalDashboard/Services/DataExportService.swift
+++ b/mobile/PersonalDashboard/Services/DataExportService.swift
@@ -197,6 +197,7 @@ final class DataExportService {
             endDate: item.endDate,
             endTime: item.endTime,
             sortOrder: item.sortOrder,
+            googleMapsLink: item.googleMapsLink,
             createdAt: item.createdAt,
             updatedAt: item.updatedAt
         )

--- a/mobile/PersonalDashboard/Services/DataImportService.swift
+++ b/mobile/PersonalDashboard/Services/DataImportService.swift
@@ -313,6 +313,7 @@ final class DataImportService {
                     endDate: dto.endDate,
                     endTime: dto.endTime,
                     sortOrder: dto.sortOrder,
+                    googleMapsLink: dto.googleMapsLink ?? "",
                     createdAt: dto.createdAt,
                     updatedAt: dto.updatedAt
                 ))

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -473,6 +473,7 @@ private struct TripDayCluster: View {
 /// jagged list.
 private struct TripTimelineRow: View {
     let entry: TimelineEntry
+    @Environment(\.openURL) private var openURL
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
@@ -520,6 +521,7 @@ private struct TripTimelineRow: View {
 
             HStack(spacing: Space.sm) {
                 TripKindChip(kind: kind)
+                mapsChip(for: item)
                 Spacer(minLength: 0)
             }
 
@@ -533,6 +535,35 @@ private struct TripTimelineRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
         .paperBorder(Tokens.border, radius: Radius.md)
+    }
+
+    /// Maps affordance on the card: a labeled "MAP" pill sitting right after
+    /// the kind chip. Renders ONLY when the item has a saved Google Maps link.
+    /// The text label makes the action obvious (vs a lone pin glyph), and its
+    /// own tap target stops the card's edit tap from firing.
+    @ViewBuilder
+    private func mapsChip(for item: LocalItineraryItem) -> some View {
+        if let url = item.mapsURL {
+            Button {
+                openURL(url)
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "map.fill")
+                        .font(.system(size: 10, weight: .regular))
+                    Text("MAP")
+                        .font(.edEyebrow)
+                        .textCase(.uppercase)
+                        .tracking(1.4)
+                }
+                .foregroundStyle(Tokens.accent(for: .itineraries))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(Tokens.accent(for: .itineraries).opacity(0.12), in: Capsule(style: .continuous))
+                .contentShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Open in Google Maps")
+        }
     }
 }
 
@@ -590,9 +621,11 @@ struct ItineraryItemEditorSheet: View {
     @State private var endDate: Date = Calendar.current.startOfDay(for: Date())
     @State private var hasEndTime: Bool = false
     @State private var notes: String = ""
+    @State private var googleMapsLink: String = ""
     @State private var loaded: Bool = false
     @State private var showingDeleteConfirmation: Bool = false
     @FocusState private var titleFocused: Bool
+    @Environment(\.openURL) private var openURL
 
     private let titleMaxLength = 96
     private let notesMaxLength = 1000
@@ -611,6 +644,7 @@ struct ItineraryItemEditorSheet: View {
                             endDateField
                         }
                         notesField
+                        googleMapsLinkField
                         if isEditing {
                             deleteButton
                                 .padding(.top, Space.sm)
@@ -844,6 +878,59 @@ struct ItineraryItemEditorSheet: View {
         }
     }
 
+    /// Optional Google Maps link. A booking email can prefill this; the user
+    /// can paste / edit / clear it here. The trailing "Open" button appears
+    /// only when a link is present and opens it directly — there is no
+    /// search fallback when the field is empty.
+    private var googleMapsLinkField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            HStack {
+                Text("Google Maps link").eyebrow()
+                Spacer()
+                Text("Optional")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            HStack(spacing: Space.sm) {
+                TextField("Paste a Google Maps link", text: $googleMapsLink)
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.ink)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .keyboardType(.URL)
+                    .submitLabel(.done)
+                    .padding(Space.md)
+                    .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                    .paperBorder(Tokens.border, radius: Radius.md)
+                    .accessibilityLabel("Google Maps link")
+
+                if let url = editorMapsURL {
+                    Button {
+                        openURL(url)
+                    } label: {
+                        Image(systemName: "map")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(Tokens.accent(for: .itineraries))
+                            .frame(width: 48, height: 48)
+                            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                            .paperBorder(Tokens.border, radius: Radius.md)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Open saved Google Maps link")
+                }
+            }
+        }
+    }
+
+    /// The current editor's maps link as a URL, coercing a bare host to https.
+    /// `nil` when the field is empty (so the Open button is hidden).
+    private var editorMapsURL: URL? {
+        let stored = googleMapsLink.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stored.isEmpty else { return nil }
+        if let url = URL(string: stored), url.scheme != nil { return url }
+        return URL(string: "https://\(stored)")
+    }
+
     /// Destructive "Delete item" button shown at the bottom of the editor
     /// scroll content when editing an existing item. Long-press on the tile
     /// in the timeline is still available (context menu); this gives the user
@@ -922,6 +1009,7 @@ struct ItineraryItemEditorSheet: View {
                 kind = existing.kindEnum
                 dayDate = existing.dayDate
                 notes = existing.notes
+                googleMapsLink = existing.googleMapsLink
                 if let start = existing.startTime {
                     hasTime = true
                     dayDate = start
@@ -945,6 +1033,7 @@ struct ItineraryItemEditorSheet: View {
         let cleanTitle = trimmedTitle
         guard !cleanTitle.isEmpty else { return }
         let cleanNotes = trimmedNotes
+        let cleanMapsLink = googleMapsLink.trimmingCharacters(in: .whitespacesAndNewlines)
         let cal = Calendar.current
         let normalisedDay = cal.startOfDay(for: dayDate)
 
@@ -969,7 +1058,8 @@ struct ItineraryItemEditorSheet: View {
                 startTime: startTimeValue,
                 endDate: endDateValue,
                 endTime: endTimeValue,
-                sortOrder: nextSort
+                sortOrder: nextSort,
+                googleMapsLink: cleanMapsLink
             )
             modelContext.insert(item)
         case .existing(let uuid):
@@ -986,6 +1076,7 @@ struct ItineraryItemEditorSheet: View {
                 }
                 existing.dayDate = normalisedDay
                 existing.notes = cleanNotes
+                existing.googleMapsLink = cleanMapsLink
                 existing.startTime = startTimeValue
                 existing.endDate = endDateValue
                 existing.endTime = endTimeValue


### PR DESCRIPTION
## Summary
- Adds an optional `googleMapsLink` field to `LocalItineraryItem`, covering all four kinds (stay / activity / place / restaurant). Additive default `""`, so it is a safe lightweight SwiftData migration on existing installs.
- Timeline tiles show a tappable **"MAP" chip** next to the kind chip, rendered **only** when the item has a saved link, opening it directly. No pin and no search fallback when there is no link.
- The item editor gains a "Google Maps link" field to paste, edit, or clear the URL, with an "Open" button that appears once a link is present.
- AI plumbing: `add_itinerary_item` and `edit_itinerary_item` accept an optional `google_maps_link` (empty / `"null"` / value tri-state on edit). The email-to-itinerary prompt extracts a maps URL when a forwarded booking contains one, and is told never to invent a link.
- The field round-trips through data export / import; the archive DTO field is optional so older backups still decode.

## Test plan
- [x] `xcodegen generate` + clean `xcodebuild` (simulator) after rebasing onto `main`.
- [x] Shipped to device; manual QA confirmed: tiles without a link show no chip, the editor field saves / clears, and a saved link opens Google Maps from both the tile chip and the editor.
- [ ] Reviewer: forward a booking email containing a Google Maps link and confirm the field populates.

Closes #144