### PR TITLE
feat(ios): add address + Google Maps link to tasks with maps-link auto-fill

### DIFF
--- a/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
@@ -95,6 +95,14 @@ final class LocalItineraryItem {
     /// found or for non-email items. Additive: existing rows keep "".
     var sourceConfirmation: String = ""
 
+    /// Optional street / postal address for this item's location. Populated
+    /// when a forwarded booking email contains one, or typed manually in the
+    /// editor. Empty when none. Stored with a default so adding it to an
+    /// existing install is a safe lightweight migration (no data loss). Shown
+    /// as a plain text line on the timeline card; the tappable map affordance
+    /// lives on `googleMapsLink`.
+    var address: String = ""
+
     /// Optional Google Maps URL for this item's location (#144). Populated when
     /// a forwarded booking email contains a maps link, or pasted manually in
     /// the editor. Empty when none. Stored with a default so adding it to an
@@ -117,6 +125,7 @@ final class LocalItineraryItem {
         endDate: Date? = nil,
         endTime: Date? = nil,
         sortOrder: Int = 0,
+        address: String = "",
         googleMapsLink: String = "",
         createdAt: Date = Date(),
         updatedAt: Date = Date()
@@ -131,6 +140,7 @@ final class LocalItineraryItem {
         self.endDate = endDate
         self.endTime = endTime
         self.sortOrder = sortOrder
+        self.address = address
         self.googleMapsLink = googleMapsLink
         self.createdAt = createdAt
         self.updatedAt = updatedAt

--- a/mobile/PersonalDashboard/Models/Local/LocalTodo.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalTodo.swift
@@ -15,6 +15,17 @@ final class LocalTodo {
     var tag: String?
     var position: Int?
 
+    /// Optional street / postal address for this task's location. Empty when
+    /// none. Stored with a default so adding it to an existing install is a
+    /// safe lightweight migration (no data loss). Shown as a plain text line
+    /// on the task row; the tappable map affordance lives on `googleMapsLink`.
+    var address: String = ""
+
+    /// Optional Google Maps URL for this task's location. Empty when none.
+    /// Stored with a default for safe migration. Read via the DTO's `mapsURL`;
+    /// the row shows a tappable "MAP" chip only when it resolves to a URL.
+    var googleMapsLink: String = ""
+
     var version: Int64
 
     var createdAt: Date
@@ -31,6 +42,8 @@ final class LocalTodo {
         dueDate: Date? = nil,
         tag: String? = nil,
         position: Int? = nil,
+        address: String = "",
+        googleMapsLink: String = "",
         version: Int64 = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
@@ -44,6 +57,8 @@ final class LocalTodo {
         self.dueDate = dueDate
         self.tag = tag
         self.position = position
+        self.address = address
+        self.googleMapsLink = googleMapsLink
         self.version = version
         self.createdAt = createdAt
         self.updatedAt = updatedAt
@@ -66,7 +81,9 @@ final class LocalTodo {
             version: version,
             createdAt: createdAt,
             updatedAt: updatedAt,
-            deletedAt: deletedAt
+            deletedAt: deletedAt,
+            address: address,
+            googleMapsLink: googleMapsLink
         )
     }
 }

--- a/mobile/PersonalDashboard/Models/Todo.swift
+++ b/mobile/PersonalDashboard/Models/Todo.swift
@@ -20,10 +20,20 @@ struct Todo: Codable, Identifiable, Hashable, Sendable {
     let updatedAt: Date
     let deletedAt: Date?
 
+    /// Optional street / postal address. Local-only (the server schema has no
+    /// column for it), so it is omitted from `CodingKeys` and carries a default
+    /// — Codable synthesis skips it on encode/decode and uses "" instead.
+    var address: String = ""
+
+    /// Optional Google Maps URL. Local-only, same handling as `address`.
+    var googleMapsLink: String = ""
+
     /// Server JSON has both `id` (int) and `client_uuid`; we map our `id`
     /// to `client_uuid` and ignore the server's int. The decoder's
     /// `.convertFromSnakeCase` strategy turns `client_uuid` into
     /// `clientUuid`, which is what the explicit raw value below matches.
+    /// `address` / `googleMapsLink` are intentionally absent: they are local
+    /// fields the server doesn't know about.
     private enum CodingKeys: String, CodingKey {
         case id = "clientUuid"
         case title
@@ -37,6 +47,16 @@ struct Todo: Codable, Identifiable, Hashable, Sendable {
         case updatedAt
         case deletedAt
     }
+
+    /// The stored Google Maps URL, coercing a bare host (e.g.
+    /// "maps.app.goo.gl/…") into an https URL. `nil` when no link is saved or
+    /// the stored string can't form a URL — the row hides the MAP chip then.
+    var mapsURL: URL? {
+        let stored = googleMapsLink.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stored.isEmpty else { return nil }
+        if let url = URL(string: stored), url.scheme != nil { return url }
+        return URL(string: "https://\(stored)")
+    }
 }
 
 struct TodoCreateRequest: Encodable {
@@ -44,6 +64,8 @@ struct TodoCreateRequest: Encodable {
     let description: String?
     let dueDate: Date?
     let tag: String?
+    var address: String = ""
+    var googleMapsLink: String = ""
 }
 
 struct TodoUpdateRequest: Encodable {
@@ -52,4 +74,7 @@ struct TodoUpdateRequest: Encodable {
     let completed: Bool?
     let dueDate: Date?
     let tag: String?
+    /// `nil` leaves the stored value untouched; a value (incl. "") overwrites.
+    var address: String? = nil
+    var googleMapsLink: String? = nil
 }

--- a/mobile/PersonalDashboard/Services/MapsLinkResolver.swift
+++ b/mobile/PersonalDashboard/Services/MapsLinkResolver.swift
@@ -1,0 +1,169 @@
+import Foundation
+import CoreLocation
+import Contacts
+
+/// Resolves a pasted Google Maps link into a human-readable street address,
+/// entirely with free, built-in iOS APIs — no Google Maps Platform key, no
+/// billing, and no location permission (reverse-geocoding an arbitrary
+/// coordinate does not require `CLLocationManager` authorization).
+///
+/// Strategy, best to worst:
+///   1. Expand short links (`maps.app.goo.gl`, `goo.gl/maps`) by capturing the
+///      first HTTP redirect target — lightweight (we never download the maps
+///      page body).
+///   2. Extract `@lat,lng` (or `!3d…!4d…` / `q=`/`ll=` coordinate forms) from
+///      the expanded URL and reverse-geocode with `CLGeocoder` → a clean
+///      postal address.
+///   3. Fall back to the human-readable `/place/<name>` path segment when no
+///      coordinate is present (plus-codes, bare search queries, offline).
+///
+/// Returns `nil` when nothing usable can be extracted.
+struct MapsLinkResolver {
+
+    func resolveAddress(from link: String) async -> String? {
+        let trimmed = link.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let url = normalizedURL(trimmed) else { return nil }
+
+        let target = await expandedURL(for: url) ?? url
+        let urlString = target.absoluteString
+
+        if let coordinate = coordinate(in: urlString),
+           let address = await reverseGeocode(coordinate) {
+            return address
+        }
+
+        // No usable coordinate: fall back to text Google embeds in the URL.
+        // Short links commonly expand to `maps.google.com?q=<full address>`.
+        return placeName(in: target) ?? textQuery(in: target)
+    }
+
+    /// `true` when the string is plausibly a Google Maps link worth resolving.
+    /// Cheap gate used by the editors so we don't fire on arbitrary typing.
+    static func looksLikeMapsLink(_ string: String) -> Bool {
+        let lower = string.lowercased()
+        guard lower.contains("http") else { return false }
+        return lower.contains("google.com/maps")
+            || lower.contains("maps.google")
+            || lower.contains("maps.app.goo.gl")
+            || lower.contains("goo.gl/maps")
+    }
+
+    // MARK: - URL normalisation
+
+    private func normalizedURL(_ string: String) -> URL? {
+        if let url = URL(string: string), url.scheme != nil { return url }
+        return URL(string: "https://\(string)")
+    }
+
+    private func isShortLink(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        return host == "maps.app.goo.gl" || host == "goo.gl"
+    }
+
+    /// Follow a short link through all its redirects to the final URL, which
+    /// carries the place data (`@lat,lng`, `/place/<name>`, or `?q=<address>`).
+    /// We read only the response URL and cancel the body stream, so the large
+    /// destination maps page is never fully downloaded. Non-short URLs are
+    /// returned unchanged.
+    private func expandedURL(for url: URL) async -> URL? {
+        guard isShortLink(url) else { return url }
+        var request = URLRequest(url: url)
+        request.setValue(
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+            forHTTPHeaderField: "User-Agent"
+        )
+        request.timeoutInterval = 12
+        do {
+            // `bytes(for:)` follows redirects automatically; `response.url` is
+            // the final URL. Cancel the stream once we have the headers.
+            let (bytes, response) = try await URLSession.shared.bytes(for: request)
+            bytes.task.cancel()
+            return response.url ?? url
+        } catch {
+            return url
+        }
+    }
+
+    // MARK: - Coordinate extraction
+
+    private func coordinate(in urlString: String) -> CLLocationCoordinate2D? {
+        // Patterns ordered by reliability. Each captures (lat, lng).
+        let patterns = [
+            "@(-?\\d{1,3}\\.\\d+),(-?\\d{1,3}\\.\\d+)",            // /@lat,lng,zoom
+            "!3d(-?\\d{1,3}\\.\\d+)!4d(-?\\d{1,3}\\.\\d+)",        // data=…!3dlat!4dlng
+            "[?&](?:q|query|ll|destination|center)=(-?\\d{1,3}\\.\\d+),(-?\\d{1,3}\\.\\d+)"
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(urlString.startIndex..., in: urlString)
+            guard let match = regex.firstMatch(in: urlString, range: range),
+                  match.numberOfRanges >= 3,
+                  let latRange = Range(match.range(at: 1), in: urlString),
+                  let lngRange = Range(match.range(at: 2), in: urlString),
+                  let lat = Double(urlString[latRange]),
+                  let lng = Double(urlString[lngRange]),
+                  (-90...90).contains(lat), (-180...180).contains(lng)
+            else { continue }
+            return CLLocationCoordinate2D(latitude: lat, longitude: lng)
+        }
+        return nil
+    }
+
+    // MARK: - Reverse geocoding
+
+    private func reverseGeocode(_ coordinate: CLLocationCoordinate2D) async -> String? {
+        let location = CLLocation(latitude: coordinate.latitude, longitude: coordinate.longitude)
+        guard let placemark = try? await CLGeocoder().reverseGeocodeLocation(location).first else {
+            return nil
+        }
+        if let postal = placemark.postalAddress {
+            let formatted = CNPostalAddressFormatter.string(from: postal, style: .mailingAddress)
+                .replacingOccurrences(of: "\n", with: ", ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !formatted.isEmpty { return formatted }
+        }
+        return placemark.name
+    }
+
+    // MARK: - Place-name fallback
+
+    /// The decoded `/place/<name>` (or `/search/<name>`) path segment, with `+`
+    /// turned back into spaces. Often a business name; useful when there are no
+    /// coordinates to geocode.
+    private func placeName(in url: URL) -> String? {
+        let components = url.pathComponents
+        guard let anchorIndex = components.firstIndex(where: { $0 == "place" || $0 == "search" }),
+              anchorIndex + 1 < components.count else { return nil }
+        let raw = components[anchorIndex + 1]
+        guard !raw.isEmpty, !raw.hasPrefix("@") else { return nil }
+        let spaced = raw.replacingOccurrences(of: "+", with: " ")
+        let decoded = spaced.removingPercentEncoding ?? spaced
+        let cleaned = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    /// The `q` / `query` / `destination` query parameter as text. Short Google
+    /// Maps links frequently expand to `maps.google.com?q=<full address>`, where
+    /// `q` holds the place name and full postal address. Skipped when `q` is a
+    /// bare `lat,lng` pair (the coordinate path handles those).
+    private func textQuery(in url: URL) -> String? {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let items = components.queryItems else { return nil }
+        for key in ["q", "query", "destination"] {
+            guard let value = items.first(where: { $0.name == key })?.value else { continue }
+            // URLComponents percent-decodes but leaves `+` as-is; treat it as space.
+            let cleaned = value
+                .replacingOccurrences(of: "+", with: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !cleaned.isEmpty, !isCoordinatePair(cleaned) else { continue }
+            return cleaned
+        }
+        return nil
+    }
+
+    /// `true` when the string is just `lat,lng` (so it isn't a usable address).
+    private func isCoordinatePair(_ string: String) -> Bool {
+        let pattern = "^-?\\d{1,3}\\.\\d+,\\s*-?\\d{1,3}\\.\\d+$"
+        return string.range(of: pattern, options: .regularExpression) != nil
+    }
+}

--- a/mobile/PersonalDashboard/Services/TodoService.swift
+++ b/mobile/PersonalDashboard/Services/TodoService.swift
@@ -35,6 +35,8 @@ struct TodoService {
             completed: false,
             dueDate: request.dueDate,
             tag: request.tag,
+            address: request.address,
+            googleMapsLink: request.googleMapsLink,
             createdAt: now,
             updatedAt: now
         )
@@ -50,6 +52,8 @@ struct TodoService {
         if let completed = request.completed { row.completed = completed }
         if let dueDate = request.dueDate { row.dueDate = dueDate }
         if let tag = request.tag { row.tag = tag }
+        if let address = request.address { row.address = address }
+        if let googleMapsLink = request.googleMapsLink { row.googleMapsLink = googleMapsLink }
         row.updatedAt = Date()
         try store.context.save()
         return row.toDTO()

--- a/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
@@ -41,9 +41,9 @@ final class TodosViewModel {
         await load()
     }
 
-    func create(title: String, description: String? = nil, dueDate: Date? = nil, tag: String? = nil) async {
+    func create(title: String, description: String? = nil, dueDate: Date? = nil, tag: String? = nil, address: String = "", googleMapsLink: String = "") async {
         do {
-            let request = TodoCreateRequest(title: title, description: description, dueDate: dueDate, tag: tag)
+            let request = TodoCreateRequest(title: title, description: description, dueDate: dueDate, tag: tag, address: address, googleMapsLink: googleMapsLink)
             let new = try await service.create(request)
             todos.insert(new, at: 0)
         } catch {
@@ -65,14 +65,16 @@ final class TodosViewModel {
         }
     }
 
-    func update(_ todo: Todo, title: String? = nil, description: String? = nil, dueDate: Date? = nil, tag: String? = nil) async {
+    func update(_ todo: Todo, title: String? = nil, description: String? = nil, dueDate: Date? = nil, tag: String? = nil, address: String? = nil, googleMapsLink: String? = nil) async {
         do {
             let request = TodoUpdateRequest(
                 title: title,
                 description: description,
                 completed: nil,
                 dueDate: dueDate,
-                tag: tag
+                tag: tag,
+                address: address,
+                googleMapsLink: googleMapsLink
             )
             let updated = try await service.update(todo, request)
             if let index = todos.firstIndex(where: { $0.id == todo.id }) {

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -525,6 +525,19 @@ private struct TripTimelineRow: View {
                 Spacer(minLength: 0)
             }
 
+            if !item.address.isEmpty {
+                HStack(alignment: .top, spacing: 4) {
+                    Image(systemName: "mappin.and.ellipse")
+                        .font(.system(size: 11, weight: .regular))
+                        .foregroundStyle(Tokens.muted)
+                    Text(item.address)
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.muted)
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                }
+            }
+
             Text(entry.dateTimeLine)
                 .font(.edCaption)
                 .foregroundStyle(Tokens.muted)
@@ -621,7 +634,10 @@ struct ItineraryItemEditorSheet: View {
     @State private var endDate: Date = Calendar.current.startOfDay(for: Date())
     @State private var hasEndTime: Bool = false
     @State private var notes: String = ""
+    @State private var address: String = ""
     @State private var googleMapsLink: String = ""
+    @State private var isResolvingAddress = false
+    @State private var addressResolveTask: Task<Void, Never>?
     @State private var loaded: Bool = false
     @State private var showingDeleteConfirmation: Bool = false
     @FocusState private var titleFocused: Bool
@@ -629,6 +645,7 @@ struct ItineraryItemEditorSheet: View {
 
     private let titleMaxLength = 96
     private let notesMaxLength = 1000
+    private let addressMaxLength = 200
 
     var body: some View {
         NavigationStack {
@@ -644,6 +661,7 @@ struct ItineraryItemEditorSheet: View {
                             endDateField
                         }
                         notesField
+                        addressField
                         googleMapsLinkField
                         if isEditing {
                             deleteButton
@@ -878,6 +896,41 @@ struct ItineraryItemEditorSheet: View {
         }
     }
 
+    /// Optional street / postal address. A booking email can prefill this; the
+    /// user can type / edit / clear it here. Plain text only — the tappable map
+    /// affordance lives on the Google Maps link field below.
+    private var addressField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            HStack {
+                Text("Address").eyebrow()
+                if isResolvingAddress {
+                    ProgressView().scaleEffect(0.7)
+                    Text("Resolving from link…")
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.muted)
+                }
+                Spacer()
+                Text("Optional")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            TextField("Street address or area", text: $address, axis: .vertical)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .lineLimit(1...3)
+                .submitLabel(.done)
+                .padding(Space.md)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                .paperBorder(Tokens.border, radius: Radius.md)
+                .onChange(of: address) { _, newValue in
+                    if newValue.count > addressMaxLength {
+                        address = String(newValue.prefix(addressMaxLength))
+                    }
+                }
+                .accessibilityLabel("Address")
+        }
+    }
+
     /// Optional Google Maps link. A booking email can prefill this; the user
     /// can paste / edit / clear it here. The trailing "Open" button appears
     /// only when a link is present and opens it directly — there is no
@@ -903,6 +956,9 @@ struct ItineraryItemEditorSheet: View {
                     .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
                     .paperBorder(Tokens.border, radius: Radius.md)
                     .accessibilityLabel("Google Maps link")
+                    .onChange(of: googleMapsLink) { _, newValue in
+                        scheduleAddressResolve(from: newValue)
+                    }
 
                 if let url = editorMapsURL {
                     Button {
@@ -929,6 +985,29 @@ struct ItineraryItemEditorSheet: View {
         guard !stored.isEmpty else { return nil }
         if let url = URL(string: stored), url.scheme != nil { return url }
         return URL(string: "https://\(stored)")
+    }
+
+    /// Auto-fill the Address field from a pasted Google Maps link (debounced).
+    /// Only fills when Address is currently empty, so it never clobbers an
+    /// address the user typed by hand.
+    private func scheduleAddressResolve(from link: String) {
+        addressResolveTask?.cancel()
+        guard address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              MapsLinkResolver.looksLikeMapsLink(link) else {
+            isResolvingAddress = false
+            return
+        }
+        addressResolveTask = Task {
+            try? await Task.sleep(nanoseconds: 600_000_000) // debounce keystrokes
+            if Task.isCancelled { return }
+            isResolvingAddress = true
+            let resolved = await MapsLinkResolver().resolveAddress(from: link)
+            if Task.isCancelled { return }
+            if let resolved, address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                address = resolved
+            }
+            isResolvingAddress = false
+        }
     }
 
     /// Destructive "Delete item" button shown at the bottom of the editor
@@ -1009,6 +1088,7 @@ struct ItineraryItemEditorSheet: View {
                 kind = existing.kindEnum
                 dayDate = existing.dayDate
                 notes = existing.notes
+                address = existing.address
                 googleMapsLink = existing.googleMapsLink
                 if let start = existing.startTime {
                     hasTime = true
@@ -1033,6 +1113,7 @@ struct ItineraryItemEditorSheet: View {
         let cleanTitle = trimmedTitle
         guard !cleanTitle.isEmpty else { return }
         let cleanNotes = trimmedNotes
+        let cleanAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
         let cleanMapsLink = googleMapsLink.trimmingCharacters(in: .whitespacesAndNewlines)
         let cal = Calendar.current
         let normalisedDay = cal.startOfDay(for: dayDate)
@@ -1059,6 +1140,7 @@ struct ItineraryItemEditorSheet: View {
                 endDate: endDateValue,
                 endTime: endTimeValue,
                 sortOrder: nextSort,
+                address: cleanAddress,
                 googleMapsLink: cleanMapsLink
             )
             modelContext.insert(item)
@@ -1076,6 +1158,7 @@ struct ItineraryItemEditorSheet: View {
                 }
                 existing.dayDate = normalisedDay
                 existing.notes = cleanNotes
+                existing.address = cleanAddress
                 existing.googleMapsLink = cleanMapsLink
                 existing.startTime = startTimeValue
                 existing.endDate = endDateValue

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -454,6 +454,7 @@ private struct TaskRow: View {
     @State private var isEditing: Bool = false
     @State private var editText: String = ""
     @FocusState private var titleFocused: Bool
+    @Environment(\.openURL) private var openURL
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Space.md) {
@@ -503,7 +504,19 @@ private struct TaskRow: View {
                         .lineLimit(2)
                 }
 
-                if todo.dueDate != nil || (todo.tag != nil && !(todo.tag?.isEmpty ?? true)) {
+                if !todo.address.isEmpty {
+                    HStack(alignment: .top, spacing: 4) {
+                        Image(systemName: "mappin.and.ellipse")
+                            .font(.system(size: 10))
+                        Text(todo.address)
+                            .lineLimit(2)
+                    }
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.muted)
+                }
+
+                let hasTag = todo.tag != nil && !(todo.tag?.isEmpty ?? true)
+                if todo.dueDate != nil || hasTag || todo.mapsURL != nil {
                     HStack(spacing: Space.sm) {
                         if let due = todo.dueDate {
                             HStack(spacing: 4) {
@@ -522,6 +535,27 @@ private struct TaskRow: View {
                                 .padding(.vertical, 2)
                                 .background(Tokens.paper2, in: Capsule())
                                 .overlay(Capsule().stroke(Tokens.border, lineWidth: 0.5))
+                        }
+                        if let url = todo.mapsURL {
+                            Button {
+                                openURL(url)
+                            } label: {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "map.fill")
+                                        .font(.system(size: 10, weight: .regular))
+                                    Text("MAP")
+                                        .font(.edEyebrow)
+                                        .textCase(.uppercase)
+                                        .tracking(1.4)
+                                }
+                                .foregroundStyle(Tokens.accentTasks)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 3)
+                                .background(Tokens.accentTasks.opacity(0.12), in: Capsule(style: .continuous))
+                                .contentShape(Capsule())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Open in Google Maps")
                         }
                     }
                 }
@@ -596,8 +630,23 @@ private struct TaskEditorSheet: View {
     @State private var hasDueDate: Bool = false
     @State private var dueDate: Date = Date().addingTimeInterval(3600)
     @State private var tag: String = ""
+    @State private var address: String = ""
+    @State private var googleMapsLink: String = ""
+    @State private var isResolvingAddress = false
+    @State private var addressResolveTask: Task<Void, Never>?
+
+    @Environment(\.openURL) private var openURL
 
     private var isEditing: Bool { todo != nil }
+
+    /// The current editor's maps link as a URL, coercing a bare host to https.
+    /// `nil` when the field is empty (so the Open button stays hidden).
+    private var editorMapsURL: URL? {
+        let stored = googleMapsLink.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !stored.isEmpty else { return nil }
+        if let url = URL(string: stored), url.scheme != nil { return url }
+        return URL(string: "https://\(stored)")
+    }
 
     var body: some View {
         NavigationStack {
@@ -640,6 +689,54 @@ private struct TaskEditorSheet: View {
                                 .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
                                 .paperBorder(Tokens.border, radius: Radius.md)
                         }
+                        VStack(alignment: .leading, spacing: Space.xs) {
+                            HStack(spacing: Space.sm) {
+                                Text("Address").eyebrow()
+                                if isResolvingAddress {
+                                    ProgressView().scaleEffect(0.7)
+                                    Text("Resolving from link…")
+                                        .font(.edCaption)
+                                        .foregroundStyle(Tokens.muted)
+                                }
+                            }
+                            TextField("Street address or area", text: $address, axis: .vertical)
+                                .lineLimit(1...3)
+                                .font(.edBody)
+                                .foregroundStyle(Tokens.ink)
+                                .padding(Space.md)
+                                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                                .paperBorder(Tokens.border, radius: Radius.md)
+                        }
+                        labeled("Google Maps link") {
+                            HStack(spacing: Space.sm) {
+                                TextField("Paste a Google Maps link", text: $googleMapsLink)
+                                    .textInputAutocapitalization(.never)
+                                    .autocorrectionDisabled(true)
+                                    .keyboardType(.URL)
+                                    .font(.edBody)
+                                    .foregroundStyle(Tokens.ink)
+                                    .padding(Space.md)
+                                    .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                                    .paperBorder(Tokens.border, radius: Radius.md)
+                                    .onChange(of: googleMapsLink) { _, newValue in
+                                        scheduleAddressResolve(from: newValue)
+                                    }
+                                if let url = editorMapsURL {
+                                    Button {
+                                        openURL(url)
+                                    } label: {
+                                        Image(systemName: "map")
+                                            .font(.system(size: 16, weight: .medium))
+                                            .foregroundStyle(Tokens.accentTasks)
+                                            .frame(width: 48, height: 48)
+                                            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                                            .paperBorder(Tokens.border, radius: Radius.md)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityLabel("Open saved Google Maps link")
+                                }
+                            }
+                        }
                     }
                     .padding(Space.lg)
                 }
@@ -674,6 +771,31 @@ private struct TaskEditorSheet: View {
         descriptionText = todo.description ?? ""
         if let due = todo.dueDate { hasDueDate = true; dueDate = due }
         tag = todo.tag ?? ""
+        address = todo.address
+        googleMapsLink = todo.googleMapsLink
+    }
+
+    /// Auto-fill the Address field from a pasted Google Maps link (debounced).
+    /// Only fills when Address is currently empty, so it never clobbers an
+    /// address the user typed by hand.
+    private func scheduleAddressResolve(from link: String) {
+        addressResolveTask?.cancel()
+        guard address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              MapsLinkResolver.looksLikeMapsLink(link) else {
+            isResolvingAddress = false
+            return
+        }
+        addressResolveTask = Task {
+            try? await Task.sleep(nanoseconds: 600_000_000) // debounce keystrokes
+            if Task.isCancelled { return }
+            isResolvingAddress = true
+            let resolved = await MapsLinkResolver().resolveAddress(from: link)
+            if Task.isCancelled { return }
+            if let resolved, address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                address = resolved
+            }
+            isResolvingAddress = false
+        }
     }
 
     private func save() async {
@@ -682,10 +804,12 @@ private struct TaskEditorSheet: View {
         let finalDescription = descriptionText.isEmpty ? nil : descriptionText
         let finalTag = tag.trimmingCharacters(in: .whitespaces).isEmpty ? nil : tag
         let finalDue = hasDueDate ? dueDate : nil
+        let finalAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalMapsLink = googleMapsLink.trimmingCharacters(in: .whitespacesAndNewlines)
         if let existing = todo {
-            await viewModel.update(existing, title: trimmed, description: finalDescription, dueDate: finalDue, tag: finalTag)
+            await viewModel.update(existing, title: trimmed, description: finalDescription, dueDate: finalDue, tag: finalTag, address: finalAddress, googleMapsLink: finalMapsLink)
         } else {
-            await viewModel.create(title: trimmed, description: finalDescription, dueDate: finalDue, tag: finalTag)
+            await viewModel.create(title: trimmed, description: finalDescription, dueDate: finalDue, tag: finalTag, address: finalAddress, googleMapsLink: finalMapsLink)
         }
         dismiss()
     }


### PR DESCRIPTION
## Summary
- Tasks gain an optional **address** and **Google Maps link**. `LocalTodo`, the `Todo` DTO, and the create/update requests carry `address` + `googleMapsLink` (local-only, omitted from server `CodingKeys`); wired through `TodoService` and `TodosViewModel`. New fields default to `""` for a safe lightweight SwiftData migration.
- Task editor gets **Address** and **Google Maps link** fields; the task row shows an address line and a tappable **MAP** chip that opens the link in Google Maps.
- Itinerary items gain the same **address** field (the maps link already shipped in #144).
- **Auto-fill from a pasted maps link**: new `MapsLinkResolver` expands short links (`maps.app.goo.gl`) by following the redirect chain, extracts `@lat,lng` / `!3d!4d` / `q=` coordinates and reverse-geocodes via `CLGeocoder`, and falls back to the `/place` name or the `q=` text address. No Google Maps Platform key, no billing, no location permission. Resolution is debounced and only fills when Address is empty, so it never clobbers a manually typed address.

## Test plan
- [x] Static build green (`xcodebuild ... build`)
- [x] Installed to device (iPhone 16 Pro Max, over USB)
- [ ] Tasks: add/edit a task → Address + Google Maps link fields present; MAP chip opens the link
- [ ] Paste a Google Maps share link (e.g. `maps.app.goo.gl/…`) → Address auto-fills after the "Resolving…" spinner
- [ ] Itinerary: item editor shows the Address field; existing maps-link behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)