### PR TITLE
feat(ios): understand Hindi input and capture items in English

### DIFF
--- a/mobile/PersonalDashboard/AI/ChatStream.swift
+++ b/mobile/PersonalDashboard/AI/ChatStream.swift
@@ -129,6 +129,14 @@ struct ChatStream {
 
         If the <personal_vocabulary> block is absent or empty, skip this step.
 
+        LANGUAGE HANDLING (apply AFTER vocabulary handling, BEFORE you write any artefact):
+        Accept input in ANY language. Hindi may arrive as Devanagari script (मुझे कल कॉल करना है) or romanized/Hinglish (mujhe kal call karna hai). Run vocabulary correction on the user's ORIGINAL-LANGUAGE words first; only then translate.
+        Write ALL artefact free-text in ENGLISH. Translate non-English content before you put it in a tool call — this applies to: task title and description; note title and body; list title and items; trip name and notes; itinerary item title and notes; expense merchant and notes. A Hindi or Hinglish input must produce a clean English artefact.
+        Preserve proper nouns, people's names, place names, brands, and <personal_vocabulary> terms VERBATIM — never translate or transliterate a name, and keep each vocabulary term's exact spelling (this reinforces VOCABULARY HANDLING and rule 11). Example: "रिया को कल कॉल करो" → task title "Call Riya tomorrow", not "Call River".
+        Keep enum fields in their defined English values regardless of input language: `tag` (Work, Personal, Shopping, Health, etc.), itinerary `kind` (stay|activity|place|restaurant), and any other fixed-choice field. Translate the user's intent into the existing English enum value; never emit an enum value in another language.
+        Parse relative dates in ANY language to ISO 8601 (extends rule 5): e.g. कल / kal = tomorrow, परसों / parson = day after tomorrow, अगले हफ्ते / agle hafte = next week, पिछले हफ्ते = last week.
+        Write your conversational reply / confirmation in the SAME language as the user's MOST RECENT message: Hindi in → reply in Hindi; Hinglish in → reply in Hinglish; English in → reply in English. Only the chat reply mirrors the user's language — the saved artefact stays English.
+
         AVAILABLE TOOLS:
 
         CREATE (for new items):

--- a/mobile/PersonalDashboard/AI/ChatToDrafts.swift
+++ b/mobile/PersonalDashboard/AI/ChatToDrafts.swift
@@ -196,6 +196,14 @@ struct ChatToDrafts {
 
         If the <personal_vocabulary> block is absent or empty, skip this step.
 
+        LANGUAGE HANDLING (apply AFTER vocabulary handling, BEFORE you write any artefact):
+        Accept input in ANY language. Hindi may arrive as Devanagari script (मुझे कल कॉल करना है) or romanized/Hinglish (mujhe kal call karna hai). Run vocabulary correction on the user's ORIGINAL-LANGUAGE words first; only then translate.
+        Write ALL artefact free-text in ENGLISH. Translate non-English content before you put it in a tool call — this applies to: task title and description; note title and body; list title and items; trip name and notes; itinerary item title and notes; expense merchant and notes. A Hindi or Hinglish input must produce a clean English artefact.
+        Preserve proper nouns, people's names, place names, brands, and <personal_vocabulary> terms VERBATIM — never translate or transliterate a name, and keep each vocabulary term's exact spelling (this reinforces VOCABULARY HANDLING and rule 11). Example: "रिया को कल कॉल करो" → task title "Call Riya tomorrow", not "Call River".
+        Keep enum fields in their defined English values regardless of input language: `tag` (Work, Personal, Shopping, Health, etc.), itinerary `kind` (stay|activity|place|restaurant), and any other fixed-choice field. Translate the user's intent into the existing English enum value; never emit an enum value in another language.
+        Parse relative dates in ANY language to ISO 8601 (extends rule 5): e.g. कल / kal = tomorrow, परसों / parson = day after tomorrow, अगले हफ्ते / agle hafte = next week, पिछले हफ्ते = last week.
+        Write your conversational reply / confirmation in the SAME language as the user's MOST RECENT message: Hindi in → reply in Hindi; Hinglish in → reply in Hinglish; English in → reply in English. Only the chat reply mirrors the user's language — the saved artefact stays English.
+
         AVAILABLE TOOLS:
 
         CREATE (for new items):

--- a/mobile/PersonalDashboard/App/AppConfig.swift
+++ b/mobile/PersonalDashboard/App/AppConfig.swift
@@ -50,4 +50,25 @@ enum AppConfig {
         }
         return nil
     }()
+
+    /// OpenAI API key, used for cloud voice transcription (issue #151).
+    /// Source order mirrors `anthropicAPIKey` exactly:
+    ///   1. `OPENAI_API_KEY` env var (Xcode scheme for local sim runs).
+    ///   2. `OPENAI_API_KEY` Info.plist key, baked at archive time by
+    ///      `mobile/ota/ship-lan.sh` so OTA-installed builds carry their own
+    ///      key without any per-device setup.
+    /// Returns nil if neither is set, in which case `VoiceDictation` falls
+    /// back to the on-device English recognizer rather than failing.
+    static let openAIAPIKey: String? = {
+        if let env = ProcessInfo.processInfo.environment["OPENAI_API_KEY"],
+           !env.isEmpty {
+            return env
+        }
+        if let plist = Bundle.main.object(forInfoDictionaryKey: "OPENAI_API_KEY") as? String,
+           !plist.isEmpty,
+           !plist.hasPrefix("$(") {
+            return plist
+        }
+        return nil
+    }()
 }

--- a/mobile/PersonalDashboard/Info.plist
+++ b/mobile/PersonalDashboard/Info.plist
@@ -53,11 +53,13 @@
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Dexter talks to your Mac dev server over wifi when you're on the same network.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Dexter listens to your voice so it can transcribe what you say into the chat.</string>
+	<string>Dexter records your voice so it can transcribe what you say into the chat.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Used to import a receipt photo when logging an expense.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>Dexter transcribes your voice into chat messages on-device. Audio never leaves your phone.</string>
+	<string>Dexter transcribes your voice into chat messages. With no transcription key set it falls back to on-device English recognition.</string>
+	<key>OPENAI_API_KEY</key>
+	<string>$(OPENAI_API_KEY)</string>
 	<key>OTA_API_URL</key>
 	<string>$(OTA_API_URL)</string>
 	<key>UIAppFonts</key>

--- a/mobile/PersonalDashboard/Services/HindiScriptNormalizer.swift
+++ b/mobile/PersonalDashboard/Services/HindiScriptNormalizer.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Converts a transcript rendered in Urdu (Perso-Arabic) script into Hindi
+/// (Devanagari), while leaving English / already-Devanagari text untouched
+/// (issue #151).
+///
+/// Hindi and Urdu are the same spoken language (Hindustani); OpenAI's STT
+/// auto-detect frequently renders spoken Hindi in Urdu script. The voice
+/// preview should only ever show Hindi or English, never Urdu, so we run this
+/// normalization on the finalized transcript.
+///
+/// The Claude round-trip fires ONLY when Perso-Arabic characters are present,
+/// so English and Devanagari transcripts incur no latency or token cost. On any
+/// failure the original text is returned — a visible (Urdu) preview beats an
+/// empty one, and the downstream parse still translates it to English.
+enum HindiScriptNormalizer {
+
+    /// True if `text` contains any Perso-Arabic (Urdu) script. Exposed so
+    /// callers (e.g. the voice overlay) can cheaply decide whether a
+    /// normalization is pending without re-scanning private state.
+    static func containsPersoArabic(_ text: String) -> Bool {
+        text.unicodeScalars.contains { s in
+            (0x0600...0x06FF).contains(s.value)   // Arabic
+                || (0x0750...0x077F).contains(s.value)   // Arabic Supplement
+                || (0x08A0...0x08FF).contains(s.value)   // Arabic Extended-A
+                || (0xFB50...0xFDFF).contains(s.value)   // Arabic Presentation Forms-A
+                || (0xFE70...0xFEFF).contains(s.value)   // Arabic Presentation Forms-B
+        }
+    }
+
+    /// If `text` is in Urdu script, convert it to Hindi in Devanagari via
+    /// Claude; otherwise return it unchanged (no API call). Never throws —
+    /// returns the input on any error so the voice pipeline degrades to showing
+    /// the raw transcript rather than nothing.
+    static func normalize(_ text: String) async -> String {
+        guard containsPersoArabic(text) else { return text }
+
+        let system = """
+        You convert Hindi text written in Urdu (Perso-Arabic) script into Hindi \
+        written in Devanagari script. Hindi and Urdu are the same spoken \
+        language, so this is a script conversion. Output ONLY the Devanagari \
+        version of the input text, preserving the meaning, numbers, and any \
+        proper nouns. Do not translate to English, do not add quotes, notes, or \
+        any other text.
+        """
+
+        do {
+            let response = try await AnthropicClient().send(
+                systemPrompt: system,
+                messages: [AnthropicMessage(role: "user", content: [.text(text)])],
+                tools: []
+            )
+            let converted = response.content
+                .compactMap { block -> String? in
+                    if case .text(let t) = block { return t }
+                    return nil
+                }
+                .joined()
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return converted.isEmpty ? text : converted
+        } catch {
+            NSLog("[voice] script normalize failed, keeping raw transcript")
+            return text
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Services/OpenAIRealtimeTranscriber.swift
+++ b/mobile/PersonalDashboard/Services/OpenAIRealtimeTranscriber.swift
@@ -1,0 +1,614 @@
+import Foundation
+import os
+
+/// Thin WebSocket client for OpenAI's Realtime transcription API (issue #151).
+///
+/// Streams PCM16 microphone audio to OpenAI and surfaces live transcript
+/// deltas + final transcripts back to `SpeechTranscriber`. The session
+/// `language` is intentionally OMITTED so the model auto-detects Hindi vs
+/// English per utterance — pinning it to `hi` forced English speech to be
+/// (mis)transcribed as Hindi, producing empty/garbled results (issue #151).
+/// Script normalization (Urdu → Devanagari) happens downstream in
+/// `SpeechTranscriber` via `HindiScriptNormalizer`, so we don't rely on the STT
+/// layer to pick a script it can't reliably control for live Hindustani speech.
+///
+/// ### Doc-confirmed Realtime API shape (platform/developers.openai.com, GA)
+///
+/// - **Connect**: `wss://api.openai.com/v1/realtime?intent=transcription`
+///   Header: `Authorization: Bearer <OPENAI_API_KEY>`. Native
+///   `URLSessionWebSocketTask` can set request headers (unlike browsers), so
+///   bearer auth works directly. No `OpenAI-Beta` header is required on the GA
+///   endpoint.
+/// - **Configure** (client → server), event `session.update`:
+///   ```json
+///   {
+///     "type": "session.update",
+///     "session": {
+///       "type": "transcription",
+///       "audio": {
+///         "input": {
+///           "format": { "type": "audio/pcm", "rate": 24000 },
+///           "transcription": { "model": "gpt-4o-mini-transcribe" },
+///           "turn_detection": { "type": "server_vad", "silence_duration_ms": 700 }
+///         }
+///       }
+///     }
+///   }
+///   ```
+///   `transcription.language` is OMITTED → the model auto-detects the spoken
+///   language (Hindi or English) per utterance. Script normalization (Urdu →
+///   Devanagari) is handled downstream in `SpeechTranscriber`.
+///   `turn_detection: server_vad` is REQUIRED for transcription to happen at
+///   all. Empirically verified against the live API: with `turn_detection:
+///   null` the server emits ZERO deltas while audio streams and only produces
+///   a transcript after `input_audio_buffer.commit` — and our old `finish()`
+///   cancelled the socket the instant it committed, so the post-commit
+///   transcript was always discarded (the "transcription not working" bug).
+///   With `server_vad` the server emits `speech_started`, then `speech_stopped`
+///   ~700ms after the user pauses, then the `…transcription.delta` stream and
+///   `…transcription.completed` (~0.5s after `speech_stopped`). So the UX is
+///   "text appears shortly after the user pauses", NOT word-by-word during
+///   speech — this transcription model does not stream mid-speech.
+/// - **Send audio** (client → server), event `input_audio_buffer.append` with
+///   base64-encoded PCM16: `{ "type": "input_audio_buffer.append", "audio": "<b64>" }`.
+/// - **Commit** (client → server) on manual stop, to force-close any open
+///   segment: `{ "type": "input_audio_buffer.commit" }`. After committing we
+///   KEEP the socket open until the resulting `…completed` arrives (or a short
+///   timeout), so the final transcript is never discarded.
+/// - **Receive** (server → client):
+///   - `input_audio_buffer.speech_started` / `…speech_stopped` — VAD markers.
+///   - `conversation.item.input_audio_transcription.delta` — incremental
+///     `delta` text (NOT cumulative; we append).
+///   - `conversation.item.input_audio_transcription.completed` — authoritative
+///     full `transcript` for the utterance.
+///   - `error` — `{ "type": "error", "error": { "message": "…" } }`.
+///
+/// The legacy beta shape (`transcription_session.update` +
+/// `input_audio_transcription` + `OpenAI-Beta: realtime=v1`) is also accepted
+/// by older accounts; we send the GA shape, which the current docs document.
+///
+/// `actor` so all socket state is serialized off the main actor. The mic tap
+/// (background queue) calls `appendAudio(_:)` and the main actor calls
+/// `connect` / `finish` — the actor keeps them race-free.
+actor OpenAIRealtimeTranscriber {
+
+    /// Voice-pipeline diagnostics (issue #151). Lets the on-device socket flow
+    /// (the one layer that can't be exercised off-device) be traced on a single
+    /// tap via Console.app, filtering on this subsystem. Terse, never logs the
+    /// API key, never logs in a hot loop (deltas are logged by count only).
+    private static let log = Logger(
+        subsystem: "com.akshaysharma.personaldashboard.voice",
+        category: "OpenAIRealtimeTranscriber"
+    )
+
+    /// Count of transcription deltas received this session, so we log "N deltas"
+    /// once rather than logging every delta (which arrives in a hot stream).
+    private var deltaCount = 0
+
+    enum TranscriberError: Error, LocalizedError {
+        case badURL
+        var errorDescription: String? {
+            switch self {
+            case .badURL: return "Invalid transcription endpoint."
+            }
+        }
+    }
+
+    /// User-facing copy for any failure to bring the socket up (never connected,
+    /// real transport error, or watchdog timeout). Deliberately non-technical:
+    /// the underlying CFNetwork code / NSError reason is logged, not shown.
+    /// `SpeechTranscriber` reads this to recognise a connection failure (vs. a
+    /// transient server error) and tear the session down so `isRecording` flips.
+    static let connectionFailedMessage =
+        "Couldn't reach voice transcription. Check your connection and try again."
+
+    private var task: URLSessionWebSocketTask?
+    private var session: URLSession?
+
+    /// True once the socket has actually come up — either the
+    /// `URLSessionWebSocketDelegate` reported `didOpenWithProtocol` OR the first
+    /// server event (`session.updated`) arrived. The watchdog and the
+    /// `didCompleteWithError` classifier both read this to tell "never connected"
+    /// from "failed after connecting".
+    private var didConnect = false
+
+    /// Cancels the connection watchdog once we connect (or tear down). The
+    /// watchdog fires `connectionFailedMessage` if neither "opened" nor
+    /// `session.updated` happens within `connectTimeoutSeconds`.
+    private var watchdogTask: Task<Void, Never>?
+    /// How long to wait for the socket to come up before declaring a connection
+    /// failure. On a weak/cellular link the socket can sit in "connecting"
+    /// indefinitely; this is the upper bound the user waits before a clear
+    /// message instead of an indefinite hang.
+    private let connectTimeoutSeconds: UInt64 = 8
+    /// Set false only when we actually tear the socket down (drain complete or
+    /// timeout) so a late receive-loop iteration doesn't reopen the read or
+    /// report a spurious error after we intentionally closed. NOTE: this stays
+    /// TRUE through `finish()` — we keep reading after a commit so the
+    /// post-commit `…completed` is delivered, not discarded.
+    private var isActive = false
+
+    /// True once `finish()` has committed and we're waiting for the final
+    /// `…completed` (or the drain timeout) before closing. Audio appends are
+    /// rejected in this window, but receives keep flowing.
+    private var isDraining = false
+
+    /// Set when a `…completed` is delivered after a manual commit, so the drain
+    /// timeout knows the result already landed and just needs to close.
+    private var didReceiveFinalAfterCommit = false
+
+    /// True when audio has been appended that the server has NOT yet committed.
+    /// With `server_vad` the server AUTO-commits each segment on `speech_stopped`,
+    /// so after a natural pause the buffer is already empty. `finish()` uses this
+    /// to avoid a REDUNDANT `input_audio_buffer.commit` on an empty buffer, which
+    /// the server rejects with a benign "buffer too small" error (issue #151).
+    private var hasUncommittedAudio = false
+
+    /// Full (non-mini) transcription model — materially better at Hindi/English
+    /// language identification than `gpt-4o-mini-transcribe`, which is what
+    /// makes spoken Hindi land in Devanagari rather than Urdu more reliably at
+    /// the source (issue #151).
+    private let transcriptionModel = "gpt-4o-transcribe"
+    /// Steers the transcription without hard-forcing a language (which would
+    /// break English detection). Biases Hindi output toward Devanagari and
+    /// keeps English in the Latin alphabet. The downstream normalizer still
+    /// catches any residual Urdu, so this only reduces how often it's needed.
+    private let transcriptionPrompt =
+        "The audio is in Hindi or English. Write Hindi in Devanagari script "
+        + "(for example: नमस्ते, कल, बजे), never in Urdu or Perso-Arabic script. "
+        + "Write English in the Latin alphabet."
+    private let sampleRate = 24_000
+    /// Server VAD silence threshold. The server finalizes a turn this long
+    /// after the user stops speaking.
+    private let vadSilenceMs = 700
+    /// Max time to wait after a manual commit for the final `…completed` before
+    /// giving up and closing the socket. The running `transcript` (built from
+    /// deltas) is the fallback if this elapses.
+    private let drainTimeoutSeconds: UInt64 = 2
+
+    // Callbacks (set on connect). Marked @Sendable; they hop to @MainActor
+    // inside `SpeechTranscriber`.
+    private var onDelta: (@Sendable (String) -> Void)?
+    private var onCompleted: (@Sendable (String) -> Void)?
+    private var onError: (@Sendable (String) -> Void)?
+
+    /// Open the socket, send the transcription session config, and start the
+    /// receive loop. Throws only on a bad URL — the actual socket open is
+    /// async and surfaces failures through `onError`.
+    func connect(
+        apiKey: String,
+        onDelta: @escaping @Sendable (String) -> Void,
+        onCompleted: @escaping @Sendable (String) -> Void,
+        onError: @escaping @Sendable (String) -> Void
+    ) throws {
+        self.onDelta = onDelta
+        self.onCompleted = onCompleted
+        self.onError = onError
+
+        guard let url = URL(string: "wss://api.openai.com/v1/realtime?intent=transcription") else {
+            Self.log.error("connect failed: bad URL")
+            throw TranscriberError.badURL
+        }
+
+        deltaCount = 0
+        didConnect = false
+        // Log the endpoint, never the bearer token.
+        Self.log.info("socket connect attempt: \(url.absoluteString, privacy: .public)")
+        // idevicesyslog-visible lifecycle trace (os.Logger .info lines are NOT
+        // relayed to idevicesyslog). Terse, never logs the key or transcript.
+        NSLog("[voice] ws connect %@", url.absoluteString)
+
+        var req = URLRequest(url: url)
+        req.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+
+        let cfg = URLSessionConfiguration.default
+        // A delegate gives us `didOpenWithProtocol` (socket actually opened) and
+        // `didCompleteWithError` (real failure, which we classify as cancellation
+        // vs. genuine). The forwarder is nonisolated and hops back into the actor.
+        let forwarder = DelegateForwarder()
+        let session = URLSession(configuration: cfg, delegate: forwarder, delegateQueue: nil)
+        let task = session.webSocketTask(with: req)
+        forwarder.owner = self
+        self.session = session
+        self.task = task
+        self.isActive = true
+
+        task.resume()
+
+        // Send the transcription session configuration.
+        sendSessionConfig()
+
+        // Start reading server events.
+        receiveLoop()
+
+        // Arm the connection watchdog. Cancelled on connect (didOpen /
+        // session.updated) or teardown.
+        startWatchdog()
+    }
+
+    /// Arm the connection watchdog: if neither the socket "opens" nor a first
+    /// server event lands within `connectTimeoutSeconds`, surface the friendly
+    /// connection-failed message and tear down. No-op if we connect first.
+    private func startWatchdog() {
+        watchdogTask?.cancel()
+        watchdogTask = Task { [connectTimeoutSeconds] in
+            try? await Task.sleep(nanoseconds: connectTimeoutSeconds * 1_000_000_000)
+            if Task.isCancelled { return }
+            self.watchdogFired()
+        }
+    }
+
+    /// The watchdog elapsed without the socket coming up. Treat as a connection
+    /// failure: report the friendly message once, then tear down cleanly so the
+    /// caller lands in a clean error/empty state (not stuck "listening").
+    private func watchdogFired() {
+        guard isActive, !didConnect else { return }
+        Self.log.error("connection watchdog fired: socket never came up in \(self.connectTimeoutSeconds, privacy: .public)s")
+        NSLog("[voice] error: connect timeout (%llus, socket never opened)", connectTimeoutSeconds)
+        reportError(Self.connectionFailedMessage)
+        // Mark inactive BEFORE closing so the in-flight receive loop / send
+        // completions classify their resulting errors as our cancellation and
+        // stay silent.
+        isActive = false
+        closeSocket()
+    }
+
+    /// Mark the socket as connected and cancel the watchdog. Called from the
+    /// delegate's `didOpenWithProtocol` and from the first server event. Idempotent.
+    private func markConnected(reason: String) {
+        guard !didConnect else { return }
+        didConnect = true
+        watchdogTask?.cancel()
+        watchdogTask = nil
+        Self.log.info("socket connected (\(reason, privacy: .public))")
+        NSLog("[voice] ws opened (%@)", reason)
+    }
+
+    /// Delegate callback (off-actor): the WebSocket handshake completed.
+    fileprivate func socketDidOpen() {
+        markConnected(reason: "didOpenWithProtocol")
+    }
+
+    /// Delegate callback (off-actor): the underlying task finished. Classify the
+    /// error: a cancellation (-999 / our own teardown) is suppressed; a genuine
+    /// transport failure before we connected is a connection failure.
+    fileprivate func socketDidComplete(error: Error?) {
+        if let error {
+            Self.log.error("task completed with error: \(error.localizedDescription, privacy: .public)")
+        } else {
+            Self.log.info("task completed cleanly")
+        }
+        // A clean completion, or one that arrives after we'd already connected
+        // and drained, needs no user-facing error.
+        if didConnect || !isActive {
+            NSLog("[voice] ws closed")
+            return
+        }
+        // We never connected and we're still active → genuine connection
+        // failure (unless it's a cancellation, which `isCancellation` filters out).
+        if Self.isCancellation(error) {
+            Self.log.debug("task completed via cancellation before connect — suppressed")
+            NSLog("[voice] ws closed (cancelled)")
+            isActive = false
+            closeSocket()
+            return
+        }
+        let classified = error?.localizedDescription ?? "no error object"
+        Self.log.error("connection failed before open: \(classified, privacy: .public)")
+        NSLog("[voice] error: connection failed before open (%@)", classified)
+        reportError(Self.connectionFailedMessage)
+        isActive = false
+        closeSocket()
+    }
+
+    /// True for errors we consider intentional/cancellation rather than a
+    /// genuine transport failure: `NSURLErrorCancelled` (-999, what a torn-down
+    /// or never-connected socket reports), `CancellationError`, and `nil`.
+    private static func isCancellation(_ error: Error?) -> Bool {
+        guard let error else { return true }
+        if error is CancellationError { return true }
+        let ns = error as NSError
+        if ns.domain == NSURLErrorDomain && ns.code == NSURLErrorCancelled { return true }
+        return false
+    }
+
+    /// True for the benign empty-buffer commit error the server returns when a
+    /// commit lands on an already-committed (empty) buffer. With server_vad the
+    /// server auto-commits each segment on pause, so a stray/redundant commit is
+    /// rejected here. Matched by substring across the known phrasings.
+    private static func isBenignCommitError(_ message: String) -> Bool {
+        let lower = message.lowercased()
+        return lower.contains("buffer too small")
+            || lower.contains("input_audio_buffer_commit_empty")
+            || lower.contains("expected at least 100ms")
+    }
+
+    /// Append one chunk of PCM16 audio (already 24kHz mono) as base64. Ignored
+    /// once we've started draining (post-commit) so we don't reopen a segment.
+    func appendAudio(_ pcm16: Data) {
+        guard isActive, !isDraining else { return }
+        let b64 = pcm16.base64EncodedString()
+        // Mark that there's uncommitted audio in the buffer; cleared when the
+        // server auto-commits on `speech_stopped` or when we commit in `finish()`.
+        hasUncommittedAudio = true
+        send([
+            "type": "input_audio_buffer.append",
+            "audio": b64
+        ])
+    }
+
+    /// Manual stop ("Stop Now" / inline-mic stop, before a natural pause).
+    ///
+    /// Force-close any open segment with a commit, then KEEP the socket open
+    /// and `isActive` true until the resulting `…completed` arrives (delivered
+    /// via `onCompleted`) or `drainTimeoutSeconds` elapses — only THEN close.
+    /// This is the fix for the discarded-transcript bug: the old code cancelled
+    /// the socket the instant it committed, so the post-commit transcript was
+    /// thrown away every time.
+    ///
+    /// In the natural-pause case server_vad auto-finalizes and `…completed`
+    /// arrives BEFORE any manual `finish()`, so this path is only hit on an
+    /// explicit stop. Idempotent: a second call while draining is a no-op.
+    func finish() {
+        guard isActive, !isDraining else { return }
+        isDraining = true
+        didReceiveFinalAfterCommit = false
+        // Only commit when there's uncommitted audio (a true manual "Stop Now"
+        // before the VAD pause). After a natural pause server_vad has already
+        // committed the segment and the buffer is empty — a redundant commit
+        // triggers the benign "buffer too small" server error (issue #151), so
+        // skip it and go straight to the drain/close.
+        if hasUncommittedAudio {
+            hasUncommittedAudio = false
+            send(["type": "input_audio_buffer.commit"])
+        } else {
+            Self.log.info("finish: skipping redundant commit (buffer already committed by server_vad)")
+            NSLog("[voice] finish: skip redundant commit (buffer empty)")
+        }
+
+        // Wait for the final transcript, but don't hang forever. The Task
+        // inherits this actor's isolation, so `drainTimedOut()` is a same-actor
+        // call (no `await` needed — that was the spurious-await warning).
+        Task { [drainTimeoutSeconds] in
+            try? await Task.sleep(nanoseconds: drainTimeoutSeconds * 1_000_000_000)
+            self.drainTimedOut()
+        }
+    }
+
+    /// Close the socket once the post-commit `…completed` has been delivered, or
+    /// after a connection failure / watchdog timeout. Tears down the task and
+    /// session and cancels the watchdog. Safe to call when already inactive
+    /// (the connection-failure paths flip `isActive` false BEFORE calling here,
+    /// so they can run teardown without re-reporting; hence no `isActive` guard).
+    private func closeSocket() {
+        Self.log.info("socket close (deltas this session: \(self.deltaCount, privacy: .public))")
+        NSLog("[voice] ws closed")
+        isActive = false
+        isDraining = false
+        watchdogTask?.cancel()
+        watchdogTask = nil
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+        session?.invalidateAndCancel()
+        session = nil
+    }
+
+    /// The drain timeout fired. If the final transcript already arrived we've
+    /// likely closed already; otherwise close now and let the caller fall back
+    /// to the running delta-built transcript.
+    private func drainTimedOut() {
+        guard isDraining else { return }
+        Self.log.info("drain timeout: closing without a post-commit completed (final lands from running deltas)")
+        closeSocket()
+    }
+
+    // MARK: Private
+
+    private func sendSessionConfig() {
+        let config: [String: Any] = [
+            "type": "session.update",
+            "session": [
+                "type": "transcription",
+                "audio": [
+                    "input": [
+                        "format": [
+                            "type": "audio/pcm",
+                            "rate": sampleRate
+                        ],
+                        // `language` intentionally OMITTED: the model
+                        // auto-detects Hindi vs English per utterance. Pinning
+                        // it to `hi` forced English audio to transcribe as
+                        // Hindi (empty/garbled), and script (Urdu vs Devanagari)
+                        // is normalized downstream, not here (issue #151).
+                        "transcription": [
+                            "model": transcriptionModel,
+                            "prompt": transcriptionPrompt
+                        ],
+                        // Server VAD is REQUIRED: with `turn_detection: null`
+                        // the server emits no deltas and only transcribes after
+                        // a manual commit. server_vad makes the server finalize
+                        // ~700ms after the user pauses and stream the result.
+                        "turn_detection": [
+                            "type": "server_vad",
+                            "silence_duration_ms": vadSilenceMs
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        send(config)
+    }
+
+    private func send(_ object: [String: Any]) {
+        guard let task else { return }
+        guard let data = try? JSONSerialization.data(withJSONObject: object),
+              let json = String(data: data, encoding: .utf8) else { return }
+        task.send(.string(json)) { [weak self] error in
+            guard let error else { return }
+            Task { await self?.handleSendFailure(error) }
+        }
+    }
+
+    /// A queued send failed. On a weak/torn-down socket the session-config and
+    /// audio appends fail with `-999` (NSURLErrorCancelled) because the socket
+    /// never finished connecting or has been cancelled — surfacing that as a
+    /// user error is exactly the spurious "cancelled" bug (issue #151). Suppress
+    /// any cancellation, or any failure once we're inactive/draining (our own
+    /// teardown). Report only a genuine transport failure on a live, non-draining
+    /// socket; the watchdog covers the never-connected case with a clearer message.
+    private func handleSendFailure(_ error: Error) {
+        if Self.isCancellation(error) || !isActive || isDraining {
+            Self.log.debug("send failure suppressed (cancellation or inactive): \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        Self.log.error("send failure on live socket: \(error.localizedDescription, privacy: .public)")
+        NSLog("[voice] error: send failed (%@)", error.localizedDescription)
+        reportError(error.localizedDescription)
+    }
+
+    private func receiveLoop() {
+        guard let task else { return }
+        task.receive { [weak self] result in
+            guard let self else { return }
+            Task { await self.handleReceive(result) }
+        }
+    }
+
+    private func handleReceive(_ result: Result<URLSessionWebSocketTask.Message, Error>) {
+        guard isActive else { return }
+        switch result {
+        case .failure(let error):
+            // A receive failure on a torn-down or never-connected socket is
+            // NSURLErrorCancelled (-999) — that's our own teardown, not a user
+            // error (issue #151). Suppress cancellations and any failure while
+            // inactive/draining; report only a genuine transport failure on a
+            // live socket. The watchdog handles the never-connected case.
+            if Self.isCancellation(error) || !isActive || isDraining {
+                Self.log.debug("receive failure suppressed (cancellation or inactive): \(error.localizedDescription, privacy: .public)")
+            } else {
+                Self.log.error("receive loop failure (socket dead): \(error.localizedDescription, privacy: .public)")
+                NSLog("[voice] error: receive failed (%@)", error.localizedDescription)
+                reportError(error.localizedDescription)
+            }
+            // Socket is dead — stop looping.
+            isActive = false
+        case .success(let message):
+            switch message {
+            case .string(let text):
+                parseServerEvent(text)
+            case .data(let data):
+                if let text = String(data: data, encoding: .utf8) {
+                    parseServerEvent(text)
+                }
+            @unknown default:
+                break
+            }
+            // Keep reading.
+            receiveLoop()
+        }
+    }
+
+    private func parseServerEvent(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = root["type"] as? String else { return }
+
+        switch type {
+        case "session.updated", "transcription_session.updated":
+            Self.log.info("session.updated received (transcription config accepted)")
+            NSLog("[voice] session.updated")
+            // First server event is the fallback "connected" signal (covers the
+            // case where the delegate's didOpen is missed/late). Cancels the watchdog.
+            markConnected(reason: "session.updated")
+        case "input_audio_buffer.speech_started":
+            Self.log.info("speech_started")
+            NSLog("[voice] speech_started")
+        case "input_audio_buffer.speech_stopped":
+            // server_vad has auto-committed this segment — the buffer is now
+            // empty, so a subsequent manual commit would be redundant.
+            hasUncommittedAudio = false
+            Self.log.info("speech_stopped (segment auto-committed by server_vad)")
+            NSLog("[voice] speech_stopped")
+        case "conversation.item.input_audio_transcription.delta",
+             "transcription.delta":
+            if let delta = root["delta"] as? String, !delta.isEmpty {
+                // Hot path — don't log per delta; count and log the total at
+                // completed / close.
+                deltaCount += 1
+                onDelta?(delta)
+            }
+        case "conversation.item.input_audio_transcription.completed",
+             "transcription.completed":
+            if let full = root["transcript"] as? String {
+                // Log length only, never the transcript text itself.
+                Self.log.info("completed transcript (len=\(full.count, privacy: .public), deltas=\(self.deltaCount, privacy: .public))")
+                NSLog("[voice] completed len=%d deltas=%d", full.count, deltaCount)
+                onCompleted?(full)
+            }
+            // If this arrived after a manual commit, the drain is done — close
+            // now rather than waiting out the timeout. (In the natural-pause /
+            // server_vad case isDraining is false and the socket stays open
+            // for the next utterance.)
+            if isDraining {
+                didReceiveFinalAfterCommit = true
+                closeSocket()
+            }
+        case "error":
+            if let err = root["error"] as? [String: Any],
+               let message = err["message"] as? String {
+                // Suppress the benign empty-buffer commit error: with server_vad
+                // the server auto-commits on pause, and any stray commit on the
+                // now-empty buffer is rejected with "buffer too small". It's not
+                // a real failure and must never surface to the user (issue #151).
+                if Self.isBenignCommitError(message) {
+                    Self.log.info("suppressing benign empty-commit error: \(message, privacy: .public)")
+                    NSLog("[voice] suppressed benign commit error")
+                    break
+                }
+                Self.log.error("server error event: \(message, privacy: .public)")
+                NSLog("[voice] error: server event (%@)", message)
+                reportError(message)
+            } else {
+                Self.log.error("server error event (no message)")
+                NSLog("[voice] error: server event (no message)")
+                reportError("Transcription error.")
+            }
+        default:
+            // Ignore session.created, buffer committed events, etc.
+            break
+        }
+    }
+
+    private func reportError(_ message: String) {
+        onError?(message)
+    }
+}
+
+/// Bridges `URLSessionWebSocketDelegate` callbacks (delivered on URLSession's
+/// delegate queue, off the actor) into the `OpenAIRealtimeTranscriber` actor.
+///
+/// `URLSession` holds the delegate strongly until `invalidateAndCancel()` (which
+/// `closeSocket()` calls), so this forwarder lives exactly as long as the socket
+/// session. `owner` is `weak` to avoid a retain cycle with the actor that owns
+/// the session that owns this delegate.
+private final class DelegateForwarder: NSObject, URLSessionWebSocketDelegate {
+    weak var owner: OpenAIRealtimeTranscriber?
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocol: String?
+    ) {
+        let owner = self.owner
+        Task { await owner?.socketDidOpen() }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        let owner = self.owner
+        Task { await owner?.socketDidComplete(error: error) }
+    }
+}

--- a/mobile/PersonalDashboard/Services/SpeechTranscriber.swift
+++ b/mobile/PersonalDashboard/Services/SpeechTranscriber.swift
@@ -1,31 +1,80 @@
 import AVFoundation
 import Foundation
 import Observation
+import os
 import Speech
 
-/// On-device speech-to-text for the chat input bar (issue #83).
+/// Speech-to-text for the chat input bar + full-screen voice capture overlay
+/// (issues #83, #150, #151).
 ///
-/// Wraps `SFSpeechRecognizer` + `AVAudioEngine`. All recognition happens on
-/// the phone — `requiresOnDeviceRecognition = true`. Audio never leaves the
-/// device; nothing is uploaded to Apple's servers and nothing is uploaded
-/// to Anthropic until the user hits send.
+/// Two engines behind ONE unchanged public surface:
 ///
-/// Usage from a SwiftUI view:
+///   • **OpenAI Realtime transcription** (preferred, issue #151). Streams mic
+///     audio over a WebSocket to OpenAI and gets back live transcript deltas.
+///     Auto-detects language (Hindi / English / Hinglish) because we omit the
+///     `language` field. Used whenever `AppConfig.openAIAPIKey` is set.
 ///
-///   @State private var transcriber = SpeechTranscriber()
-///   ...
-///   ChatInputBar(... onMic: { Task { await transcriber.toggle() } })
-///   .onChange(of: transcriber.transcript) { _, new in
-///       if transcriber.isRecording { viewModel.draftInput = new }
-///   }
+///   • **On-device `SFSpeechRecognizer`** (fallback, en-US). Used when no
+///     OpenAI key is configured at runtime, so the app stays usable offline /
+///     keyless. This is the original issue-#83 path, kept verbatim as the
+///     else-branch.
+///
+/// The choice is made per `start()` based on the key. Both engines feed the
+/// SAME `transcript` / `isRecording` / `audioLevel` surface, so the overlay,
+/// `VoiceCaptureViewModel`, `ChatView`, and `ChatInputBar` work unchanged:
+///   - `audioLevel` is always computed from the local mic tap (`normalizedRMS`
+///     + `publishLevel`), independent of which engine transcribes — reused
+///     verbatim from #150.
+///   - `transcript` updates incrementally while the user speaks (OpenAI: we
+///     append each delta; SFSpeech: the system hands back the full running
+///     string). Either way it holds the full text by the time
+///     `VoiceCaptureViewModel` snapshots it on silence.
+///   - The OpenAI engine uses server VAD: each pause is finalized as its own
+///     `…completed`, and utterances are accumulated (so multi-phrase dictation
+///     in one recording doesn't lose earlier text). A manual `stop()` commits
+///     any open segment and drains the socket for the final transcript.
 @Observable
 @MainActor
 final class SpeechTranscriber {
 
-    /// Live partial transcript while recording. Replaced (not appended)
-    /// every time `SFSpeechRecognizer` emits a partial result, because the
-    /// system already returns the full running transcript per callback.
+    /// Voice-pipeline diagnostics (issue #151). Same subsystem as the socket
+    /// client so a single Console.app filter shows the whole flow end to end.
+    private static let log = Logger(
+        subsystem: "com.akshaysharma.personaldashboard.voice",
+        category: "SpeechTranscriber"
+    )
+
+    /// One-shot flag so we log the first converted PCM16 chunk size once per
+    /// session rather than on every audio buffer (the tap fires continuously).
+    private var loggedFirstChunk = false
+
+    /// One-shot flag so we log only the FIRST transcript delta (marks when the
+    /// stream starts producing text) rather than every delta (a hot stream).
+    private var loggedFirstDelta = false
+
+    /// Live partial transcript while recording. For the OpenAI engine this is
+    /// built up by appending each `…transcription.delta` (deltas are
+    /// incremental, not cumulative) and replaced by the authoritative
+    /// `…transcription.completed` transcript when it arrives. For the SFSpeech
+    /// fallback it is replaced wholesale on every partial (the system already
+    /// returns the full running transcript per callback).
+    ///
+    /// NOTE (issue #151): the OpenAI transcript arrives ASYNC — with server VAD
+    /// the `…completed` lands ~0.5s after the user pauses, and on a manual stop
+    /// it lands shortly after the commit. So `transcript` keeps updating from
+    /// the socket even after `stop()` has flipped `isRecording` false, until
+    /// the socket drains. Callers must NOT assume `transcript` is final the
+    /// instant they call `stop()`; observe `didFinalizeTranscript` (or the
+    /// `transcript` itself) instead of snapshotting synchronously.
     private(set) var transcript: String = ""
+
+    /// Monotonic counter bumped each time a non-empty authoritative transcript
+    /// is delivered (OpenAI `…completed`, or SFSpeech final). `@Observable`
+    /// callers can watch this to finalize off the transcript actually being
+    /// present rather than racing a synchronous snapshot at stop time. The
+    /// counter (vs. a Bool) guarantees a distinct value per finalize so
+    /// back-to-back finals each register as a change.
+    private(set) var didFinalizeTranscript: Int = 0
 
     /// True between a successful start and the corresponding stop. The
     /// chat view uses this both to mirror `transcript` into the input
@@ -41,7 +90,8 @@ final class SpeechTranscriber {
     /// low-pass filtered (rolling average over the last 4 frames) so it
     /// doesn't strobe. Drives the voice-capture InkOrb animation (issue #150).
     /// Resets to 0 on stop. No extra permission needed — it reads the same
-    /// buffer the recognizer already taps.
+    /// buffer the recognizer already taps. Independent of the transcription
+    /// engine; computed identically for OpenAI and SFSpeech paths.
     private(set) var audioLevel: Float = 0
 
     // MARK: Private state
@@ -53,6 +103,12 @@ final class SpeechTranscriber {
     private var levelWindow: [Float] = []
     private let levelWindowSize = 4
 
+    /// Which engine the current (or most recent) session is using. Decided in
+    /// `start()` so `stop()` tears down the right one.
+    private enum Engine { case openAI, onDevice }
+    private var engine: Engine = .onDevice
+
+    // -- On-device (SFSpeech) state --
     private let recognizer: SFSpeechRecognizer? = {
         // Force en-US — `.dictation` taskHint plus on-device model is best
         // tuned here. Falling back to the user's locale is fine in theory
@@ -63,6 +119,24 @@ final class SpeechTranscriber {
     private let audioEngine = AVAudioEngine()
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
+
+    // -- OpenAI Realtime state --
+    private let openAI = OpenAIRealtimeTranscriber()
+    /// Finalized (script-normalized) utterances for the current OpenAI session,
+    /// joined with spaces. server_vad finalizes each pause as its own
+    /// `…completed`, so one recording can yield several; accumulating here means
+    /// a later utterance never clobbers an earlier one — the fix for the inline
+    /// transcript "disappearing" mid-session (issue #151).
+    private var committedTranscript: String = ""
+    /// Raw deltas for the utterance currently being spoken (before its
+    /// `…completed` lands). Appended to `committedTranscript` for the live view,
+    /// then folded in (normalized) and cleared when the utterance completes.
+    private var pendingDeltas: String = ""
+    /// Converts the mic tap's native format into the PCM16 mono @ 24kHz that
+    /// the Realtime API expects. Built lazily per session because the input
+    /// node's hardware format isn't known until the engine is configured.
+    private var pcm16Converter: AVAudioConverter?
+    private var pcm16Format: AVAudioFormat?
 
     /// Synchronous re-entry guard for the async start window. `isRecording`
     /// alone is insufficient: `start()` only flips it to true at the very end,
@@ -96,20 +170,38 @@ final class SpeechTranscriber {
         // (issue #150). `start()`'s own `defer` normally handles this.
         isStarting = false
         guard isRecording else { return }
+        Self.log.info("stop() called (engine: \(self.engine == .openAI ? "openAI" : "onDevice", privacy: .public))")
         isRecording = false
         audioLevel = 0
         levelWindow.removeAll()
 
-        // End-of-audio first, then tear down the engine. `endAudio()` lets
-        // SFSpeech finalize a "best result" partial; cancelling the task
-        // would discard it.
-        request?.endAudio()
+        // Tear down the mic tap + engine first (shared by both engines).
         if audioEngine.isRunning {
             audioEngine.stop()
             audioEngine.inputNode.removeTap(onBus: 0)
         }
-        request = nil
-        task = nil
+
+        switch engine {
+        case .openAI:
+            // Commit the buffered audio so OpenAI force-finalizes the current
+            // segment. `finish()` KEEPS the socket open until the resulting
+            // `…transcription.completed` arrives (or a short timeout), so the
+            // final transcript is delivered through `onCompleted` and never
+            // discarded (issue #151). The mic tap is already removed above, so
+            // no more audio is appended; the transcript will land async and
+            // bump `didFinalizeTranscript` for the caller to finalize off.
+            pcm16Converter = nil
+            pcm16Format = nil
+            // `openAI` is an actor; hop off the main actor to commit + drain.
+            let socket = openAI
+            Task { await socket.finish() }
+        case .onDevice:
+            // End-of-audio first, then tear down. `endAudio()` lets SFSpeech
+            // finalize a "best result" partial; cancelling would discard it.
+            request?.endAudio()
+            request = nil
+            task = nil
+        }
 
         // Deactivate the audio session so Music / podcasts resume cleanly.
         // `.notifyOthersOnDeactivation` is what makes the resume happen.
@@ -133,22 +225,256 @@ final class SpeechTranscriber {
 
         errorMessage = nil
         transcript = ""
+        committedTranscript = ""
+        pendingDeltas = ""
+        loggedFirstChunk = false
+        loggedFirstDelta = false
+
+        // Pick the engine for this session: OpenAI when a key is present,
+        // on-device SFSpeech otherwise (keyless / offline fallback).
+        let keyPresent = (AppConfig.openAIAPIKey?.isEmpty == false)
+        let useOpenAI = keyPresent
+        engine = useOpenAI ? .openAI : .onDevice
+        Self.log.info("engine chosen: \(useOpenAI ? "openAI" : "onDevice", privacy: .public) (openAI key present: \(keyPresent, privacy: .public))")
+        // idevicesyslog-visible (os.Logger .info lines aren't relayed). Never
+        // logs the key itself — only whether one is present.
+        NSLog("[voice] engine=%@ keyPresent=%@", useOpenAI ? "openAI" : "onDevice", keyPresent ? "true" : "false")
+
+        // Microphone permission is required for both engines.
+        let micOK = await Self.requestMicrophonePermission()
+        guard micOK else {
+            errorMessage = "Enable Microphone access for Dexter in Settings."
+            return
+        }
+
+        if useOpenAI {
+            await startOpenAI()
+        } else {
+            await startOnDevice()
+        }
+    }
+
+    // MARK: OpenAI Realtime engine
+
+    private func startOpenAI() async {
+        guard let apiKey = AppConfig.openAIAPIKey, !apiKey.isEmpty else {
+            // Shouldn't happen (start() already checked) — fall back defensively.
+            await startOnDevice()
+            return
+        }
+
+        // Audio session: `.record` + `.measurement` minimizes processing
+        // (no echo cancellation tuned for voice calls); `.duckOthers` dims
+        // background audio while we're listening.
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.record, mode: .measurement, options: [.duckOthers])
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+        } catch {
+            errorMessage = "Couldn't start the microphone (\(error.localizedDescription))."
+            return
+        }
+
+        // Target format for the Realtime API: PCM16, mono, 24kHz.
+        guard let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: 24_000,
+            channels: 1,
+            interleaved: true
+        ) else {
+            errorMessage = "Couldn't configure audio for transcription."
+            return
+        }
+        pcm16Format = targetFormat
+
+        let inputNode = audioEngine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+        pcm16Converter = AVAudioConverter(from: inputFormat, to: targetFormat)
+
+        // Open the socket and configure the transcription session. If the
+        // connection setup throws, surface an error and bail before touching
+        // the audio engine so we leave nothing half-initialized.
+        do {
+            try await openAI.connect(
+                apiKey: apiKey,
+                onDelta: { [weak self] delta in
+                    // Deltas are incremental — append to build the running
+                    // transcript. Hop to the main actor (socket callbacks are
+                    // off the main actor). We intentionally do NOT guard on
+                    // `isRecording` here: with server VAD the deltas (and the
+                    // `…completed` below) arrive AFTER the user pauses / after a
+                    // manual commit, by which point `stop()` may already have
+                    // flipped `isRecording` false. Dropping them on that guard
+                    // is exactly the discarded-transcript bug (issue #151). The
+                    // engine guard alone is enough to ignore a stale session.
+                    Task { @MainActor in
+                        guard let self, self.engine == .openAI else { return }
+                        // Live view = finalized utterances so far + this
+                        // utterance's raw deltas. The raw (possibly Urdu) deltas
+                        // are replaced by the normalized text when the utterance
+                        // completes below.
+                        self.pendingDeltas += delta
+                        self.transcript = self.committedTranscript.isEmpty
+                            ? self.pendingDeltas
+                            : self.committedTranscript + " " + self.pendingDeltas
+                        if !self.loggedFirstDelta {
+                            self.loggedFirstDelta = true
+                            Self.log.info("transcript updating from deltas (first delta received)")
+                        }
+                    }
+                },
+                onCompleted: { [weak self] fullText in
+                    // Authoritative final text for the utterance. Replace the
+                    // running transcript with it so any delta drift is
+                    // corrected. Only adopt non-empty finals. Survives past
+                    // `stop()` for the same reason as `onDelta` above, and bumps
+                    // `didFinalizeTranscript` so the caller can finalize off the
+                    // transcript actually being present rather than a synchronous
+                    // snapshot that races the network.
+                    Task { @MainActor in
+                        guard let self, self.engine == .openAI else { return }
+                        let trimmed = fullText.trimmingCharacters(in: .whitespacesAndNewlines)
+                        guard !trimmed.isEmpty else { return }
+                        // Normalize Urdu (Perso-Arabic) → Hindi (Devanagari) so
+                        // the preview only ever shows Hindi or English, never
+                        // Urdu. English / already-Devanagari text returns
+                        // unchanged with no API call (issue #151).
+                        let normalized = await HindiScriptNormalizer.normalize(trimmed)
+                        // The session may have ended (or switched engine) during
+                        // the async normalize — bail so we don't write stale text.
+                        guard self.engine == .openAI else { return }
+                        // Fold this utterance into the committed transcript and
+                        // clear the pending deltas so the next utterance starts
+                        // clean. Cumulative: multi-utterance dictation in one
+                        // recording never drops earlier text.
+                        self.committedTranscript = self.committedTranscript.isEmpty
+                            ? normalized
+                            : self.committedTranscript + " " + normalized
+                        self.pendingDeltas = ""
+                        self.transcript = self.committedTranscript
+                        self.didFinalizeTranscript &+= 1
+                        Self.log.info("transcript updated from completed (len=\(self.transcript.count, privacy: .public)); didFinalizeTranscript bumped to \(self.didFinalizeTranscript, privacy: .public)")
+                        // idevicesyslog-visible. Length only, never the text.
+                        NSLog("[voice] transcript set len=%d", self.transcript.count)
+                        NSLog("[voice] finalize len=%d", self.transcript.count)
+                    }
+                },
+                onError: { [weak self] message in
+                    Task { @MainActor in
+                        guard let self, self.engine == .openAI else { return }
+                        // Surface the message inline / to the overlay.
+                        self.errorMessage = message
+                        // A connection failure (never connected, transport
+                        // error, or watchdog timeout) means there will be no
+                        // transcript ever — the socket is already torn down on
+                        // the transcriber side. If we're still flagged
+                        // "recording", stop so `isRecording` flips false: that
+                        // is the single signal both callers watch to leave the
+                        // listening state cleanly instead of hanging (issue
+                        // #151). A transient/server error mid-session is NOT a
+                        // connection failure — leave the session alone there so
+                        // the silence timer / stop() still drive finalize.
+                        if message == OpenAIRealtimeTranscriber.connectionFailedMessage, self.isRecording {
+                            Self.log.info("connection failure onError → stopping to flip isRecording")
+                            NSLog("[voice] error: connection failed; stopping session")
+                            self.stop()
+                        }
+                    }
+                }
+            )
+        } catch {
+            errorMessage = "Couldn't reach voice transcription (\(error.localizedDescription))."
+            return
+        }
+
+        // Install the mic tap: meter the level AND ship converted PCM16 to OpenAI.
+        // Defensive removeTap before installTap (issue #150 crash guard).
+        // The converter, target format, and OpenAI actor are captured as locals
+        // (all `Sendable`/immutable refs) so the tap never reaches back into
+        // `@MainActor` state from its background queue.
+        let converter = pcm16Converter
+        let outFormat = targetFormat
+        let socket = openAI
+        inputNode.removeTap(onBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { [weak self] buffer, _ in
+            // (1) Level metering — identical to the original path.
+            let level = Self.normalizedRMS(buffer)
+            Task { @MainActor in self?.publishLevel(level) }
+            // (2) Convert + send to OpenAI. Done on this background queue (cheap).
+            guard let converter, let data = Self.convertToPCM16(buffer, using: converter, to: outFormat) else { return }
+            // Log the first converted chunk size once (not every buffer — this
+            // tap fires continuously). The flag lives on the main actor.
+            let chunkBytes = data.count
+            Task { @MainActor in
+                guard let self, !self.loggedFirstChunk else { return }
+                self.loggedFirstChunk = true
+                Self.log.info("first converted PCM16 chunk: \(chunkBytes, privacy: .public) bytes")
+            }
+            Task { await socket.appendAudio(data) }
+        }
+        Self.log.info("audio tap installed (OpenAI engine)")
+
+        audioEngine.prepare()
+        do {
+            try audioEngine.start()
+        } catch {
+            inputNode.removeTap(onBus: 0)
+            let socket = openAI
+            Task { await socket.finish() }
+            pcm16Converter = nil
+            pcm16Format = nil
+            errorMessage = "Couldn't start audio capture (\(error.localizedDescription))."
+            return
+        }
+
+        isRecording = true
+    }
+
+    /// Convert one mic buffer to PCM16 mono @ 24kHz and return the raw little-
+    /// endian bytes. Pure function — safe to call on the audio tap's background
+    /// queue. Returns nil if conversion yields nothing.
+    private nonisolated static func convertToPCM16(
+        _ buffer: AVAudioPCMBuffer,
+        using converter: AVAudioConverter,
+        to outFormat: AVAudioFormat
+    ) -> Data? {
+        // Output capacity scaled by the sample-rate ratio (input → 24kHz).
+        let ratio = outFormat.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio + 1024)
+        guard let outBuffer = AVAudioPCMBuffer(pcmFormat: outFormat, frameCapacity: capacity) else { return nil }
+
+        var fed = false
+        var convErr: NSError?
+        let status = converter.convert(to: outBuffer, error: &convErr) { _, inputStatus in
+            if fed {
+                inputStatus.pointee = .noDataNow
+                return nil
+            }
+            fed = true
+            inputStatus.pointee = .haveData
+            return buffer
+        }
+        guard status != .error, convErr == nil, outBuffer.frameLength > 0,
+              let channelData = outBuffer.int16ChannelData else { return nil }
+
+        let byteCount = Int(outBuffer.frameLength) * MemoryLayout<Int16>.size
+        return Data(bytes: channelData[0], count: byteCount)
+    }
+
+    // MARK: On-device (SFSpeech) fallback engine
+
+    private func startOnDevice() async {
+        engine = .onDevice
 
         guard let recognizer, recognizer.isAvailable else {
             errorMessage = "Speech recognition isn't available on this device."
             return
         }
 
-        // Permissions: speech recognition + microphone. Both must be granted
-        // before we touch the audio engine, otherwise `installTap` traps.
+        // Speech-recognition permission (mic already granted by start()).
         let speechOK = await Self.requestSpeechAuthorization()
         guard speechOK else {
             errorMessage = "Enable Speech Recognition for Dexter in Settings."
-            return
-        }
-        let micOK = await Self.requestMicrophonePermission()
-        guard micOK else {
-            errorMessage = "Enable Microphone access for Dexter in Settings."
             return
         }
 

--- a/mobile/PersonalDashboard/ViewModels/VoiceCaptureViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/VoiceCaptureViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os
 import Speech
 import AVFoundation
 import UIKit
@@ -34,11 +35,24 @@ final class VoiceCaptureViewModel {
         case error(String)      // G  — transcription or AI failure (message)
     }
 
+    /// Voice-pipeline diagnostics (issue #151). Same subsystem as the
+    /// transcriber + socket client so one Console.app filter shows the whole
+    /// overlay flow: state transitions, silence-timer fire, finalize snapshot.
+    private static let log = Logger(
+        subsystem: "com.akshaysharma.personaldashboard.voice",
+        category: "VoiceCaptureViewModel"
+    )
+
     /// The single shared transcriber. Exposed so `ChatView`'s inline mic and
     /// the overlay both read the same instance (audioLevel, transcript, etc.).
     let transcriber = SpeechTranscriber()
 
-    private(set) var state: State = .listening
+    private(set) var state: State = .listening {
+        didSet {
+            guard state != oldValue else { return }
+            Self.log.info("state: \(String(describing: oldValue), privacy: .public) → \(String(describing: self.state), privacy: .public)")
+        }
+    }
 
     /// Success rows for State D — one per applied action.
     private(set) var successLabels: [String] = []
@@ -84,6 +98,12 @@ final class VoiceCaptureViewModel {
 
     private var safetyTask: Task<Void, Never>?
     private var executeTask: Task<Void, Never>?
+    /// Awaits the async final transcript after a manual stop that raced the
+    /// network (issue #151). Cancelled by teardown / restart.
+    private var awaitFinalTask: Task<Void, Never>?
+    /// Max time to wait for the async `…completed` after a manual stop before
+    /// giving up. Comfortably covers the transcriber's own ~2s socket drain.
+    private let finalTranscriptTimeout: TimeInterval = 2.5
 
     // MARK: Lifecycle
 
@@ -92,6 +112,14 @@ final class VoiceCaptureViewModel {
         successLabels = []
         errorMessageText = nil
         finalizedTranscript = ""
+        // Reset to .listening SYNCHRONOUSLY. This VM is a single shared
+        // instance, so after a prior capture `state` is still a terminal value
+        // (e.g. .success). `startListening()` runs in a Task (one runloop
+        // later), so without this the overlay's first render on re-open shows
+        // the stale terminal state — which mounts the success auto-dismiss line
+        // and schedules a 2s dismiss that closes the overlay right after it
+        // opens (issue #151, second-open bug).
+        state = .listening
         Task { await startListening() }
     }
 
@@ -116,12 +144,42 @@ final class VoiceCaptureViewModel {
         }
     }
 
+    /// A transcriber error surfaced asynchronously while we were listening (most
+    /// commonly a connection failure: the WebSocket never came up on a weak
+    /// link, issue #151). The transcriber has already torn its socket down and
+    /// flipped `isRecording` false, so there will be no transcript. Route the
+    /// overlay to its error state (State G) with the friendly message rather
+    /// than hanging in `.listening` forever. Only acts from the live "before
+    /// finalize" states — once we're past finalize the execute path owns errors.
+    func handleTranscriberError(_ message: String) {
+        switch state {
+        case .listening, .safetyWindow:
+            cancelTimers()
+            Self.log.info("transcriber error while pre-finalize → State G")
+            errorMessageText = Self.stripTechnicalPrefix(message)
+            state = .error(errorMessageText ?? "Something went wrong.")
+        case .executing, .success, .empty, .permissionDenied, .error:
+            // Past finalize (or already terminal): the execute path / existing
+            // terminal state owns the UI. Don't override it.
+            break
+        }
+    }
+
     /// Re-arm the 1.5s silence countdown. Called by the overlay on every
     /// transcript partial while in State A. Resets on each word; when it fires
     /// with a non-empty transcript we enter the safety window, with an empty
     /// one we go to State E.
     func scheduleSilenceFinalize() {
         guard state == .listening else { return }
+        // Never arm on an empty transcript. With the OpenAI engine the
+        // transcript is empty — and stays empty — WHILE the user is still
+        // speaking (server VAD only emits text after a pause). The overlay
+        // arms this on every transcript change, including the empty reset at
+        // open, which fired the timer mid-speech and killed the session before
+        // it captured anything ("stops as soon as it opens", issue #151). Arm
+        // only once real text exists; server VAD's own turn detection is what
+        // produces that text after the user pauses.
+        guard !transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         silenceTimer?.invalidate()
         silenceTimer = Timer.scheduledTimer(
             withTimeInterval: silenceDelay,
@@ -133,6 +191,7 @@ final class VoiceCaptureViewModel {
 
     private func onSilenceElapsed() {
         guard state == .listening else { return }
+        Self.log.info("silence timer fired")
         let text = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         if text.isEmpty {
             transcriber.stop()
@@ -142,28 +201,108 @@ final class VoiceCaptureViewModel {
         }
     }
 
-    /// "Stop Now" (State A): skip the silence wait and go straight to the
-    /// safety window if there's content, else State E.
+    /// "Stop Now" (State A): skip the silence wait and finalize immediately.
+    ///
+    /// With server VAD the transcript arrives async (issue #151): if the user
+    /// taps Stop before pausing, no `…completed` has landed yet and a
+    /// synchronous snapshot would be empty. So when the snapshot is empty we
+    /// commit (via `stop()`) and AWAIT the async final transcript before
+    /// deciding between the safety window and State E, rather than racing the
+    /// network. When the snapshot is already non-empty (the user paused first,
+    /// so `…completed` landed) we proceed straight to the safety window.
     func stopNow() {
         guard state == .listening else { return }
         let text = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
         if text.isEmpty {
-            transcriber.stop()
-            state = .empty
+            awaitFinalThenFinalize()
         } else {
             enterSafetyWindow()
         }
     }
 
-    /// A → A1. Stop the mic, snapshot the transcript, fire a light haptic, and
-    /// start the 1.5s safety countdown that auto-executes unless cancelled.
+    /// Stop the mic (commits + drains the socket) and wait for the async final
+    /// transcript. Used by the manual-stop path that can race the network. If a
+    /// non-empty transcript lands before the timeout we enter the safety
+    /// window; otherwise State E (silence detected, no speech).
+    private func awaitFinalThenFinalize() {
+        cancelTimers()
+        // Show the "Got it" safety window immediately so the UI isn't frozen
+        // while we wait for the network, but DON'T snapshot/execute yet — the
+        // safety countdown is (re)started once the real transcript lands.
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        transcriber.stop() // commit + drain; transcript lands async
+        state = .safetyWindow
+
+        let baseline = transcriber.didFinalizeTranscript
+        awaitFinalTask?.cancel()
+        awaitFinalTask = Task { [finalTranscriptTimeout] in
+            let deadline = Date().addingTimeInterval(finalTranscriptTimeout)
+            // Poll for a finalize signal or non-empty transcript. Cheap: a few
+            // 100ms ticks over at most ~2.5s, cancelled as soon as we resolve.
+            while Date() < deadline {
+                if Task.isCancelled { return }
+                if transcriber.didFinalizeTranscript != baseline
+                    || !transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    break
+                }
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
+            if Task.isCancelled { return }
+            let text = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+            if text.isEmpty {
+                state = .empty
+            } else {
+                // Snapshot the now-arrived transcript and start the real safety
+                // countdown to auto-execute.
+                finalizedTranscript = text
+                Self.log.info("finalize snapshot (async after manual stop): len=\(text.count, privacy: .public)")
+                startSafetyCountdown()
+            }
+        }
+    }
+
+    /// A → A1. Stop the mic, snapshot the (already-present) transcript, fire a
+    /// light haptic, and start the 1.5s safety countdown that auto-executes
+    /// unless cancelled. Used when the transcript is already non-empty (natural
+    /// pause: `…completed` has landed). The racy manual-stop case goes through
+    /// `awaitFinalThenFinalize()` instead.
     private func enterSafetyWindow() {
         cancelTimers()
         finalizedTranscript = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        Self.log.info("finalize snapshot (natural pause): len=\(self.finalizedTranscript.count, privacy: .public)")
+        let snapshotFinalize = transcriber.didFinalizeTranscript
         transcriber.stop()
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
         state = .safetyWindow
+        startSafetyCountdown()
+        // If the snapshot is still in Urdu script, the Devanagari-normalized
+        // final may land during the socket drain (issue #151). Watch for the
+        // next `…completed` within the safety window and adopt the normalized
+        // text so both the preview and the parsed input use Hindi, not Urdu.
+        // Only for the Urdu case — English / Devanagari snapshots are final.
+        if HindiScriptNormalizer.containsPersoArabic(finalizedTranscript) {
+            awaitFinalTask?.cancel()
+            awaitFinalTask = Task { [safetyWindowDelay] in
+                let deadline = Date().addingTimeInterval(safetyWindowDelay)
+                while Date() < deadline {
+                    if Task.isCancelled { return }
+                    if transcriber.didFinalizeTranscript != snapshotFinalize {
+                        let updated = transcriber.transcript
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !updated.isEmpty { finalizedTranscript = updated }
+                        return
+                    }
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                }
+            }
+        }
+    }
 
+    /// Start (or restart) the 1.5s safety countdown that auto-executes
+    /// `finalizedTranscript` unless cancelled. Assumes `state == .safetyWindow`
+    /// and `finalizedTranscript` is set.
+    private func startSafetyCountdown() {
+        safetyTask?.cancel()
         safetyTask = Task { [safetyWindowDelay] in
             try? await Task.sleep(nanoseconds: UInt64(safetyWindowDelay * 1_000_000_000))
             if Task.isCancelled { return }
@@ -216,6 +355,7 @@ final class VoiceCaptureViewModel {
         cancelTimers()
         safetyTask?.cancel(); safetyTask = nil
         executeTask?.cancel(); executeTask = nil
+        awaitFinalTask?.cancel(); awaitFinalTask = nil
         transcriber.stop()
     }
 
@@ -233,6 +373,8 @@ final class VoiceCaptureViewModel {
         silenceTimer = nil
         safetyTask?.cancel()
         safetyTask = nil
+        awaitFinalTask?.cancel()
+        awaitFinalTask = nil
     }
 
     private func routeStartFailure() {

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -18,6 +18,22 @@ struct ChatView: View {
     /// restores the baseline so we don't clobber typed text on a misfire.
     @State private var preMicBaseline: String = ""
 
+    /// Tracks an in-progress inline-mic session (issue #151). With the OpenAI
+    /// streaming engine the transcript arrives ASYNC, AFTER `stop()` has flipped
+    /// `transcriber.isRecording` false (server_vad finalizes ~0.5s after a pause;
+    /// a manual stop commits, then the `…completed` lands ~1-2s later). So we
+    /// can't gate transcript-mirroring on `isRecording` — that drops the inline
+    /// transcript every time. Instead we open this flag when the inline mic
+    /// starts and keep it true through the async tail until the final transcript
+    /// has landed (observed via `didFinalizeTranscript`) or the session is
+    /// superseded by a send / a new mic start. Mirrors the await-the-final
+    /// pattern already used in `VoiceCaptureViewModel`.
+    @State private var inlineMicActive = false
+    /// Baseline value of `transcriber.didFinalizeTranscript` captured when the
+    /// inline session starts, so we can tell when a NEW non-empty final lands
+    /// during THIS session (vs. a stale bump from a prior one).
+    @State private var inlineMicFinalizeBaseline = 0
+
     /// Silence-finalize timer (issue #150). Each transcript update from the
     /// transcriber resets this; when it fires after `silenceFinalizeDelay` of
     /// no new partials, we stop the mic and leave the transcript in the input
@@ -169,30 +185,59 @@ struct ChatView: View {
             // baseline (whatever was typed before mic-tap) instead of
             // replacing — keeps already-typed context intact.
             //
+            // Gated on `inlineMicActive` (NOT `transcriber.isRecording`): with
+            // the OpenAI engine the transcript lands AFTER `isRecording` has
+            // gone false, so gating on `isRecording` drops the final text every
+            // time (issue #151). The inline session stays open through that
+            // async tail, so this mirroring still fires when the post-stop
+            // transcript arrives.
+            //
             // Suppressed while the global voice overlay is presented: the
             // overlay's `VoiceCaptureViewModel` owns the transcript and its
             // own silence timer in that mode, so the inline chat mirroring
             // must stand down to avoid two owners writing the same transcriber.
-            guard transcriber.isRecording, !router.showVoiceOverlay else { return }
-            if newTranscript.isEmpty {
-                viewModel.draftInput = preMicBaseline
-            } else if preMicBaseline.isEmpty {
-                viewModel.draftInput = newTranscript
-            } else {
-                viewModel.draftInput = preMicBaseline + " " + newTranscript
-            }
+            guard inlineMicActive, !router.showVoiceOverlay else { return }
+            mirrorTranscript(newTranscript)
             // Each new partial is a sign of speech: reset the silence
             // countdown. Once partials stop arriving for `silenceFinalizeDelay`
-            // the timer fires and finalizes (issue #150).
-            scheduleSilenceFinalize()
+            // the timer fires and finalizes (issue #150). Only meaningful while
+            // the mic is genuinely still recording — the post-stop async tail
+            // shouldn't re-arm a finalize timer.
+            if transcriber.isRecording { scheduleSilenceFinalize() }
+        }
+        .onChange(of: transcriber.didFinalizeTranscript) { _, _ in
+            // A non-empty authoritative transcript landed. If it belongs to the
+            // current inline session (counter advanced past our baseline), make
+            // sure it's in the input field, then close the inline session so a
+            // later session can't bleed this text in. The overlay path ignores
+            // this — it owns the transcriber when presented (issue #151).
+            guard inlineMicActive, !router.showVoiceOverlay else { return }
+            guard transcriber.didFinalizeTranscript > inlineMicFinalizeBaseline else { return }
+            mirrorTranscript(transcriber.transcript)
+            // Only close the session once the mic has actually stopped. While
+            // it's still recording, server_vad finalizes each pause as its own
+            // `…completed`, so closing here would drop every utterance after the
+            // first (the mid-session "disappearing" bug). The transcriber
+            // accumulates across utterances, so mirroring the running transcript
+            // keeps the full text in the field until the user stops (issue #151).
+            if !transcriber.isRecording { endInlineMicSession() }
         }
         .onChange(of: transcriber.isRecording) { _, recording in
             // If recording ends for any reason (user tapped stop, an error,
             // or our own finalize), tear the silence timer down so it can't
-            // fire against a dead session.
+            // fire against a dead session. We deliberately do NOT end the inline
+            // mic session here: the OpenAI final transcript arrives AFTER
+            // `isRecording` goes false, and the session must stay open to catch
+            // it (issue #151). The session is closed on `didFinalizeTranscript`,
+            // on send, or when a new mic session starts.
             if !recording { cancelSilenceTimer() }
         }
-        .onDisappear { cancelSilenceTimer() }
+        .onDisappear {
+            cancelSilenceTimer()
+            // Leaving chat ends any inline session so a late async transcript
+            // can't write into the field after the user has navigated away.
+            endInlineMicSession()
+        }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
             withAnimation(.easeOut(duration: 0.18)) { keyboardVisible = true }
         }
@@ -302,6 +347,11 @@ struct ChatView: View {
         if transcriber.isRecording {
             stopListening()
         }
+        // The user committed to sending whatever's in the field now. End the
+        // inline mic session so a still-in-flight async transcript from this
+        // session can't land in `draftInput` after the message has shipped
+        // (issue #151).
+        endInlineMicSession()
         Task { await viewModel.send() }
     }
 
@@ -332,15 +382,46 @@ struct ChatView: View {
         // Snapshot what's already in the field so live partials append to it
         // rather than overwriting typed context.
         preMicBaseline = viewModel.draftInput
+        // Open the inline mic session BEFORE starting the transcriber. Each
+        // `transcriber.start()` resets `transcript` to "" and we re-capture the
+        // baseline here, so a fresh session is clean and can't inherit a prior
+        // session's text. Baseline the finalize counter so we only react to a
+        // NEW non-empty final from this session (issue #151).
+        inlineMicActive = true
+        inlineMicFinalizeBaseline = transcriber.didFinalizeTranscript
         await transcriber.toggle()
     }
 
     /// Stop the transcriber and leave the transcript in the input field as
     /// editable text. Deliberately does NOT submit — the user reads/edits and
     /// taps send, or speaks again to append (issue #150).
+    ///
+    /// Does NOT end the inline mic session: with the OpenAI engine the final
+    /// transcript arrives AFTER this returns, so the session must stay open to
+    /// catch it (issue #151). It closes on `didFinalizeTranscript`, on send, or
+    /// when a new session starts.
     private func stopListening() {
         transcriber.stop()
         cancelSilenceTimer()
+    }
+
+    /// Write the live/final transcript into the input field, appended to the
+    /// pre-mic baseline so typed context survives. Shared by the partial-
+    /// mirroring and the final-landing paths so they stay consistent.
+    private func mirrorTranscript(_ text: String) {
+        if text.isEmpty {
+            viewModel.draftInput = preMicBaseline
+        } else if preMicBaseline.isEmpty {
+            viewModel.draftInput = text
+        } else {
+            viewModel.draftInput = preMicBaseline + " " + text
+        }
+    }
+
+    /// Close the inline mic session so a later session can't inherit this one's
+    /// async transcript. Safe to call repeatedly (issue #151).
+    private func endInlineMicSession() {
+        inlineMicActive = false
     }
 
     /// (Re)arm the silence-finalize countdown. Called on every transcript

--- a/mobile/PersonalDashboard/Views/Chat/VoiceCaptureOverlay.swift
+++ b/mobile/PersonalDashboard/Views/Chat/VoiceCaptureOverlay.swift
@@ -63,6 +63,14 @@ struct VoiceCaptureOverlay: View {
         .onChange(of: vm.transcript) { _, _ in
             vm.scheduleSilenceFinalize()
         }
+        .onChange(of: vm.transcriber.errorMessage) { _, message in
+            // A connection failure (or other transcriber error) arriving async
+            // while we're listening must route the overlay to State G with the
+            // friendly message instead of hanging in "Listening" (issue #151).
+            if let message, !message.isEmpty {
+                vm.handleTranscriberError(message)
+            }
+        }
         .onChange(of: vm.state) { _, newState in
             announce(for: newState)
             if newState != .listening, !vm.transcript.isEmpty, !hasSeenVoiceHint {
@@ -393,6 +401,11 @@ private struct AutoDismissProgressLine: View {
     let reduceMotion: Bool
     let onComplete: () -> Void
     @State private var progress: CGFloat = 0
+    /// The pending dismissal, held so it can be cancelled if this line is
+    /// removed from the tree before it fires (e.g. a stale success state mounts
+    /// it for one frame on re-open). Without cancellation the dismiss fired
+    /// anyway and closed a freshly-opened overlay (issue #151).
+    @State private var pendingDismiss: DispatchWorkItem?
 
     var body: some View {
         GeometryReader { geo in
@@ -404,7 +417,13 @@ private struct AutoDismissProgressLine: View {
         .frame(height: 1)
         .onAppear {
             withAnimation(.linear(duration: 2.0)) { progress = 1 }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { onComplete() }
+            let work = DispatchWorkItem { onComplete() }
+            pendingDismiss = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: work)
+        }
+        .onDisappear {
+            pendingDismiss?.cancel()
+            pendingDismiss = nil
         }
     }
 }

--- a/mobile/ota/ship-lan.sh
+++ b/mobile/ota/ship-lan.sh
@@ -69,6 +69,22 @@ fi
 [ -n "${ANTHROPIC_API_KEY:-}" ] || { echo "ANTHROPIC_API_KEY not set (env or server/.env). Aborting — AI features won't work without it."; exit 1; }
 echo "-> ANTHROPIC_API_KEY resolved (length=${#ANTHROPIC_API_KEY})"
 
+# ---- Resolve OpenAI API key (voice transcription, #151) ----
+# Same source order as Anthropic. Unlike Anthropic this is OPTIONAL: with no
+# key the app falls back to on-device English dictation, so we warn but do
+# NOT abort the build.
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+    if [ -f "${MOBILE_DIR}/../server/.env" ]; then
+        OPENAI_API_KEY="$(grep -E '^OPENAI_API_KEY=' "${MOBILE_DIR}/../server/.env" | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'")"
+    fi
+fi
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+    echo "-> OPENAI_API_KEY resolved (length=${#OPENAI_API_KEY})"
+else
+    OPENAI_API_KEY=""
+    echo "-> WARNING: OPENAI_API_KEY not set (env or server/.env). Cloud voice transcription (Hindi/Hinglish) will be DISABLED; the app falls back to on-device English dictation."
+fi
+
 # ---- Regenerate project ----
 echo "-> regenerating Xcode project"
 xcodegen generate >/dev/null
@@ -147,6 +163,7 @@ xcodebuild \
     MARKETING_VERSION="${SHORT_VERSION}" \
     OTA_API_URL="${API_URL}" \
     ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}" \
+    OPENAI_API_KEY="${OPENAI_API_KEY}" \
     -allowProvisioningUpdates \
     archive \
     2>&1 | grep -E "(error:|warning: .*\.swift:|\*\* )" || true

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -40,6 +40,9 @@ targets:
         ITSAppUsesNonExemptEncryption: false
         OTA_API_URL: $(OTA_API_URL)
         ANTHROPIC_API_KEY: $(ANTHROPIC_API_KEY)
+        # OpenAI key for cloud voice transcription (#151). Injected at
+        # archive time by ship-lan.sh; empty for plain Xcode builds.
+        OPENAI_API_KEY: $(OPENAI_API_KEY)
         # Allow plain-HTTP calls to the Mac dev server on the local network.
         # Personal-use dev build only — App Store distribution is not a goal.
         NSAppTransportSecurity:
@@ -61,11 +64,12 @@ targets:
           - CFBundleURLName: com.akshaysharma.personaldashboard.deeplink
             CFBundleURLSchemes:
               - dexter
-        # Voice input in chat (issue #83). On-device only — audio never
-        # leaves the phone. Both keys are required: Speech for transcription,
-        # Microphone for the audio capture that feeds it.
-        NSSpeechRecognitionUsageDescription: "Dexter transcribes your voice into chat messages on-device. Audio never leaves your phone."
-        NSMicrophoneUsageDescription: "Dexter listens to your voice so it can transcribe what you say into the chat."
+        # Voice input in chat (issues #83, #151). Primary path uploads a
+        # short recording to OpenAI for transcription (auto-detects Hindi /
+        # English / Hinglish). Speech key is still required for the on-device
+        # English fallback used when no OpenAI key is configured.
+        NSSpeechRecognitionUsageDescription: "Dexter transcribes your voice into chat messages. With no transcription key set it falls back to on-device English recognition."
+        NSMicrophoneUsageDescription: "Dexter records your voice so it can transcribe what you say into the chat."
         # Receipt capture for Finance (issue #114, Phase B). Camera + photo
         # library access used by AddExpense flow to extract details via Vision.
         NSCameraUsageDescription: "Used to capture receipts so Dexter can log expenses for you."

--- a/server/.env.example
+++ b/server/.env.example
@@ -18,6 +18,8 @@ ANTHROPIC_API_KEY=sk-ant-replace-with-your-own-key
 # Leave unset for local development.
 # FRONTEND_URL=https://your-frontend.example.com
 
-# Optional: only used by legacy/diagnostic scripts (server/test-bytez.js,
-# server/check-env.js). The active chat path uses ANTHROPIC_API_KEY above.
-# OPENAI_API_KEY=sk-replace-or-leave-unset
+# OpenAI API key. Used by the iOS chat mic for cloud voice transcription
+# (#151) — it auto-detects Hindi / English / Hinglish. ship-lan.sh sources
+# this and bakes it into the IPA. Optional: with no key the app falls back to
+# on-device English dictation. Get one at https://platform.openai.com/api-keys.
+OPENAI_API_KEY=sk-replace-or-leave-unset


### PR DESCRIPTION
## Summary
- Adds Hindi and Hinglish support to the on-device assistant. Typed or spoken input in Hindi is understood and parsed, items are saved in **English** (names and personal-vocabulary terms preserved verbatim), and the assistant replies in the language you wrote in.
- The chat mic and the full-screen voice capture both **stream to OpenAI's Realtime transcription API** over a WebSocket, auto-detecting Hindi vs English per utterance (no language toggle). On-device English transcription remains as a fallback when no key is configured.

## Changes
- **System prompt**: new LANGUAGE HANDLING section in both the capture and chat prompts (`ChatToDrafts.swift`, `ChatStream.swift`) — translate artifact free-text to English, preserve names/vocabulary, parse relative dates in any language, reply in the user's language.
- **`OpenAIRealtimeTranscriber`** (new): actor WebSocket client using server VAD. Language is intentionally not pinned (pinning to `hi` forced English audio through the Hindi model and produced empty/garbled output). Uses `gpt-4o-transcribe` with a Devanagari-biasing prompt for better Hindi-vs-Urdu identification.
- **`HindiScriptNormalizer`** (new): converts Urdu (Perso-Arabic) STT output to Hindi (Devanagari) via Claude, and only when Perso-Arabic characters are present — English / already-Devanagari text incurs no API call.
- **`SpeechTranscriber`**: single public surface over the OpenAI engine (on-device English fallback when no key); accumulates utterances across server-VAD pauses so multi-phrase dictation never drops earlier text.
- **Key plumbing**: `OPENAI_API_KEY` flows through `project.yml`, `Info.plist`, and `AppConfig`, injected at archive time by `ship-lan.sh` (soft-fails to on-device English if absent). Documented in `server/.env.example`. The key is never committed — it lives only in the gitignored `server/.env`.

## Bugs fixed during device QA
- Inline chat mic no longer drops the async cloud transcript.
- Full-screen voice no longer stops the instant it opens (silence timer arms only once real text exists, not on the empty transcript at open).
- Full-screen voice second-open no longer closes itself (state resets synchronously on `begin`; the success auto-dismiss is now cancellable).

## Test plan
- [x] Static build green (`xcodebuild`, iOS device SDK)
- [x] Shipped to iPhone 16 Pro Max and exercised on device
- [x] Hindi voice → English task, confirmation in Hindi; English voice still transcribes (auto-detect both directions)
- [x] Inline chat mic captures and keeps the transcript
- [x] Full-screen voice works on repeated opens
- [x] Urdu→Devanagari normalization verified against the live API

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)