### PR TITLE
feat(ios): full-screen voice capture from the AI button

### DIFF
--- a/docs/design/202606 - Voice Capture Overlay - Concept.md
+++ b/docs/design/202606 - Voice Capture Overlay - Concept.md
@@ -1,0 +1,722 @@
+# Voice Capture Overlay
+
+**Concept Document — June 2026**
+**Status:** For approval
+**Platform:** iOS 17+ · SwiftUI
+**Issue:** #150
+
+---
+
+> **Revision — Full-Screen / Auto-Execute (June 2026)**
+>
+> This revision replaces the bottom-sheet form factor (v1, 44–48% height) with a full-screen cover. The "finalize to an editable box, user taps Send" model is replaced with auto-execution on silence detection. Glass-style controls replace the earlier solid/ghost button pair. The recording animation is redesigned from the existing WaveformBars into a new InkOrb treatment. State B (editable review) is removed. All other states are carried forward and updated. Section numbering is preserved for reference continuity; changed sections are marked [REVISED].
+
+---
+
+## Purpose
+
+Design spec for the AI voice capture experience on the Dexter iOS app. When the user taps the AI button, a full-screen overlay covers the current screen — whether on Notes, Lists, Tasks, Activity, or Chat — showing a recording animation, a live transcript, and auto-executing the command after ~1.5s of silence. The user returns to the exact page they started from, unchanged, after execution completes.
+
+---
+
+## Section 1 — Overlay Form Factor [REVISED]
+
+### Recommendation
+
+**Full-screen cover using `.fullScreenCover`.** The overlay replaces the sheet entirely. It presents as a full-screen modal that slides up from the bottom (system default for `fullScreenCover` on iOS), covers the entire display including the navigation bar and tab bar, and dismisses back to the originating page with no navigation side effect.
+
+Rationale: The Google-style voice experience the user described is specifically a full-screen take-over — the context shrinks away, the voice animation becomes the hero of the moment, and there is nothing competing for attention. A 46% sheet keeps the user in two contexts simultaneously; a full-screen cover puts them fully in "voice mode." This matches the established pattern of iOS voice search (Safari), Siri full-screen, and Google Assistant. The cognitive clarity this buys outweighs the loss of visible page context, especially since the interaction is brief (typically under 10 seconds from open to auto-dismiss).
+
+The originating page is preserved automatically: `fullScreenCover` does not push a navigation entry, so dismissing it returns to the exact scroll position and tab the user was on.
+
+### Viable Alternative
+
+**Bottom sheet at 72% height with suppressed drag indicator.** If user testing shows that losing the page context causes orientation confusion (the user forgets which tab they were on), revert to a tall sheet at `.fraction(0.72)`. This preserves the spatial memory of the underlying page while still giving the recording animation enough vertical room. The glass buttons and InkOrb animation described below work identically in either form factor. Prefer the full-screen cover unless testing reveals the orientation confusion problem.
+
+### Geometry
+
+| Property | Value | Notes |
+|---|---|---|
+| Presentation style | `.fullScreenCover(isPresented:)` | Slides up from bottom. System handles the spring entry animation. Covers status bar, nav bar, and tab bar. |
+| Background | `Tokens.surface` (paper-white in light mode, ~#FAFAF8) | Solid, not blurred — there is nothing to blur through on a full-screen cover. The calm paper ground is the canvas for the animation. |
+| Safe area handling | Respect top and bottom safe areas | Content stays within safe area insets. The animation lives in the visual center of the safe area, not the screen center, so it clears the Dynamic Island / notch. |
+| Status bar style | `.dark` on the `fullScreenCover` view | Matches the ink-on-paper palette. Use `preferredColorScheme(.light)` on the cover view if the system is in dark mode and the overlay should stay paper-light — or honor dark mode if the app supports it (see dark mode note below). |
+| Scrim behind | None (full-screen cover, no scrim layer needed) | The cover IS the full surface. |
+| Drag to dismiss | Disabled (`interactiveDismissDisabled(true)`) | Voice state is managed explicitly. Accidental swipe should not abort a recording. Cancel is always available via the glass Cancel button. |
+
+**Dark mode note:** If the app supports dark mode, `Tokens.surface` maps to a dark ground (approximately #1A1A18). The InkOrb animation inverts naturally — use `Tokens.paper` as the orb fill on dark ground. This doc assumes light mode as the primary case; the token system handles both without custom overrides.
+
+---
+
+## Section 2 — Recording Animation [REVISED]
+
+### Recommendation: InkOrb — Breathing Ink Sphere
+
+**Concept:** A single circular element centered in the upper two-thirds of the screen (above the transcript area). At rest, it is a filled circle in `Tokens.ink` at approximately 30% opacity — a quiet, contained shape. When the user speaks, it breathes outward, the opacity deepens toward full ink, and a soft secondary ring pulses at a larger radius. The effect reads as "a living thing listening" without the rainbow complexity of Siri or the mechanical grid of Google's 4-dot indicator.
+
+**Why this over the alternatives:**
+
+- Siri morphing orb: requires a rainbow gradient and complex mesh deformation — off-palette and overproduced for Dexter's monochrome restraint.
+- Google 4-dot listening indicator: closely associated with Google's brand identity; would read as borrowed.
+- Concentric pulse rings: works well but is purely decorative — it does not react to voice amplitude, so it feels less alive.
+- WaveformBars (existing): horizontal bars work well in a compact header slot; in a full-screen context they feel small and misplaced. The InkOrb fills the vertical space with authority.
+
+The InkOrb is reactive to audio level if feasible (using `AVAudioRecorder` metering or the `SpeechTranscriber`'s existing audio session). If amplitude metering is not available in the first implementation pass, the animation runs on a gentle autonomous rhythm (see reduce-motion note) that still feels alive.
+
+**Geometry:**
+
+| Property | Value |
+|---|---|
+| Base diameter | 120pt |
+| Active diameter (max, at peak amplitude) | 160pt |
+| Inner circle fill | `Tokens.ink` |
+| Inner circle opacity at rest | 0.22 |
+| Inner circle opacity at peak | 0.90 |
+| Outer ring stroke | `Tokens.ink`, 1pt |
+| Outer ring diameter at rest | 140pt (hidden, opacity 0) |
+| Outer ring diameter at peak | 200pt |
+| Outer ring opacity range | 0 → 0.18 (soft, does not compete with text) |
+| Position | Centered horizontally; vertical center at 38% of the safe area height (upper third, breathing room above the transcript) |
+
+**Animation curves:**
+
+- Inner circle scale and opacity: driven by audio level. Map normalized amplitude (0.0–1.0) to scale (1.0–1.33) and opacity (0.22–0.90). Apply a low-pass filter (rolling average over the last 4 frames at 30fps) so jitter does not create strobing. Transition with `.animation(.spring(response: 0.18, dampingFraction: 0.65), value: amplitude)`.
+- Outer ring: lags the inner circle by 80ms (apply with `.animation(.spring(response: 0.28, dampingFraction: 0.70).delay(0.08), value: amplitude)`). Creates a trailing echo effect.
+- Autonomous rhythm (fallback when amplitude is not available, or between words during brief silence): gentle sine wave cycling the inner circle between 0.22 and 0.42 opacity and 1.0–1.08 scale on a 1.4s period. `repeatForever(autoreverses: true)` with `.easeInOut`.
+- On silence detection (just before auto-execute): the orb compresses slightly (scale 0.88, duration 0.15s ease-in), then the overlay transitions to the Executing state.
+
+**Color:**
+
+`Tokens.ink` throughout. No gradients. No color shifts with amplitude. The depth of the ink is the signal, not hue change. This keeps the animation strictly within the app's monochrome palette.
+
+**Reduce-motion fallback:**
+
+When `accessibilityReduceMotion` is true: the InkOrb is a static filled circle at `Tokens.ink` 50% opacity. No scale, no outer ring, no pulse. A thin 1pt `Tokens.border` ring at 144pt diameter makes it legible as a distinct element at rest. The listening state is communicated entirely by the "Listening" label and the live transcript text appearing.
+
+### Alternative: Concentric Pulse Rings
+
+A fixed mic icon (SF Symbol `mic.fill`, 32pt, `Tokens.ink`) at the center, surrounded by two concentric rings that pulse outward independently:
+- Ring 1: starts at 64pt diameter, expands to 96pt, fades from opacity 0.25 to 0, duration 1.2s, linear, `repeatForever`.
+- Ring 2: same geometry, offset 0.6s (half-period phase shift).
+- Amplitude reactivity: the ring expansion range maps to audio level (at peak, rings expand to 120pt).
+
+This is simpler to implement but less visually differentiated from generic "recording in progress" indicators. Choose it if the InkOrb spring-driven amplitude animation proves too complex for the first ship.
+
+---
+
+## Section 3 — All States [REVISED]
+
+### Layout structure (all states)
+
+```
+┌─ Safe area top ──────────────────────────────────────────────────────────────┐
+│                                                                               │
+│   [status label, left-aligned, edCaption, Tokens.muted]     [Cancel glass]  │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                       ○  ●  ○                                                │
+│                    (InkOrb, 120pt)                                           │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│   ─────────────────────────────────────────────────────────────────────────  │
+│                                                                               │
+│   Live transcript text here. Grows downward.                                 │
+│   Auto-scrolls to the last word.                                             │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                              [  Stop  glass  ]                               │
+│                                                                               │
+└─ Safe area bottom ───────────────────────────────────────────────────────────┘
+```
+
+The three zones are fixed:
+1. **Top bar** (status label + Cancel): 52pt height, pinned to top safe area edge.
+2. **Animation zone**: upper 38% of safe-area height, vertically centered on the InkOrb.
+3. **Transcript zone**: lower 55% of safe-area height, separated from the animation zone by a 0.5pt `Tokens.border` divider. Scrollable if content exceeds the zone.
+4. **Bottom control zone**: 80pt height above the bottom safe area edge. Contains the glass Stop button (State A) or glass Done / Cancel pair (Executing state).
+
+---
+
+### State A: Listening — live partial transcript
+
+```
+┌─ Safe area top ──────────────────────────────────────────────────────────────┐
+│                                                                               │
+│   Listening                                              [ Cancel ]          │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                          (  ●  )                                             │
+│                     InkOrb — breathing, reactive                             │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│   ─────────────────────────────────────────────────────────────────────────  │
+│                                                                               │
+│   Remind me to call John tomorrow                                            │
+│   at 3 pm, and also pick up —|                                              │
+│                                                                               │
+│   (live partial. Text grows here. Scrollable if exceeds zone.)              │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                            [ Stop Now ]                                      │
+│                                                                               │
+└─ Safe area bottom ───────────────────────────────────────────────────────────┘
+  (full-screen cover — underlying page fully hidden)
+```
+
+**Element specs:**
+
+| Element | Spec | Detail |
+|---|---|---|
+| Status label | `.edCaption`, `Tokens.muted`, left-aligned in top bar | "Listening" — one word. No pulsing danger dot (the InkOrb IS the recording indicator; a second pulsing element would compete). |
+| Cancel button | Glass style (see Section 5 — Glass Controls) | Top-right of the top bar. 44pt tap target. Stops recording, discards transcript, dismisses the overlay. |
+| InkOrb | 120pt base, amplitude-reactive | Positioned at vertical center of the animation zone (upper 38% of safe area). See Section 2 for full spec. |
+| Divider | 0.5pt, `Tokens.border` | Separates animation zone from transcript zone. Full-width, no padding. |
+| Transcript area | Scrollable, `Space.xl` horizontal padding, `Space.lg` top padding | Font: `.edBody`, color: `Tokens.ink`. Text auto-scrolls to the last word as partials arrive. Cursor blink (`|`) at end while recording. No placeholder text when empty — silence while listening is understood from context. |
+| Stop Now button | Glass style, centered horizontally in bottom control zone | "Stop Now" — triggers immediate auto-execute without waiting for silence. Same behavior as the silence timer firing. See glass spec in Section 5. Min tap target 44pt. |
+| Silence auto-execute | 1.5s of detected silence | When `SpeechTranscriber` emits no new words for 1.5s and the transcript is non-empty, the overlay transitions to State A1 (Safety Window), then State C (Executing). Timer resets on each new word. |
+
+---
+
+### State A1: Safety Window — "Executing in a moment"
+
+This state exists for approximately 1.5s between silence detection and actual AI execution. It gives the user an escape hatch in case the transcript was wrong or the command was not intended.
+
+```
+┌─ Safe area top ──────────────────────────────────────────────────────────────┐
+│                                                                               │
+│   Got it                                                 [ Cancel ]          │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                          (  ●  )                                             │
+│                     InkOrb — gently settling                                 │
+│                        (compress to 0.88, hold)                              │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│   ─────────────────────────────────────────────────────────────────────────  │
+│                                                                               │
+│   Remind me to call John tomorrow at 3 pm, and also                         │
+│   pick up the groceries on the way home.                                     │
+│                                                                               │
+│   (transcript is now static — recording stopped)                            │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│          [ Cancel ]               ─────── executing ──────                  │
+│                        (glass)        (sweeping progress bar, 1.5s)         │
+│                                                                               │
+└─ Safe area bottom ───────────────────────────────────────────────────────────┘
+```
+
+**Element specs:**
+
+| Element | Spec | Detail |
+|---|---|---|
+| Status label | "Got it" | Cross-fades from "Listening". Signals receipt of the command without being instructional. |
+| InkOrb | Settles — scale compresses to 0.88, autonomous rhythm stops | The orb holds this compressed state for the duration of the safety window, communicating that listening has ended. No outer ring. |
+| Transcript | Static text, `Tokens.ink` (still fully readable) | Recording has stopped. The transcript is finalized. The cursor blink disappears. |
+| Cancel button (top-right) | Glass style, remains active | Same position as State A. Tap cancels the pending execution and dismisses the overlay. This is the primary escape hatch. |
+| Bottom control zone | Progress bar + secondary Cancel | A thin horizontal progress bar (1pt, `Tokens.ink` 30% opacity) sweeps from left to right over 1.5s using `.linear` timing. It indicates how much time remains before execution fires. Below or beside it: a ghost-glass "Cancel" button for the user who needs a large target. The Cancel button at the top-right is sufficient; this is a redundant affordance for ergonomics (thumb reach on large phones). |
+| After 1.5s | Auto-advance to State C (Executing) | If Cancel is not tapped, execution begins automatically. |
+| Haptic on entering A1 | `UIImpactFeedbackGenerator(style: .light).impactOccurred()` | Signals that listening has stopped and execution is pending. Distinct from the recording-start haptic (`.medium`) so the user can distinguish the two by feel alone. |
+
+**Design rationale for A1 vs always-visible Cancel:**
+
+The 1.5s safety window pattern (like "Undo Send" in Gmail) is preferable to keeping a permanent "do not execute" button visible during State A, because a permanent abort button trains the user to second-guess the system. The safety window communicates confidence ("we heard you") while still giving an escape. The window length of 1.5s is deliberate: long enough to read the transcript and make a decision, short enough to feel instant in the happy path. The user can also tap "Stop Now" during State A to skip silence detection and trigger A1 immediately.
+
+---
+
+### State C: Executing — AI processing [REVISED]
+
+```
+┌─ Safe area top ──────────────────────────────────────────────────────────────┐
+│                                                                               │
+│   Working…                                               [ Cancel ]          │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                          (  ●  )                                             │
+│                     InkOrb — slow pulse, autonomous                          │
+│                       (waiting rhythm, not reactive)                         │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│   ─────────────────────────────────────────────────────────────────────────  │
+│                                                                               │
+│   Remind me to call John tomorrow at 3 pm, and also                         │
+│   pick up the groceries on the way home.                                     │
+│                                                                               │
+│   ●  ●  ●   (TypingIndicator, Tokens.muted, below transcript)               │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+└─ Safe area bottom ───────────────────────────────────────────────────────────┘
+```
+
+**Element specs:**
+
+| Element | Spec | Detail |
+|---|---|---|
+| Status label | "Working…" | Cross-fades from "Got it". Ellipsis is the standard iOS progress idiom. |
+| InkOrb | Slow autonomous pulse: 0.30–0.55 opacity, 1.0–1.10 scale, 2.0s period, `.easeInOut` | Distinct from the listening rhythm (faster, amplitude-driven). The slower rhythm communicates "thinking, not listening." |
+| Transcript | Static, `Tokens.muted` | Text color softens to communicate the field is no longer the focus. The AI is processing the content. |
+| Typing indicator | Reuse `TypingIndicator` from `ChatComponents.swift` | Three-dot sequencer, `Tokens.muted`. Left-aligned below the transcript area, `Space.lg` top margin. Signals AI activity. |
+| Cancel button | Glass style, top-right | Best-effort cancel: calls task cancel on the in-flight AI call. Dismisses overlay. If SwiftData writes have already committed, they are not rolled back (acceptable at this scale). |
+| Bottom control zone | Empty | No Stop button. The user is no longer recording. Only the top Cancel is available. |
+
+---
+
+### State D: Success — confirmation + auto-dismiss [unchanged, updated layout]
+
+```
+┌─ Safe area top ──────────────────────────────────────────────────────────────┐
+│                                                                               │
+│   Done                                                                       │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                          (  ●  )                                             │
+│                     InkOrb — slow fade to rest (opacity 0.15)               │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│   ─────────────────────────────────────────────────────────────────────────  │
+│                                                                               │
+│   ✓  Task added: Call John tomorrow at 3 pm                                  │
+│   ✓  Note created: Groceries list                                            │
+│                                                                               │
+│   (one SuccessRow per action applied. Stagger entrance 80ms apart.)         │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                              ─────────────────                              │
+│                           (progress line, 2.0s, auto-dismiss)               │
+│                                                                               │
+└─ Safe area bottom ───────────────────────────────────────────────────────────┘
+```
+
+**Element specs:**
+
+| Element | Spec | Detail |
+|---|---|---|
+| Status label | "Done" | Cross-fades from "Working…". No buttons in top bar in this state. |
+| InkOrb | Fades to rest: opacity 0.15, scale 1.0, `.easeOut` 0.4s | The orb quiets down as the work is complete. It does not disappear — it remains as a calm anchor in the animation zone. |
+| Success rows | Reuse `SuccessRow` | One row per `ChatActionResult` outcome. Checkmark + label. Stagger entrance: each row `.transition(.opacity.combined(with: .move(edge: .bottom)))`, 80ms offset. Max 4 rows before scroll. |
+| Haptic | `.notificationFeedback(.success)` | Fires once on transition into State D. |
+| Auto-dismiss progress line | 1pt, `Tokens.ink` 20% opacity | Sweeps left-to-right over 2.0s `.linear` from the bottom control zone. After completion, the overlay dismisses with the system `fullScreenCover` slide-down animation. |
+| Cancel / early dismiss | Swipe down gesture (re-enabled for State D) | `interactiveDismissDisabled(false)` in State D only. The user can swipe the overlay down at any time during State D to dismiss immediately. |
+| After dismiss | Originating page, unchanged | The user lands on the exact tab, scroll position, and view they were on when they tapped the AI button. No navigation. |
+
+---
+
+### State E: Empty — silence detected with no speech [unchanged layout, updated form factor]
+
+```
+┌─ Safe area top ──────────────────────────────────────────────────────────────┐
+│                                                                               │
+│   Nothing heard                                          [ Cancel ]          │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                          (  ○  )                                             │
+│                     InkOrb — static, rest opacity (0.22)                    │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│   ─────────────────────────────────────────────────────────────────────────  │
+│                                                                               │
+│                                                                               │
+│        Try speaking, or tap the mic to record again.                         │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│           [ Cancel ]                    [ Try Again ]                        │
+│                (glass)                      (glass)                          │
+│                                                                               │
+└─ Safe area bottom ───────────────────────────────────────────────────────────┘
+```
+
+**Element specs:**
+
+| Element | Spec | Detail |
+|---|---|---|
+| Trigger | Silence timer fires with empty transcript | `SFSpeech` error code 1110 (already silenced in transcriber) or 1.5s silence with zero words captured. |
+| InkOrb | Static at rest opacity (0.22), no animation | Recording has stopped and there is nothing to show for it. The orb sits quietly. |
+| Body text | `.edBody`, `Tokens.inkSoft`, centered in transcript zone | "Try speaking, or tap the mic to record again." |
+| Cancel | Glass style, bottom-left | Dismisses overlay, no action. |
+| Try Again | Glass style, bottom-right | Restarts recording from scratch — back to State A. `SpeechTranscriber` restarts. |
+
+---
+
+### State F: Permission denied [unchanged]
+
+```
+┌─ Safe area top ──────────────────────────────────────────────────────────────┐
+│                                                                               │
+│   Microphone access needed                               [ Not now ]         │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                          (  ○  )                                             │
+│                     InkOrb — static, 0.15 opacity (dim)                     │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│   ─────────────────────────────────────────────────────────────────────────  │
+│                                                                               │
+│                                                                               │
+│   Dexter needs microphone and speech access to record                        │
+│   your voice. Turn them on in Settings to continue.                          │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│         [ Not now ]                   [ Open Settings ]                      │
+│              (glass)                       (glass)                           │
+│                                                                               │
+└─ Safe area bottom ───────────────────────────────────────────────────────────┘
+```
+
+**Element specs:**
+
+| Element | Spec | Detail |
+|---|---|---|
+| InkOrb | Dimmed static: 0.15 opacity, no animation | The orb is visually "off" — feature is unavailable. |
+| Open Settings | Glass style, bottom-right | `UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)`. Overlay stays open. |
+| Not now | Glass style, top-right and bottom-left (two touch points for ergonomics) | Dismisses overlay. |
+
+---
+
+### State G: Error — transcription or AI failure [unchanged]
+
+```
+┌─ Safe area top ──────────────────────────────────────────────────────────────┐
+│                                                                               │
+│   Something went wrong                                   [ Dismiss ]         │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│                          (  ○  )                                             │
+│                     InkOrb — static, 0.15 opacity (dim)                     │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│   ─────────────────────────────────────────────────────────────────────────  │
+│                                                                               │
+│                                                                               │
+│   [inline error message from transcriber or AI — stripped of tech prefixes] │
+│                                                                               │
+│                                                                               │
+│                                                                               │
+│        [ Dismiss ]                       [ Try Again ]                       │
+│             (glass)                           (glass)                        │
+│                                                                               │
+└─ Safe area bottom ───────────────────────────────────────────────────────────┘
+```
+
+**Element specs:**
+
+| Element | Spec | Detail |
+|---|---|---|
+| Error message | `.edBody`, `Tokens.inkSoft`, centered | Raw message from `transcriber.errorMessage` or `ChatViewModel.errorMessage`, stripped of technical prefixes. Two lines max before truncation with "…". |
+| Try Again | Glass style | For transcription errors: restart recording (State A). For AI errors: re-run `ChatViewModel.send()` with the last transcript. |
+| Dismiss | Glass style | Dismisses overlay. No action on data. |
+
+---
+
+## Section 4 — State Machine (Auto-Execute Flow) [REVISED]
+
+```
+[Tap AI button]
+       │
+       ▼
+  [State A: Listening]
+  ┌─── Recording active, InkOrb reactive, live transcript ──────────────────┐
+  │                                                                          │
+  │  1.5s silence + non-empty transcript ──────────────────────────────────►[State A1: Safety Window]
+  │                                                                          │         │
+  │  "Stop Now" glass button ──────────────────────────────────────────────►[State A1]│
+  │                                                                          │         │ 1.5s (no Cancel)
+  │  Cancel button or swipe ───────────────────────────────────────────────►[Dismiss] │
+  │                                                                          │         ▼
+  │  1.5s silence + empty transcript ──────────────────────────────────────►[State E: Empty]
+  │                                                                          │
+  └──────────────────────────────────────────────────────────────────────────┘
+                                                                             │
+  [State A1: Safety Window]                                                  │
+  ┌─── "Got it", progress bar sweeping, Cancel available ───────────────────┘
+  │
+  │  Cancel tapped ────────────────────────────────────────────────────────►[Dismiss]
+  │
+  │  1.5s elapsed (no Cancel) ─────────────────────────────────────────────►[State C: Executing]
+  │
+  └──────────────────────────────────────────────────────────────────────────┘
+
+  [State C: Executing]
+  ┌─── "Working…", InkOrb thinking rhythm, TypingIndicator ────────────────┐
+  │                                                                         │
+  │  AI success ───────────────────────────────────────────────────────────►[State D: Success]
+  │                                                                         │
+  │  AI error ─────────────────────────────────────────────────────────────►[State G: Error]
+  │                                                                         │
+  │  Cancel tapped ────────────────────────────────────────────────────────►[Dismiss]
+  │                                                                         │
+  └─────────────────────────────────────────────────────────────────────────┘
+
+  [State D: Success]
+  ┌─── "Done", success rows, auto-dismiss progress line ───────────────────┐
+  │                                                                         │
+  │  2.0s elapsed ─────────────────────────────────────────────────────────►[Dismiss → originating page]
+  │                                                                         │
+  │  User swipes down ─────────────────────────────────────────────────────►[Dismiss → originating page]
+  │                                                                         │
+  └─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Silence timer implementation note:** The 1.5s timer starts (or restarts) on every `SpeechTranscriber` partial result. It fires when no new partial result arrives within 1.5s. The timer is cancelled immediately on entering State A1 (the safety window manages its own 1.5s countdown independently). Use `Task.sleep(nanoseconds:)` or a `Timer.publish` that is cancelled and recreated on each word. Do not use a single ongoing timer that counts total session duration.
+
+---
+
+## Section 5 — Glass Controls [NEW]
+
+All interactive controls on the voice capture overlay use a glass treatment. There is no "solid primary" button in this overlay — the InkOrb is the visual hero; controls must not compete with it.
+
+### Glass button specification
+
+| Property | Value | Notes |
+|---|---|---|
+| Background material | `.ultraThinMaterial` | SwiftUI's thinnest material — the lightest blur. On the paper-white `Tokens.surface` background this reads as a subtle frosted disc. |
+| Background tint overlay | `Color(Tokens.surface).opacity(0.5)` drawn over the material | Ensures the button stays legible even when the background is animated (prevents the material from looking too transparent). |
+| Corner radius | `Radius.pill` (fully rounded capsule for single-line labels) | Matches the app's existing floating pill aesthetic. |
+| Border stroke | `Color.white.opacity(0.35)` at 0.5pt | Hairline white inner border gives the glass a clean edge. In dark mode, use `Color.white.opacity(0.20)` (slightly more transparent because dark surfaces show borders more strongly). |
+| Shadow | `Color(Tokens.ink).opacity(0.08)` radius 8pt, y offset 2pt | A very gentle lift — barely perceptible. The glass sits on the surface rather than floating dramatically over it. |
+| Label / icon color | `Tokens.ink` | Full-opacity ink ensures the label passes contrast at 4.5:1 regardless of what is blurred behind the button. |
+| Font | `.edBodyMedium` for action labels, `.edCaption` for secondary labels | Consistent with the app's named font system. |
+| Padding | `Space.sm` vertical (8pt), `Space.lg` horizontal (20pt) for text buttons | Sufficient interior room for the glass effect to register. |
+| Minimum tap target | 44pt × 44pt | Use `.frame(minWidth: 44, minHeight: 44)` with `.contentShape(Capsule())` if the visual size is smaller. |
+| Pressed state | Scale to 0.96, `.easeOut 0.1s`, with `UIImpactFeedbackGenerator(style: .light).impactOccurred()` | Immediate, physical, tactile. No color change on press (the glass treats color change as too prominent). |
+| Disabled state | Opacity 0.4 on the entire button, `.allowsHitTesting(false)` | Maintains the glass look while clearly communicating unavailability. |
+
+### SwiftUI implementation sketch (not production code — for engineer reference)
+
+```
+// GlassButtonStyle
+struct GlassButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.edBodyMedium)
+            .foregroundStyle(Tokens.ink)
+            .padding(.vertical, Space.sm)
+            .padding(.horizontal, Space.lg)
+            .background {
+                Capsule()
+                    .fill(.ultraThinMaterial)
+                    .overlay {
+                        Capsule()
+                            .fill(Color(Tokens.surface).opacity(0.5))
+                    }
+                    .overlay {
+                        Capsule()
+                            .strokeBorder(Color.white.opacity(0.35), lineWidth: 0.5)
+                    }
+                    .shadow(color: Color(Tokens.ink).opacity(0.08),
+                            radius: 8, x: 0, y: 2)
+            }
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+```
+
+### Control map by state
+
+| State | Top-right | Bottom-left | Bottom-center / right |
+|---|---|---|---|
+| A — Listening | Cancel (glass) | — | Stop Now (glass) |
+| A1 — Safety Window | Cancel (glass) | Cancel (glass, secondary) | — (progress bar sweeps the zone) |
+| C — Executing | Cancel (glass) | — | — |
+| D — Success | — | — | — (progress line, swipe to dismiss) |
+| E — Empty | Cancel (glass) | Cancel (glass) | Try Again (glass) |
+| F — Permission | Not now (glass) | Not now (glass) | Open Settings (glass) |
+| G — Error | Dismiss (glass) | Dismiss (glass) | Try Again (glass) |
+
+Note: In State D, no glass buttons are visible. The auto-dismiss line handles the terminal action. The user can swipe down at any time.
+
+---
+
+## Section 6 — Motion [REVISED]
+
+| Phase | Duration | Spec |
+|---|---|---|
+| Overlay entry | System default for `fullScreenCover` (~0.38s spring) | Slides up from bottom, full-screen. No custom override needed; the system spring matches the app's established `.spring(response: 0.35, dampingFraction: 0.85)`. |
+| Status label cross-fade (any state transition) | 0.2s `.easeOut` | All state label changes use an opacity cross-fade. The label does not slide; only opacity animates. |
+| InkOrb amplitude response | Per-frame, spring-driven (see Section 2) | `.spring(response: 0.18, dampingFraction: 0.65)`. Outer ring lags by 80ms. |
+| InkOrb → A1 (settle) | 0.15s `.easeIn` | Scale to 0.88, autonomous rhythm stops. |
+| InkOrb → C (thinking) | 0.3s `.easeInOut` | Transitions from settled (0.88 scale) back to base (1.0 scale) and begins slow autonomous pulse (2.0s period). |
+| InkOrb → D (rest) | 0.4s `.easeOut` | Fades to 0.15 opacity, scale 1.0, all animation stops. |
+| Transcript text arrival | Instant (SwiftUI diff) | New words appear as SFSpeech emits partials. Auto-scroll: `withAnimation(.easeOut(duration: 0.15))`. |
+| A1 safety window progress bar | 1.5s `.linear` | Sweeps from 0 to full width. The linearity is intentional: the user needs a predictable countdown, not one that accelerates. |
+| TypingIndicator entrance (C) | 0.2s `.easeOut`, `.transition(.opacity)` | Fades in below transcript when entering State C. |
+| Success rows (D) | 80ms offset per row, `.transition(.opacity.combined(with: .move(edge: .bottom)))` | Same stagger pattern as v1. |
+| D auto-dismiss progress line | 2.0s `.linear` | As in v1. Proceeds to native `fullScreenCover` dismiss (slide down) on completion. |
+| Overlay dismiss (any terminal state) | Native `fullScreenCover` dismiss (~0.35s spring) | Slides down. No custom override. |
+| Reduce-motion overrides | Global | When `accessibilityReduceMotion` is true: InkOrb is static (no scale, no pulse, no outer ring). State transitions use `.opacity` only, 0.15s. Success rows appear simultaneously (no stagger). Progress bars still animate (they are informational, not decorative) — per Apple's guidance that informational animations are exempt from reduce-motion. |
+
+---
+
+## Section 7 — Controls and Gestures [REVISED]
+
+| Control / Gesture | Behavior | Tap target |
+|---|---|---|
+| AI button tap (entry) | Presents `fullScreenCover`. Haptic: `UIImpactFeedbackGenerator(style: .medium).impactOccurred()`. Recording begins immediately. | Existing tap target in `BottomTabBar`. |
+| Cancel (top-right, States A / A1 / C) | Stop recording / cancel pending execution / best-effort cancel AI task. Discard transcript. Dismiss overlay. | 44pt × 44pt minimum. Glass button. |
+| Stop Now (bottom, State A) | Trigger silence-end early: advance to State A1 immediately. Does not wait for the 1.5s silence timer. | 44pt height, glass button. Centered at bottom of screen. |
+| Cancel during safety window (A1) | Abort pending execution. Return to State A to record again, OR dismiss overlay — design choice: recommend dismissing fully (the user who taps Cancel during A1 typically does not want to retry immediately; they want to think). Present State A again only if the user navigates back and taps the AI button again. | 44pt height, glass. Accessible from both top-right and bottom-left in A1. |
+| Swipe down | Disabled during States A, A1, C via `interactiveDismissDisabled(true)`. Re-enabled in States D, E, F, G. | System gesture. |
+| Tap outside overlay | Not applicable — full-screen cover has no "outside." | N/A |
+| Try Again (States E, G) | Restarts recording from scratch (State A). | 44pt height, glass. |
+| Open Settings (State F) | `UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)`. Overlay stays open. | 44pt height, glass. |
+| Dismiss / Not now (States D, E, F, G) | Dismiss overlay. No data action. | 44pt height, glass. |
+| Hardware back | Not applicable on iOS for a modal. | N/A |
+| Volume buttons | No interaction with the overlay. | System behavior. |
+
+---
+
+## Section 8 — Microcopy [REVISED]
+
+Voice and tone: plain, direct, lowercase-friendly. No em dashes. No exclamation marks. No apologies. State what is happening or what to do next.
+
+| Context | String | Note |
+|---|---|---|
+| Listening status | "Listening" | One word. The InkOrb communicates recording is active; the label confirms it. |
+| Safety window status | "Got it" | Two words. Communicates receipt without over-promising ("Done" would be premature). |
+| Executing status | "Working…" | Unchanged from v1. |
+| Success status | "Done" | Unchanged. |
+| Empty / no speech status | "Nothing heard" | Unchanged. |
+| Permission status | "Microphone access needed" | Unchanged. |
+| Error status | "Something went wrong" | Unchanged. |
+| Stop Now button | "Stop Now" | Two words, title case. Actionable. Not "Send" (no explicit sending in auto-execute model) or "Done" (reserved for success state). |
+| Cancel button | "Cancel" | Single word. Always the same label regardless of state — predictability matters for a control the user may grab in a hurry. |
+| Try Again button | "Try Again" | States E and G. |
+| Open Settings | "Open Settings" | State F. Names the destination. |
+| Not now | "Not now" | State F. Lowercase "now". |
+| Empty body text | "Try speaking, or tap the mic to record again." | Unchanged. |
+| Permission body text | "Dexter needs microphone and speech access to record your voice. Turn them on in Settings to continue." | Unchanged. |
+| Error body text | [inline from `transcriber.errorMessage` or `ChatViewModel.errorMessage`] | Strip technical prefixes. 2-line max. |
+| First-launch hint (State A, empty transcript, first session only) | "Start speaking — Dexter is listening." | Replaces the v1 "Hold to record. Release to finalize." which referenced a gesture that no longer applies. Shown centered in the transcript zone only when the transcript is empty and `AppStorage("hasSeenVoiceHint")` is false. Hidden after first recording completes. |
+
+---
+
+## Section 9 — Accessibility [REVISED]
+
+| Element | VoiceOver label | Notes |
+|---|---|---|
+| AI button | "Voice capture. Tap to start." | Update the existing `.accessibilityHint` on the AI button in `BottomTabBar`. The "touch and hold" wording no longer applies if the gesture changes to a tap. |
+| InkOrb | "Recording in progress." (State A) / "Processing." (State C) / Hidden in States D, E, F, G | `.accessibilityElement(children: .ignore)`. Post `.announcement` on state change. In State A: announce once when the overlay opens. |
+| Status label | Read by VoiceOver as the container's label (via `.accessibilityLabel` on the top bar zone) | The status label and InkOrb are combined into a single VoiceOver region. |
+| Cancel button | "Cancel voice capture" | `.accessibilityLabel("Cancel voice capture")`. VoiceOver users may not know they are in a voice capture context; the label names it. |
+| Stop Now button | "Stop and execute" | More descriptive than the visual label "Stop Now" — tells VoiceOver users what happens next. |
+| Safety window progress | Announce once: "Executing in 1.5 seconds. Double tap Cancel to abort." | `UIAccessibility.post(notification: .announcement, argument: ...)` on entering A1. The visual progress bar is `.accessibilityHidden(true)`. |
+| Transcript text | System `Text` view; VoiceOver reads normally | No label override needed. VoiceOver focus should move to the transcript as text appears. Post `.screenChanged` notification when the first partial result arrives. |
+| Typing indicator (State C) | Announce once: "Processing your request." | Post `.announcement` on entering State C. Dots themselves are `.accessibilityHidden(true)`. |
+| Success rows | One announcement per row, 500ms staggered | Post `.announcement` for each `SuccessRow`. Then: "Closing in 2 seconds." |
+| Auto-dismiss progress line | `.accessibilityHidden(true)` | Already announced via text. |
+| Glass buttons | All buttons get `.accessibilityAddTraits(.isButton)` and explicit `.accessibilityLabel` | The glass material effect does not affect VoiceOver — VoiceOver reads the label, not the visual. |
+| Dynamic Type | Full support via named font styles | Test at Accessibility Extra Extra Extra Large. The animation zone may need to shrink slightly at max sizes to give the transcript zone more room — use `@Environment(\.dynamicTypeSize)` to adjust the zone split ratio from 38/55 to 30/63 at sizes above `.xxLarge`. |
+| Reduce Motion | InkOrb is static; all transitions use `.opacity` only | See Section 6. |
+| Color contrast | `Tokens.ink` on `Tokens.surface` (light mode): ~18.5:1 (AAA). Glass button labels (`Tokens.ink` on ultraThinMaterial over `Tokens.surface`): the blur background is effectively `Tokens.surface`-adjacent, so contrast is maintained at ~18.5:1. `Tokens.muted` on `Tokens.surface`: ~4.6:1 (AA). No element uses color as the only indicator of state. | |
+
+---
+
+## Section 10 — Architecture Note [REVISED]
+
+The overlay must be presentable from any tab. The `.fullScreenCover` replaces the `.sheet` attachment point but the architecture recommendation from v1 stands and is now cleaner:
+
+**`VoiceCaptureViewModel`** (`@Observable`, `@MainActor`) owns:
+- `SpeechTranscriber` instance
+- The silence timer (1.5s, resets on each partial result)
+- The safety-window timer (1.5s, starts when silence timer fires and transcript is non-empty)
+- `VoiceCaptureState` enum: `.listening`, `.safetyWindow`, `.executing`, `.success([ChatActionResult])`, `.empty`, `.permissionDenied`, `.error(String)`
+- `transcript: String` (the live partial)
+- `audioLevel: Float` (normalized 0.0–1.0 from `AVAudioRecorder` metering, published at 30fps via a `Timer.publish`)
+- The `ChatViewModel.send()` call (or a dedicated `executeVoiceCapture(_ transcript: String)` method)
+
+Inject into the environment from `ContentView`. `AppRouter.showVoiceCaptureOverlay: Bool` triggers the `.fullScreenCover`. The overlay binds to `VoiceCaptureViewModel` from environment.
+
+**Audio level metering:** Enable `AVAudioRecorder` metering with `isMeteringEnabled = true` and call `updateMeters()` at 30fps via `Timer.publish(every: 1/30, ...)`. Normalize the `averagePower(forChannel: 0)` dB value (typical range -60dBFS to 0dBFS) to 0.0–1.0 using a simple linear map with a -40dBFS floor. Apply a rolling average (last 4 readings) before publishing to `VoiceCaptureViewModel.audioLevel`. The InkOrb animation subscribes to `audioLevel` and the spring handles smoothing.
+
+**`interactiveDismissDisabled` management:** Set to `true` when state is `.listening`, `.safetyWindow`, or `.executing`. Set to `false` when state is `.success`, `.empty`, `.permissionDenied`, or `.error`. Handle via a computed property on `VoiceCaptureViewModel` and a `.onChange(of: viewModel.isInteractiveDismissDisabled)` modifier on the `fullScreenCover` content view.
+
+**Teardown path:** `onDismiss` on the `fullScreenCover` calls `viewModel.cancel()` which stops the transcriber, cancels both timers, and cancels any in-flight AI task. This is the single teardown path regardless of how the overlay was closed.
+
+---
+
+## Pre-Delivery Checklist [REVISED]
+
+**Form factor and entry**
+- [ ] `.fullScreenCover` presents from any tab without navigating away from the current page
+- [ ] Tapping the AI button triggers recording immediately (no hold gesture required)
+- [ ] Overlay covers status bar, nav bar, and tab bar
+- [ ] Dismissing the overlay returns to the exact tab and scroll position
+
+**Recording and auto-execute**
+- [ ] Silence timer (1.5s) resets on each new partial result from `SpeechTranscriber`
+- [ ] Non-empty transcript after 1.5s silence advances to State A1 (safety window)
+- [ ] Empty transcript after 1.5s silence advances to State E
+- [ ] Stop Now button forces State A1 immediately (no silence wait)
+- [ ] Safety window shows progress bar sweeping over 1.5s before auto-executing
+- [ ] Cancel during A1 stops execution and dismisses overlay
+- [ ] Cancel during C is best-effort; overlay dismisses without crash
+
+**InkOrb animation**
+- [ ] Base diameter 120pt, active diameter up to 160pt
+- [ ] Amplitude drives scale and opacity at 30fps (spring response 0.18)
+- [ ] Outer ring lags inner circle by 80ms
+- [ ] InkOrb settles to 0.88 scale when entering A1
+- [ ] InkOrb pulses slowly (2.0s period) during State C
+- [ ] InkOrb fades to 0.15 opacity in State D
+- [ ] Reduce-motion: static filled circle, no animation
+
+**Glass controls**
+- [ ] All buttons use `.ultraThinMaterial` with `Color(Tokens.surface).opacity(0.5)` tint
+- [ ] All buttons have 0.5pt `Color.white.opacity(0.35)` stroke border
+- [ ] All buttons scale to 0.96 on press with light haptic
+- [ ] All buttons minimum 44pt × 44pt tap target
+- [ ] Glass labels pass 4.5:1 contrast against the overlay background
+
+**State machine**
+- [ ] All seven states (A, A1, C, D, E, F, G) implemented
+- [ ] State transitions use 0.2s opacity cross-fade for status labels
+- [ ] `interactiveDismissDisabled(true)` in States A, A1, C; `false` in D, E, F, G
+- [ ] Permission denied routes to State F, not State G
+- [ ] Success state auto-dismisses after 2.0s progress line completes
+
+**Accessibility**
+- [ ] VoiceOver: AI button announces "Voice capture. Tap to start."
+- [ ] VoiceOver: Cancel announces "Cancel voice capture"
+- [ ] VoiceOver: Stop Now announces "Stop and execute"
+- [ ] VoiceOver: entering A1 announces "Executing in 1.5 seconds. Double tap Cancel to abort."
+- [ ] VoiceOver: entering C announces "Processing your request."
+- [ ] VoiceOver: each success row announced with 500ms stagger; then "Closing in 2 seconds."
+- [ ] `accessibilityReduceMotion` respected: static InkOrb, opacity-only transitions, no stagger
+- [ ] Dynamic Type tested at Accessibility Extra Extra Extra Large
+- [ ] Audio level metering does not require microphone permission beyond what `SpeechTranscriber` already requests
+
+**Robustness**
+- [ ] Recording stops synchronously in `onDismiss` — dismiss never leaves the mic open
+- [ ] Second tap on AI button while overlay is open does not crash or duplicate the transcriber
+- [ ] App sent to background mid-recording: overlay dismisses and transcriber stops
+- [ ] Re-record in State E cleanly stops and restarts the transcriber
+- [ ] Open Settings (State F) correctly opens the app's Settings page
+- [ ] Page behind the overlay is unchanged after dismiss in all terminal states

--- a/mobile/PersonalDashboard/App/AppRouter.swift
+++ b/mobile/PersonalDashboard/App/AppRouter.swift
@@ -52,6 +52,14 @@ final class AppRouter {
     /// back to nil so it doesn't fire again on the next appearance.
     var focus: ActivityFocus?
 
+    /// Drives the global voice-capture bottom sheet (issue #150). Set to true
+    /// when the user press-and-holds the centre chat button; the overlay is
+    /// attached once at the root `ZStack` in `ContentView` via
+    /// `.sheet(isPresented:)` bound to this flag, so it can present over ANY
+    /// tab without navigating. The sheet's `onDismiss` stops the shared
+    /// transcriber as the single teardown path.
+    var showVoiceOverlay: Bool = false
+
     /// When non-nil, an edge-swipe-from-leading on the active surface routes
     /// through this handler instead of opening the side drawer. Notes and
     /// Lists set this when the user is inside a sub-screen (folder, note,

--- a/mobile/PersonalDashboard/Design/Buttons.swift
+++ b/mobile/PersonalDashboard/Design/Buttons.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 enum ButtonKind {
     case primary
@@ -128,5 +129,45 @@ struct EdSendButtonStyle: ButtonStyle {
             .background(bg, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
             .opacity(configuration.isPressed ? 0.8 : 1)
             .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Glass capsule button (voice-capture overlay — issue #150)
+
+/// Frosted-glass capsule control for the full-screen voice overlay. The InkOrb
+/// is the visual hero, so these controls sit back: `.ultraThinMaterial` blur,
+/// a 50% surface tint for legibility over an animated ground, a hairline white
+/// stroke, and a barely-there ink shadow. Ink-colored label, press scale 0.96
+/// + a light haptic. No solid fills (concept doc Section 5).
+struct GlassButtonStyle: ButtonStyle {
+    /// `.edBodyMedium` for primary action labels, `.edCaption` for secondary.
+    var font: Font = .edBodyMedium
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(font)
+            .foregroundStyle(Tokens.ink)
+            .padding(.vertical, Space.sm)
+            .padding(.horizontal, Space.lg)
+            .frame(minWidth: 44, minHeight: 44)
+            .background {
+                Capsule(style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .fill(Tokens.surface.opacity(0.5))
+                    )
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .strokeBorder(Color.white.opacity(0.35), lineWidth: 0.5)
+                    )
+                    .shadow(color: Tokens.ink.opacity(0.08), radius: 8, x: 0, y: 2)
+            }
+            .contentShape(Capsule(style: .continuous))
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
+            .onChange(of: configuration.isPressed) { _, pressed in
+                if pressed { UIImpactFeedbackGenerator(style: .light).impactOccurred() }
+            }
     }
 }

--- a/mobile/PersonalDashboard/Services/SpeechTranscriber.swift
+++ b/mobile/PersonalDashboard/Services/SpeechTranscriber.swift
@@ -36,7 +36,22 @@ final class SpeechTranscriber {
     /// the audio engine fails. Cleared on the next successful `toggle()`.
     var errorMessage: String?
 
+    /// Normalized microphone amplitude (0.0–1.0), computed as RMS of each
+    /// audio buffer in the input tap, mapped from a -40dBFS floor, and
+    /// low-pass filtered (rolling average over the last 4 frames) so it
+    /// doesn't strobe. Drives the voice-capture InkOrb animation (issue #150).
+    /// Resets to 0 on stop. No extra permission needed — it reads the same
+    /// buffer the recognizer already taps.
+    private(set) var audioLevel: Float = 0
+
     // MARK: Private state
+
+    /// Rolling window of the last few normalized RMS readings for the
+    /// low-pass filter. Mutated on the audio tap's background queue, read +
+    /// averaged there too; the averaged value is hopped to the main actor for
+    /// publishing.
+    private var levelWindow: [Float] = []
+    private let levelWindowSize = 4
 
     private let recognizer: SFSpeechRecognizer? = {
         // Force en-US — `.dictation` taskHint plus on-device model is best
@@ -48,6 +63,16 @@ final class SpeechTranscriber {
     private let audioEngine = AVAudioEngine()
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
+
+    /// Synchronous re-entry guard for the async start window. `isRecording`
+    /// alone is insufficient: `start()` only flips it to true at the very end,
+    /// AFTER awaiting permission, so two near-simultaneous `start()` calls can
+    /// both pass an `isRecording` check while it's still false and both reach
+    /// `installTap`, which trips an AVAudioEngine assertion (issue #150 crash:
+    /// "required condition is false: nullptr == Tap()"). This flag is set
+    /// synchronously at the top of `start()` before any `await`, so the second
+    /// caller bails immediately.
+    private var isStarting = false
 
     init() {}
 
@@ -66,8 +91,14 @@ final class SpeechTranscriber {
     /// Synchronous tear-down. Used by `ChatView.send()` to flush a final
     /// transcript before the message ships, and by `toggle()` itself.
     func stop() {
+        // Belt-and-suspenders: clear the start-in-progress flag too, so a
+        // stop that races a start can never leave `isStarting` stuck true
+        // (issue #150). `start()`'s own `defer` normally handles this.
+        isStarting = false
         guard isRecording else { return }
         isRecording = false
+        audioLevel = 0
+        levelWindow.removeAll()
 
         // End-of-audio first, then tear down the engine. `endAudio()` lets
         // SFSpeech finalize a "best result" partial; cancelling the task
@@ -92,6 +123,14 @@ final class SpeechTranscriber {
     // MARK: Private
 
     private func start() async {
+        // Re-entry guard: bail if we're already recording OR mid-start. This
+        // runs synchronously before any `await`, so a second concurrent
+        // `start()` can't slip through the async permission window and install
+        // a duplicate tap (issue #150). Cleared on every exit via `defer`.
+        guard !isRecording && !isStarting else { return }
+        isStarting = true
+        defer { isStarting = false }
+
         errorMessage = nil
         transcript = ""
 
@@ -140,10 +179,21 @@ final class SpeechTranscriber {
 
         let inputNode = audioEngine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
+        // Defensive: remove any stale tap before installing a fresh one. A
+        // node can hold at most one tap per bus; installing over an existing
+        // tap trips "required condition is false: nullptr == Tap()" and
+        // crashes (issue #150). `removeTap` on a bus with no tap is a no-op.
+        inputNode.removeTap(onBus: 0)
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
             // The tap fires on a background queue, but the request's
             // append is thread-safe per Apple's docs.
             self?.request?.append(buffer)
+            // Compute a normalized, smoothed amplitude for the InkOrb. Done on
+            // this background queue (cheap RMS over the buffer), then the
+            // smoothed scalar is hopped to the main actor for publishing.
+            guard let self else { return }
+            let level = Self.normalizedRMS(buffer)
+            Task { @MainActor in self.publishLevel(level) }
         }
 
         audioEngine.prepare()
@@ -187,6 +237,38 @@ final class SpeechTranscriber {
                 }
             }
         }
+    }
+
+    // MARK: Audio level metering
+
+    /// RMS of the buffer's first channel, mapped from a -40dBFS floor to 0–1.
+    /// Pure function, safe to call on the audio tap's background queue.
+    private nonisolated static func normalizedRMS(_ buffer: AVAudioPCMBuffer) -> Float {
+        guard let channelData = buffer.floatChannelData else { return 0 }
+        let frameCount = Int(buffer.frameLength)
+        guard frameCount > 0 else { return 0 }
+        let samples = channelData[0]
+        var sumSquares: Float = 0
+        for i in 0..<frameCount {
+            let s = samples[i]
+            sumSquares += s * s
+        }
+        let rms = sqrt(sumSquares / Float(frameCount))
+        // Convert to dBFS, clamp to a -40dB floor, then linear-map to 0–1.
+        let db = 20 * log10(max(rms, 1e-7))
+        let floorDB: Float = -40
+        let clamped = max(floorDB, min(0, db))
+        return (clamped - floorDB) / -floorDB
+    }
+
+    /// Append a new reading to the rolling window and publish the average.
+    private func publishLevel(_ level: Float) {
+        levelWindow.append(level)
+        if levelWindow.count > levelWindowSize {
+            levelWindow.removeFirst(levelWindow.count - levelWindowSize)
+        }
+        let avg = levelWindow.reduce(0, +) / Float(levelWindow.count)
+        audioLevel = avg
     }
 
     private static func requestSpeechAuthorization() async -> Bool {

--- a/mobile/PersonalDashboard/ViewModels/VoiceCaptureViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/VoiceCaptureViewModel.swift
@@ -1,0 +1,302 @@
+import Foundation
+import Observation
+import Speech
+import AVFoundation
+import UIKit
+
+/// Drives the global full-screen voice-capture overlay (issue #150, revised
+/// auto-execute concept).
+///
+/// Owns the SINGLE `SpeechTranscriber` instance for the whole app, the 1.5s
+/// silence-finalize timer, the 1.5s safety-window timer, and the AI execute
+/// path. Injected into the SwiftUI environment from `ContentView` so the
+/// overlay (attached once at the root via `.fullScreenCover`) and `ChatView`'s
+/// inline mic button both drive the same transcriber — there is never a second
+/// instance that could install a duplicate audio tap and crash the engine (the
+/// re-entry guard in `SpeechTranscriber` backs this up).
+///
+/// The state machine is the source of truth for the overlay UI:
+///   listening → safetyWindow → executing → success
+///   listening → empty
+///   (any) → error / permissionDenied
+@Observable
+@MainActor
+final class VoiceCaptureViewModel {
+
+    /// The auto-execute state machine (concept doc Section 4).
+    enum State: Equatable {
+        case listening          // A  — recording, InkOrb reactive, live transcript
+        case safetyWindow       // A1 — "Got it", 1.5s escape hatch before execute
+        case executing          // C  — AI processing
+        case success            // D  — confirmation rows + auto-dismiss
+        case empty              // E  — silence detected, no speech
+        case permissionDenied   // F  — mic / speech permission denied
+        case error(String)      // G  — transcription or AI failure (message)
+    }
+
+    /// The single shared transcriber. Exposed so `ChatView`'s inline mic and
+    /// the overlay both read the same instance (audioLevel, transcript, etc.).
+    let transcriber = SpeechTranscriber()
+
+    private(set) var state: State = .listening
+
+    /// Success rows for State D — one per applied action.
+    private(set) var successLabels: [String] = []
+
+    /// Error/AI message surfaced in State G.
+    private(set) var errorMessageText: String?
+
+    /// Live transcript convenience (reads through to the transcriber). The
+    /// overlay binds to this for State A; the finalized text is snapshotted
+    /// into `finalizedTranscript` when listening stops.
+    var transcript: String { transcriber.transcript }
+
+    /// Normalized mic amplitude (0–1) for the InkOrb.
+    var audioLevel: Float { transcriber.audioLevel }
+
+    /// Snapshot of the transcript captured when listening stops (A → A1). This
+    /// is what gets executed; the live `transcriber.transcript` is cleared on
+    /// the next start so we can't rely on it past finalize.
+    private(set) var finalizedTranscript: String = ""
+
+    /// Swipe-to-dismiss is allowed only in the terminal states (concept doc
+    /// Section 10). The overlay binds `interactiveDismissDisabled` to the
+    /// inverse of this.
+    var allowsInteractiveDismiss: Bool {
+        switch state {
+        case .listening, .safetyWindow, .executing: return false
+        case .success, .empty, .permissionDenied, .error: return true
+        }
+    }
+
+    // MARK: Private
+
+    /// The overlay runs its own `ChatViewModel` so the AI execute path is
+    /// identical to the chat surface (same streaming service + executor),
+    /// without coupling to `ChatView`'s on-screen conversation.
+    private let chat = ChatViewModel()
+
+    private var silenceTimer: Timer?
+    /// 1.5s silence window per the revised concept doc.
+    private let silenceDelay: TimeInterval = 1.5
+    /// 1.5s safety window before auto-execute.
+    private let safetyWindowDelay: TimeInterval = 1.5
+
+    private var safetyTask: Task<Void, Never>?
+    private var executeTask: Task<Void, Never>?
+
+    // MARK: Lifecycle
+
+    /// Called when the overlay appears. Starts a fresh recording session.
+    func begin() {
+        successLabels = []
+        errorMessageText = nil
+        finalizedTranscript = ""
+        Task { await startListening() }
+    }
+
+    /// Start (or restart) recording — used by `begin()` and Try Again (E/G).
+    /// The transcriber's own re-entry guard makes a redundant start a no-op.
+    func startListening() async {
+        cancelTimers()
+        successLabels = []
+        errorMessageText = nil
+        finalizedTranscript = ""
+        state = .listening
+
+        // Permission gate up front so denial routes to State F, not the
+        // generic error path (concept doc State F vs G).
+        if Self.permissionDenied {
+            state = .permissionDenied
+            return
+        }
+        await transcriber.toggle()
+        if !transcriber.isRecording {
+            routeStartFailure()
+        }
+    }
+
+    /// Re-arm the 1.5s silence countdown. Called by the overlay on every
+    /// transcript partial while in State A. Resets on each word; when it fires
+    /// with a non-empty transcript we enter the safety window, with an empty
+    /// one we go to State E.
+    func scheduleSilenceFinalize() {
+        guard state == .listening else { return }
+        silenceTimer?.invalidate()
+        silenceTimer = Timer.scheduledTimer(
+            withTimeInterval: silenceDelay,
+            repeats: false
+        ) { [weak self] _ in
+            Task { @MainActor in self?.onSilenceElapsed() }
+        }
+    }
+
+    private func onSilenceElapsed() {
+        guard state == .listening else { return }
+        let text = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.isEmpty {
+            transcriber.stop()
+            state = .empty
+        } else {
+            enterSafetyWindow()
+        }
+    }
+
+    /// "Stop Now" (State A): skip the silence wait and go straight to the
+    /// safety window if there's content, else State E.
+    func stopNow() {
+        guard state == .listening else { return }
+        let text = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.isEmpty {
+            transcriber.stop()
+            state = .empty
+        } else {
+            enterSafetyWindow()
+        }
+    }
+
+    /// A → A1. Stop the mic, snapshot the transcript, fire a light haptic, and
+    /// start the 1.5s safety countdown that auto-executes unless cancelled.
+    private func enterSafetyWindow() {
+        cancelTimers()
+        finalizedTranscript = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        transcriber.stop()
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        state = .safetyWindow
+
+        safetyTask = Task { [safetyWindowDelay] in
+            try? await Task.sleep(nanoseconds: UInt64(safetyWindowDelay * 1_000_000_000))
+            if Task.isCancelled { return }
+            execute()
+        }
+    }
+
+    /// A1 → C. Run the finalized transcript through the AI pipeline, then D or G.
+    private func execute() {
+        let input = finalizedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !input.isEmpty else { state = .empty; return }
+        state = .executing
+        successLabels = []
+        errorMessageText = nil
+
+        executeTask = Task {
+            chat.draftInput = input
+            await chat.send()
+            if Task.isCancelled { return }
+            if let err = chat.errorMessage {
+                errorMessageText = Self.stripTechnicalPrefix(err)
+                state = .error(errorMessageText ?? "Something went wrong.")
+                return
+            }
+            let results = chat.turns.last(where: { $0.role == .assistant })?.results ?? []
+            let applied = results.filter { !$0.isFailure }
+            if applied.isEmpty {
+                successLabels = ["Message sent"]
+            } else {
+                successLabels = applied.map(Self.successLabel(for:))
+            }
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            state = .success
+        }
+    }
+
+    /// Try Again on an AI error (State G) — re-run the same transcript.
+    func retryExecute() {
+        guard !finalizedTranscript.isEmpty else {
+            Task { await startListening() }
+            return
+        }
+        execute()
+    }
+
+    /// Cancel from any state with no side effect. Best-effort cancels an
+    /// in-flight AI task in State C. This is the single teardown path, called
+    /// from the `.fullScreenCover` `onDismiss` regardless of how it closed.
+    func teardown() {
+        cancelTimers()
+        safetyTask?.cancel(); safetyTask = nil
+        executeTask?.cancel(); executeTask = nil
+        transcriber.stop()
+    }
+
+    /// Open the system Settings app (State F).
+    func openSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    // MARK: Helpers
+
+    private func cancelTimers() {
+        silenceTimer?.invalidate()
+        silenceTimer = nil
+        safetyTask?.cancel()
+        safetyTask = nil
+    }
+
+    private func routeStartFailure() {
+        if Self.permissionDenied {
+            state = .permissionDenied
+        } else if let msg = transcriber.errorMessage {
+            errorMessageText = msg
+            state = .error(msg)
+        }
+        // Otherwise (e.g. SFSpeech "no speech" already silenced) stay in
+        // .listening; the silence timer routes to State E.
+    }
+
+    /// True when speech recognition OR microphone access is denied/restricted.
+    private static var permissionDenied: Bool {
+        let speech = SFSpeechRecognizer.authorizationStatus()
+        let speechBad = (speech == .denied || speech == .restricted)
+        let micBad: Bool
+        if #available(iOS 17.0, *) {
+            micBad = (AVAudioApplication.shared.recordPermission == .denied)
+        } else {
+            micBad = (AVAudioSession.sharedInstance().recordPermission == .denied)
+        }
+        return speechBad || micBad
+    }
+
+    /// "Task added: Call John" style label for a success row, mirroring the
+    /// chat result-card vocabulary (entity word + verb + title).
+    private static func successLabel(for result: ChatActionResult) -> String {
+        let entity = entityWord(for: result.actionType).capitalized
+        let verb: String
+        switch result.state {
+        case .created: verb = "added"
+        case .deleted: verb = "removed"
+        case .updated: verb = "updated"
+        case .error:   verb = "failed"
+        }
+        if let title = result.title, !title.isEmpty {
+            return "\(entity) \(verb): \(title)"
+        }
+        return "\(entity) \(verb)"
+    }
+
+    /// Mirrors `ChatResultCard.entityWord` so the overlay's rows read the same.
+    private static func entityWord(for actionType: DraftActionType) -> String {
+        switch actionType {
+        case .createTodo, .updateTodo, .completeTodo, .deleteTodo: return "task"
+        case .createNote, .updateNote, .appendToNote, .deleteNote: return "note"
+        case .createList, .updateList, .deleteList, .addToList:    return "list"
+        case .updateListItem, .removeListItem:                     return "item"
+        case .updateFolder, .deleteFolder:                         return "folder"
+        case .createTrip, .updateTrip, .deleteTrip, .addItineraryItems: return "trip"
+        case .updateItineraryItem, .deleteItineraryItem:           return "item"
+        case .addExpense:                                          return "expense"
+        case .unknown:                                             return "action"
+        }
+    }
+
+    /// Strip a leading technical prefix from an AI/transcriber error.
+    private static func stripTechnicalPrefix(_ message: String) -> String {
+        if let range = message.range(of: ": ", options: .backwards),
+           message.distance(from: message.startIndex, to: range.lowerBound) < 40 {
+            return String(message[range.upperBound...])
+        }
+        return message
+    }
+}

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -3,7 +3,13 @@ import UIKit
 
 struct ChatView: View {
     @State private var viewModel = ChatViewModel()
-    @State private var transcriber = SpeechTranscriber()
+    /// The speech transcriber is owned by the app-level `VoiceCaptureViewModel`
+    /// and shared via the environment (issue #150). The inline mic button here
+    /// and the global press-and-hold overlay therefore drive the SAME single
+    /// transcriber instance, which is what keeps the re-entry guard meaningful
+    /// (two instances could each install a tap and crash the audio engine).
+    @Environment(VoiceCaptureViewModel.self) private var voiceVM
+    private var transcriber: SpeechTranscriber { voiceVM.transcriber }
     @State private var pendingViewMore: Bool = false
     @State private var keyboardVisible: Bool = false
     /// Whatever the user had typed at the moment they tapped the mic.
@@ -11,6 +17,16 @@ struct ChatView: View {
     /// so partials feel live; tapping mic-stop with an empty transcript
     /// restores the baseline so we don't clobber typed text on a misfire.
     @State private var preMicBaseline: String = ""
+
+    /// Silence-finalize timer (issue #150). Each transcript update from the
+    /// transcriber resets this; when it fires after `silenceFinalizeDelay` of
+    /// no new partials, we stop the mic and leave the transcript in the input
+    /// field as editable text (we do NOT auto-submit). Invalidated on stop.
+    @State private var silenceTimer: Timer?
+    /// How long the user has to stop speaking before we finalize. ~1.8s sits
+    /// in the requested 1.5–2s window: long enough to ride out a natural
+    /// mid-sentence pause, short enough to feel responsive.
+    private let silenceFinalizeDelay: TimeInterval = 1.8
 
     /// Owned here so we can auto-focus the input bar when the user lands on
     /// chat (issue #48 — tapping the chat icon should pop the keyboard
@@ -72,6 +88,13 @@ struct ChatView: View {
                     }
                 )
 
+                if transcriber.isRecording {
+                    ListeningIndicator(onStop: stopListening)
+                        .padding(.horizontal, Space.lg)
+                        .padding(.bottom, Space.xs)
+                        .transition(.opacity.combined(with: .move(edge: .bottom)))
+                }
+
                 if let micError = transcriber.errorMessage {
                     // Restrained inline note above the input bar — matches
                     // the design vocabulary (Tokens.surface bg, muted text).
@@ -116,6 +139,9 @@ struct ChatView: View {
                 // sits visually close to the floating pill.
                 .padding(.bottom, keyboardVisible ? Space.md : BottomTabBarMetrics.height)
             }
+            // Animate the listening banner and inline mic-error in/out so they
+            // don't pop (their transitions are declared at each call site).
+            .animation(.easeOut(duration: 0.2), value: transcriber.isRecording)
         }
         .background(Tokens.paper)
         .onAppear {
@@ -142,7 +168,12 @@ struct ChatView: View {
             // sees the transcription appear in real time. Append to the
             // baseline (whatever was typed before mic-tap) instead of
             // replacing — keeps already-typed context intact.
-            guard transcriber.isRecording else { return }
+            //
+            // Suppressed while the global voice overlay is presented: the
+            // overlay's `VoiceCaptureViewModel` owns the transcript and its
+            // own silence timer in that mode, so the inline chat mirroring
+            // must stand down to avoid two owners writing the same transcriber.
+            guard transcriber.isRecording, !router.showVoiceOverlay else { return }
             if newTranscript.isEmpty {
                 viewModel.draftInput = preMicBaseline
             } else if preMicBaseline.isEmpty {
@@ -150,7 +181,18 @@ struct ChatView: View {
             } else {
                 viewModel.draftInput = preMicBaseline + " " + newTranscript
             }
+            // Each new partial is a sign of speech: reset the silence
+            // countdown. Once partials stop arriving for `silenceFinalizeDelay`
+            // the timer fires and finalizes (issue #150).
+            scheduleSilenceFinalize()
         }
+        .onChange(of: transcriber.isRecording) { _, recording in
+            // If recording ends for any reason (user tapped stop, an error,
+            // or our own finalize), tear the silence timer down so it can't
+            // fire against a dead session.
+            if !recording { cancelSilenceTimer() }
+        }
+        .onDisappear { cancelSilenceTimer() }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
             withAnimation(.easeOut(duration: 0.18)) { keyboardVisible = true }
         }
@@ -258,20 +300,69 @@ struct ChatView: View {
         // Flush any in-flight transcription first so the final partial
         // lands in `draftInput` before the message ships.
         if transcriber.isRecording {
-            transcriber.stop()
+            stopListening()
         }
         Task { await viewModel.send() }
     }
 
     private func toggleMic() async {
         if transcriber.isRecording {
-            transcriber.stop()
+            stopListening()
         } else {
-            // Snapshot what's already in the field so live partials append
-            // to it rather than overwriting typed context.
-            preMicBaseline = viewModel.draftInput
-            await transcriber.toggle()
+            await startListening()
         }
+    }
+
+    /// Begin a voice-capture session: drop the keyboard (so the listening UI
+    /// owns the surface), snapshot any typed baseline, and start the
+    /// transcriber. Shared by the mic button and the press-and-hold entry
+    /// point (issue #150). If permission is denied, the transcriber surfaces
+    /// the failure through `errorMessage` and the inline error path renders it.
+    private func startListening() async {
+        guard !transcriber.isRecording else { return }
+        // Drop the keyboard so the listening UI owns the surface and the
+        // input field shows the live transcript instead of a caret.
+        inputFocused = false
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+        // Snapshot what's already in the field so live partials append to it
+        // rather than overwriting typed context.
+        preMicBaseline = viewModel.draftInput
+        await transcriber.toggle()
+    }
+
+    /// Stop the transcriber and leave the transcript in the input field as
+    /// editable text. Deliberately does NOT submit — the user reads/edits and
+    /// taps send, or speaks again to append (issue #150).
+    private func stopListening() {
+        transcriber.stop()
+        cancelSilenceTimer()
+    }
+
+    /// (Re)arm the silence-finalize countdown. Called on every transcript
+    /// partial; the most recent call wins, so the timer only fires once the
+    /// user has been quiet for `silenceFinalizeDelay`. On fire we stop the
+    /// mic but keep the transcript editable (no auto-send).
+    private func scheduleSilenceFinalize() {
+        silenceTimer?.invalidate()
+        silenceTimer = Timer.scheduledTimer(
+            withTimeInterval: silenceFinalizeDelay,
+            repeats: false
+        ) { _ in
+            Task { @MainActor in
+                guard transcriber.isRecording else { return }
+                stopListening()
+            }
+        }
+    }
+
+    private func cancelSilenceTimer() {
+        silenceTimer?.invalidate()
+        silenceTimer = nil
     }
 
     private var hasLiveAssistantTurn: Bool {
@@ -293,6 +384,63 @@ struct ChatView: View {
     }
 }
 
+/// "Listening…" banner shown above the input bar while the transcriber is
+/// active (issue #150). A pulsing dot + animated waveform bars read as a live
+/// mic state, and tapping anywhere on the row stops listening (mirrors the
+/// input-bar stop button so the user has an obvious cancel target right where
+/// their eyes are). Uses the restrained design vocabulary: surface fill,
+/// paper border, danger-tinted dot to echo the input-bar stop affordance.
+private struct ListeningIndicator: View {
+    let onStop: () -> Void
+
+    @State private var pulse = false
+
+    var body: some View {
+        HStack(spacing: Space.sm) {
+            // Pulsing mic dot — the recording "heartbeat".
+            Circle()
+                .fill(Tokens.danger)
+                .frame(width: 8, height: 8)
+                .scaleEffect(pulse ? 1.0 : 0.55)
+                .opacity(pulse ? 1.0 : 0.5)
+                .onAppear {
+                    withAnimation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true)) {
+                        pulse = true
+                    }
+                }
+
+            Text("Listening…")
+                .font(.edCaption)
+                .foregroundStyle(Tokens.ink)
+
+            WaveformBars()
+
+            Spacer(minLength: 0)
+
+            Text("Tap to stop")
+                .font(.edCaption)
+                .foregroundStyle(Tokens.muted)
+        }
+        .padding(.horizontal, Space.md)
+        .padding(.vertical, Space.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Tokens.surface,
+            in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+        )
+        .paperBorder(Tokens.border, radius: Radius.md)
+        .contentShape(Rectangle())
+        .onTapGesture { onStop() }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Listening. Tap to stop voice input.")
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+/// Three short bars that bob continuously to suggest live audio. Decorative
+/// only — height is time-driven, not bound to actual mic levels (the
+/// transcriber doesn't expose levels), so it reads as "active" without
+/// implying a meter.
 /// Three pill-capped bars + accent dot mirroring the Deks logo (top 55%,
 /// middle 85%, bottom 70%, dot just past the end of the top bar). The
 /// bars are anchored at the leading edge; each bar's *length* oscillates

--- a/mobile/PersonalDashboard/Views/Chat/InkOrb.swift
+++ b/mobile/PersonalDashboard/Views/Chat/InkOrb.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// The voice-capture overlay's hero animation (concept doc Section 2): a single
+/// `Tokens.ink` filled circle that breathes with the mic amplitude, plus a
+/// soft trailing outer ring that lags the inner circle. Strictly monochrome —
+/// the depth of the ink is the signal, never hue.
+///
+/// Modes map to the overlay state machine:
+///   - `.listening`: amplitude-reactive (scale 1.0→1.33, opacity 0.22→0.90),
+///     with an autonomous 1.4s sine pulse layered in for the gaps between
+///     words so it never reads as dead.
+///   - `.settled`: compressed to 0.88 scale, animation stopped (State A1).
+///   - `.thinking`: slow 2.0s autonomous pulse (0.30–0.55 opacity), no
+///     amplitude (State C).
+///   - `.rest`: faded to 0.15 opacity, still (State D).
+///   - `.dim`: 0.15 opacity, still (States F/G — feature unavailable).
+///   - `.idle`: 0.22 opacity, still (State E — nothing heard).
+///
+/// Reduce-motion collapses every mode to a static filled circle (0.50 opacity)
+/// with a thin border ring for legibility.
+struct InkOrb: View {
+    enum Mode: Equatable {
+        case listening
+        case settled
+        case thinking
+        case rest
+        case dim
+        case idle
+    }
+
+    var mode: Mode
+    /// Normalized mic amplitude (0–1). Only consulted in `.listening`.
+    var level: Float = 0
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let baseDiameter: CGFloat = 120
+
+    var body: some View {
+        if reduceMotion {
+            reducedMotionOrb
+        } else {
+            animatedOrb
+        }
+    }
+
+    // MARK: Reduce-motion
+
+    private var reducedMotionOrb: some View {
+        ZStack {
+            Circle()
+                .fill(Tokens.ink)
+                .opacity(0.50)
+            Circle()
+                .strokeBorder(Tokens.border, lineWidth: 1)
+                .frame(width: 144, height: 144)
+        }
+        .frame(width: baseDiameter, height: baseDiameter)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: Animated
+
+    private var animatedOrb: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: isStatic)) { ctx in
+            let t = ctx.date.timeIntervalSinceReferenceDate
+            let (innerScale, innerOpacity, ringScale, ringOpacity) = values(at: t)
+
+            ZStack {
+                // Trailing outer ring — lags the inner circle (springs below).
+                Circle()
+                    .stroke(Tokens.ink, lineWidth: 1)
+                    .frame(width: 140, height: 140)
+                    .scaleEffect(ringScale)
+                    .opacity(ringOpacity)
+                    .animation(.spring(response: 0.28, dampingFraction: 0.70).delay(0.08), value: level)
+
+                // Inner filled circle — the hero.
+                Circle()
+                    .fill(Tokens.ink)
+                    .frame(width: baseDiameter, height: baseDiameter)
+                    .scaleEffect(innerScale)
+                    .opacity(innerOpacity)
+                    .animation(.spring(response: 0.18, dampingFraction: 0.65), value: level)
+            }
+            .animation(.easeOut(duration: modeTransitionDuration), value: mode)
+        }
+        .accessibilityHidden(true)
+    }
+
+    /// Static modes don't need the 30fps timeline driving them.
+    private var isStatic: Bool {
+        switch mode {
+        case .settled, .rest, .dim, .idle: return true
+        case .listening, .thinking: return false
+        }
+    }
+
+    private var modeTransitionDuration: Double {
+        switch mode {
+        case .settled: return 0.15
+        case .thinking: return 0.3
+        case .rest: return 0.4
+        default: return 0.2
+        }
+    }
+
+    /// Returns (innerScale, innerOpacity, ringScale, ringOpacity) for time `t`.
+    private func values(at t: Double) -> (CGFloat, CGFloat, CGFloat, CGFloat) {
+        switch mode {
+        case .listening:
+            // Amplitude drives the headline motion; an autonomous 1.4s sine
+            // fills the silence between words so the orb still breathes.
+            let amp = CGFloat(max(0, min(1, level)))
+            let idle = (sin(2 * .pi * t / 1.4) + 1) / 2  // 0...1
+            let idleScale = 1.0 + 0.08 * idle
+            let idleOpacity = 0.22 + 0.20 * idle
+            // Blend: amplitude takes over as the user speaks.
+            let innerScale = max(idleScale, 1.0 + 0.33 * amp)
+            let innerOpacity = max(idleOpacity, 0.22 + 0.68 * amp)
+            let ringScale = 1.0 + (200.0 / 140.0 - 1.0) * amp   // 140pt → 200pt
+            let ringOpacity = 0.18 * amp
+            return (innerScale, innerOpacity, ringScale, ringOpacity)
+
+        case .settled:
+            return (0.88, 0.80, 1.0, 0)
+
+        case .thinking:
+            // Slow 2.0s waiting pulse, no amplitude.
+            let p = (sin(2 * .pi * t / 2.0) + 1) / 2
+            let scale = 1.0 + 0.10 * p
+            let opacity = 0.30 + 0.25 * p
+            return (scale, opacity, 1.0, 0)
+
+        case .rest:
+            return (1.0, 0.15, 1.0, 0)
+
+        case .dim:
+            return (1.0, 0.15, 1.0, 0)
+
+        case .idle:
+            return (1.0, 0.22, 1.0, 0)
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Views/Chat/VoiceCaptureOverlay.swift
+++ b/mobile/PersonalDashboard/Views/Chat/VoiceCaptureOverlay.swift
@@ -1,0 +1,410 @@
+import SwiftUI
+import UIKit
+
+/// Global full-screen voice-capture overlay (issue #150, auto-execute concept).
+///
+/// Presented once from `ContentView`'s root via `.fullScreenCover` bound to
+/// `AppRouter.showVoiceOverlay`, so it covers whatever tab the user was on
+/// without navigating — dismiss returns to the same page/scroll. Renders the
+/// state machine in `VoiceCaptureViewModel` (A / A1 / C / D / E / F / G) as a
+/// pure projection of `vm.state`. All teardown funnels through the cover's
+/// `onDismiss` → `vm.teardown()`.
+///
+/// Layout (concept doc Section 3): top bar (status + Cancel), animation zone
+/// (InkOrb, upper portion), divider, transcript zone, bottom control zone.
+struct VoiceCaptureOverlay: View {
+    @Bindable var vm: VoiceCaptureViewModel
+    /// Bound to `router.showVoiceOverlay`; set false to dismiss the cover.
+    @Binding var isPresented: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @AppStorage("hasSeenVoiceHint") private var hasSeenVoiceHint: Bool = false
+
+    var body: some View {
+        GeometryReader { geo in
+            let animationFraction: CGFloat = dynamicTypeSize > .xxLarge ? 0.30 : 0.38
+
+            ZStack {
+                Tokens.surface.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    topBar
+                        .frame(height: 52)
+                        .padding(.horizontal, Space.xl)
+
+                    // Animation zone — InkOrb centered.
+                    ZStack {
+                        InkOrb(mode: orbMode, level: vm.audioLevel)
+                    }
+                    .frame(height: geo.size.height * animationFraction)
+                    .frame(maxWidth: .infinity)
+
+                    Divider().overlay(Tokens.border)
+
+                    // Transcript / body zone.
+                    bodyZone
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                    // Bottom control zone.
+                    bottomZone
+                        .frame(minHeight: 80)
+                        .padding(.horizontal, Space.xl)
+                        .padding(.bottom, Space.sm)
+                }
+            }
+        }
+        .preferredColorScheme(nil)
+        .interactiveDismissDisabled(!vm.allowsInteractiveDismiss)
+        .onAppear {
+            vm.begin()
+            UIAccessibility.post(notification: .announcement, argument: "Recording in progress.")
+        }
+        .onChange(of: vm.transcript) { _, _ in
+            vm.scheduleSilenceFinalize()
+        }
+        .onChange(of: vm.state) { _, newState in
+            announce(for: newState)
+            if newState != .listening, !vm.transcript.isEmpty, !hasSeenVoiceHint {
+                hasSeenVoiceHint = true
+            }
+        }
+        .animation(.easeOut(duration: reduceMotion ? 0.15 : 0.2), value: vm.state)
+    }
+
+    // MARK: - Top bar
+
+    @ViewBuilder
+    private var topBar: some View {
+        HStack(alignment: .center) {
+            Text(statusLabel)
+                .font(.edCaption)
+                .foregroundStyle(Tokens.muted)
+                .transition(.opacity)
+                .id(statusLabel)  // cross-fade on change
+
+            Spacer(minLength: Space.md)
+
+            if let action = topRightControl {
+                Button(action.title) { action.run() }
+                    .buttonStyle(GlassButtonStyle(font: .edCaption))
+                    .accessibilityLabel(action.a11y)
+            }
+        }
+    }
+
+    private var statusLabel: String {
+        switch vm.state {
+        case .listening:        return "Listening"
+        case .safetyWindow:     return "Got it"
+        case .executing:        return "Working…"
+        case .success:          return "Done"
+        case .empty:            return "Nothing heard"
+        case .permissionDenied: return "Microphone access needed"
+        case .error:            return "Something went wrong"
+        }
+    }
+
+    /// (title, accessibility label, action) for the top-right glass control.
+    private var topRightControl: (title: String, a11y: String, run: () -> Void)? {
+        switch vm.state {
+        case .listening, .safetyWindow, .executing:
+            return ("Cancel", "Cancel voice capture", { isPresented = false })
+        case .empty:
+            return ("Cancel", "Cancel voice capture", { isPresented = false })
+        case .permissionDenied:
+            return ("Not now", "Not now", { isPresented = false })
+        case .error:
+            return ("Dismiss", "Dismiss", { isPresented = false })
+        case .success:
+            return nil  // no buttons in Done
+        }
+    }
+
+    // MARK: - Body zone
+
+    @ViewBuilder
+    private var bodyZone: some View {
+        switch vm.state {
+        case .listening:
+            transcriptScroll(static: false)
+        case .safetyWindow:
+            transcriptScroll(static: true)
+        case .executing:
+            executingBody
+        case .success:
+            successBody
+        case .empty:
+            centeredMessage("Try speaking, or tap the mic to record again.")
+        case .permissionDenied:
+            centeredMessage("Dexter needs microphone and speech access to record your voice. Turn them on in Settings to continue.")
+        case .error(let message):
+            centeredMessage(message)
+        }
+    }
+
+    /// State A / A1 transcript. `static` true freezes the cursor (A1).
+    private func transcriptScroll(static isStatic: Bool) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    if vm.transcript.isEmpty && !isStatic {
+                        if !hasSeenVoiceHint {
+                            Text("Start speaking — Dexter is listening.")
+                                .font(.edCaption)
+                                .foregroundStyle(Tokens.muted)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.top, Space.xl)
+                        }
+                    } else {
+                        HStack(alignment: .lastTextBaseline, spacing: 2) {
+                            Text(vm.transcript)
+                                .font(.edBody)
+                                .foregroundStyle(Tokens.ink)
+                                .fixedSize(horizontal: false, vertical: true)
+                            if !isStatic {
+                                BlinkingCursor(reduceMotion: reduceMotion)
+                            }
+                        }
+                    }
+                    Color.clear.frame(height: 1).id("bottom")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, Space.xl)
+                .padding(.top, Space.lg)
+            }
+            .onChange(of: vm.transcript) { _, _ in
+                withAnimation(.easeOut(duration: 0.15)) {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
+            }
+        }
+    }
+
+    // State C — muted static transcript + typing indicator.
+    private var executingBody: some View {
+        VStack(alignment: .leading, spacing: Space.lg) {
+            Text(vm.finalizedTranscript)
+                .font(.edBody)
+                .foregroundStyle(Tokens.muted)
+                .fixedSize(horizontal: false, vertical: true)
+
+            TypingIndicator()
+                .transition(.opacity)
+                .accessibilityLabel("Processing your request.")
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, Space.xl)
+        .padding(.top, Space.lg)
+    }
+
+    // State D — success rows.
+    private var successBody: some View {
+        VStack(alignment: .leading, spacing: Space.md) {
+            ForEach(Array(vm.successLabels.enumerated()), id: \.offset) { _, label in
+                SuccessRow(label: label)
+                    .transition(
+                        reduceMotion ? .opacity
+                                     : .opacity.combined(with: .move(edge: .bottom))
+                    )
+                    .accessibilityHidden(true)  // announced via VoiceOver post
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, Space.xl)
+        .padding(.top, Space.lg)
+    }
+
+    private func centeredMessage(_ text: String) -> some View {
+        VStack {
+            Spacer(minLength: 0)
+            Text(text)
+                .font(.edBody)
+                .foregroundStyle(Tokens.inkSoft)
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+                .frame(maxWidth: .infinity)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Space.xl)
+    }
+
+    // MARK: - Bottom control zone
+
+    @ViewBuilder
+    private var bottomZone: some View {
+        switch vm.state {
+        case .listening:
+            // Stop Now, centered.
+            HStack {
+                Spacer()
+                Button("Stop Now") { vm.stopNow() }
+                    .buttonStyle(GlassButtonStyle())
+                    .accessibilityLabel("Stop and execute")
+                Spacer()
+            }
+
+        case .safetyWindow:
+            // Secondary Cancel (thumb reach) + sweeping progress bar.
+            HStack(spacing: Space.lg) {
+                Button("Cancel") { isPresented = false }
+                    .buttonStyle(GlassButtonStyle())
+                    .accessibilityLabel("Cancel voice capture")
+                SafetyProgressBar(duration: 1.5)
+                    .accessibilityHidden(true)
+            }
+
+        case .executing:
+            // No bottom control — only the top Cancel.
+            Color.clear.frame(height: 1)
+
+        case .success:
+            // Auto-dismiss progress line.
+            AutoDismissProgressLine(reduceMotion: reduceMotion) {
+                isPresented = false
+            }
+            .accessibilityHidden(true)
+
+        case .empty:
+            twoGlass(
+                left: ("Cancel", "Cancel voice capture", { isPresented = false }),
+                right: ("Try Again", "Try again", { Task { await vm.startListening() } })
+            )
+
+        case .permissionDenied:
+            twoGlass(
+                left: ("Not now", "Not now", { isPresented = false }),
+                right: ("Open Settings", "Open Settings", { vm.openSettings() })
+            )
+
+        case .error:
+            twoGlass(
+                left: ("Dismiss", "Dismiss", { isPresented = false }),
+                right: ("Try Again", "Try again", { vm.retryExecute() })
+            )
+        }
+    }
+
+    private func twoGlass(
+        left: (String, String, () -> Void),
+        right: (String, String, () -> Void)
+    ) -> some View {
+        HStack {
+            Button(left.0) { left.2() }
+                .buttonStyle(GlassButtonStyle())
+                .accessibilityLabel(left.1)
+            Spacer()
+            Button(right.0) { right.2() }
+                .buttonStyle(GlassButtonStyle())
+                .accessibilityLabel(right.1)
+        }
+    }
+
+    // MARK: - InkOrb mode mapping
+
+    private var orbMode: InkOrb.Mode {
+        switch vm.state {
+        case .listening:        return .listening
+        case .safetyWindow:     return .settled
+        case .executing:        return .thinking
+        case .success:          return .rest
+        case .empty:            return .idle
+        case .permissionDenied: return .dim
+        case .error:            return .dim
+        }
+    }
+
+    // MARK: - Accessibility announcements
+
+    private func announce(for state: VoiceCaptureViewModel.State) {
+        switch state {
+        case .safetyWindow:
+            UIAccessibility.post(notification: .announcement,
+                                 argument: "Executing in 1.5 seconds. Double tap Cancel to abort.")
+        case .executing:
+            UIAccessibility.post(notification: .announcement, argument: "Processing your request.")
+        case .success:
+            for (idx, label) in vm.successLabels.enumerated() {
+                DispatchQueue.main.asyncAfter(deadline: .now() + Double(idx) * 0.5) {
+                    UIAccessibility.post(notification: .announcement, argument: label)
+                }
+            }
+            let after = Double(vm.successLabels.count) * 0.5
+            DispatchQueue.main.asyncAfter(deadline: .now() + after) {
+                UIAccessibility.post(notification: .announcement, argument: "Closing in 2 seconds.")
+            }
+        default:
+            break
+        }
+    }
+}
+
+// MARK: - Blinking transcript cursor
+
+private struct BlinkingCursor: View {
+    let reduceMotion: Bool
+    @State private var visible = true
+
+    var body: some View {
+        Rectangle()
+            .fill(Tokens.ink)
+            .frame(width: 2, height: 18)
+            .opacity(reduceMotion ? 1 : (visible ? 1 : 0))
+            .accessibilityHidden(true)
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                    visible = false
+                }
+            }
+    }
+}
+
+// MARK: - Safety-window sweeping progress bar (A1)
+
+/// 1pt ink-30% bar that sweeps 0 → full width over `duration` (linear). It is
+/// informational, so it animates even under reduce-motion (Apple's guidance).
+private struct SafetyProgressBar: View {
+    let duration: Double
+    @State private var progress: CGFloat = 0
+
+    var body: some View {
+        GeometryReader { geo in
+            Rectangle()
+                .fill(Tokens.ink.opacity(0.30))
+                .frame(width: geo.size.width * progress, height: 1)
+                .frame(maxHeight: .infinity, alignment: .center)
+        }
+        .frame(height: 44)
+        .onAppear {
+            withAnimation(.linear(duration: duration)) { progress = 1 }
+        }
+    }
+}
+
+// MARK: - Auto-dismiss progress line (D)
+
+/// 1pt ink-20% line that depletes over 2.0s, then dismisses. Informational, so
+/// it animates under reduce-motion too.
+private struct AutoDismissProgressLine: View {
+    let reduceMotion: Bool
+    let onComplete: () -> Void
+    @State private var progress: CGFloat = 0
+
+    var body: some View {
+        GeometryReader { geo in
+            Rectangle()
+                .fill(Tokens.ink.opacity(0.2))
+                .frame(width: geo.size.width * progress, height: 1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(height: 1)
+        .onAppear {
+            withAnimation(.linear(duration: 2.0)) { progress = 1 }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { onComplete() }
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Views/Chat/WaveformBars.swift
+++ b/mobile/PersonalDashboard/Views/Chat/WaveformBars.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Three short bars that bob continuously to suggest live audio. Decorative
+/// only — height is time-driven, not bound to actual mic levels (the
+/// transcriber doesn't expose levels), so it reads as "active" without
+/// implying a meter. Shared by the inline chat `ListeningIndicator` and the
+/// global voice-capture overlay (issue #150).
+struct WaveformBars: View {
+    private let barWidth: CGFloat = 3
+    private let baseHeight: CGFloat = 6
+    private let maxHeight: CGFloat = 16
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0, paused: false)) { ctx in
+            let t = ctx.date.timeIntervalSinceReferenceDate
+            HStack(alignment: .center, spacing: 3) {
+                bar(height: height(t: t, period: 0.62, phase: 0.0))
+                bar(height: height(t: t, period: 0.48, phase: 1.1))
+                bar(height: height(t: t, period: 0.70, phase: 2.0))
+            }
+            .frame(height: maxHeight)
+        }
+    }
+
+    private func bar(height: CGFloat) -> some View {
+        Capsule(style: .continuous)
+            .fill(Tokens.danger.opacity(0.8))
+            .frame(width: barWidth, height: height)
+    }
+
+    private func height(t: Double, period: Double, phase: Double) -> CGFloat {
+        let s = (sin(2 * .pi * t / period + phase) + 1) / 2  // 0...1
+        return baseHeight + (maxHeight - baseHeight) * CGFloat(s)
+    }
+}

--- a/mobile/PersonalDashboard/Views/ContentView.swift
+++ b/mobile/PersonalDashboard/Views/ContentView.swift
@@ -3,6 +3,11 @@ import UIKit
 
 struct ContentView: View {
     @State private var router = AppRouter()
+    /// App-level owner of the single `SpeechTranscriber`, the silence timer,
+    /// and the AI send path for voice capture (issue #150). Injected into the
+    /// environment so the global overlay AND `ChatView`'s inline mic share one
+    /// transcriber instance.
+    @State private var voiceVM = VoiceCaptureViewModel()
     @AppStorage("colorSchemePref") private var schemePrefRaw: String = ColorSchemePref.system.rawValue
 
     /// Tracks whether we've already resigned first responder for the active
@@ -80,6 +85,19 @@ struct ContentView: View {
                 .zIndex(4)
         }
         .preferredColorScheme((ColorSchemePref(rawValue: schemePrefRaw) ?? .system).resolved)
+        // Share the single voice-capture view model (and thus the single
+        // transcriber) with every surface, including ChatView's inline mic.
+        .environment(voiceVM)
+        // Global voice-capture overlay (issue #150, full-screen auto-execute) —
+        // attached ONCE here so press-and-hold presents it over whatever tab
+        // the user is on. A `.fullScreenCover` pushes NO navigation entry, so
+        // dismissing returns to the exact tab and scroll position. `onDismiss`
+        // is the single teardown path: it stops the mic and cancels every
+        // timer/AI task regardless of how the cover closed (Cancel, swipe in a
+        // terminal state, or auto-dismiss).
+        .fullScreenCover(isPresented: $router.showVoiceOverlay, onDismiss: { voiceVM.teardown() }) {
+            VoiceCaptureOverlay(vm: voiceVM, isPresented: $router.showVoiceOverlay)
+        }
         .activeSection(router.currentSection)
         .coordinateSpace(name: edgeCoordinateSpace)
         // Edge-swipe-to-open is scoped to a 20pt-wide leading strip overlay,

--- a/mobile/PersonalDashboard/Views/Shell/BottomTabBar.swift
+++ b/mobile/PersonalDashboard/Views/Shell/BottomTabBar.swift
@@ -37,6 +37,9 @@ struct BottomTabBar: View {
     @Bindable var router: AppRouter
 
     @State private var keyboardVisible = false
+    /// True while the chat circle is being pressed (drives the press-down
+    /// scale). Set/cleared by the long-press gesture's `onPressingChanged`.
+    @State private var isPressingChat = false
     @Namespace private var activePillNamespace
 
     /// Flat tabs (4 positions inside the pill — chat is the floating circle
@@ -209,27 +212,53 @@ struct BottomTabBar: View {
     private var chatButton: some View {
         let isActive = router.currentSection == .chat
 
-        return Button {
-            router.popToChat()
-        } label: {
-            ZStack {
-                Circle()
-                    .fill(Tokens.ink)
-                    .frame(width: chatDiameter, height: chatDiameter)
+        // NOT a Button. A Button + `.simultaneousGesture(LongPressGesture)`
+        // lets BOTH recognizers fire: the hold presents the overlay AND the
+        // Button's tap action still runs on touch-up, navigating to chat
+        // (issue #150 device QA). Pairing `.onTapGesture` with
+        // `.onLongPressGesture` instead makes them mutually exclusive —
+        // SwiftUI cancels the pending tap once the long-press succeeds, so a
+        // completed hold never triggers `popToChat()`. Tap and hold are now
+        // distinct outcomes:
+        //   • quick TAP  → router.popToChat()        (open chat to type)
+        //   • HOLD ≥0.6s → haptic + show overlay      (stay on current page)
+        return ZStack {
+            Circle()
+                .fill(Tokens.ink)
+                .frame(width: chatDiameter, height: chatDiameter)
 
-                Image(systemName: "sparkles")
-                    .font(.system(size: 22, weight: .regular))
-                    .foregroundStyle(Tokens.paper)
-            }
-            // Shadow alone lifts the circle off the pill in both themes —
-            // a paper/surface rim was producing a white halo in light mode
-            // (the dark circle already has plenty of natural contrast
-            // against a light pill, so the rim was over-engineering).
-            .shadow(color: .black.opacity(0.22), radius: 16, x: 0, y: 7)
-            .scaleEffect(isActive ? 1.0 : 1.0)
+            Image(systemName: "sparkles")
+                .font(.system(size: 22, weight: .regular))
+                .foregroundStyle(Tokens.paper)
         }
-        .buttonStyle(.plain)
+        // Shadow alone lifts the circle off the pill in both themes — a
+        // paper/surface rim was producing a white halo in light mode (the
+        // dark circle already has plenty of natural contrast against a light
+        // pill, so the rim was over-engineering).
+        .shadow(color: .black.opacity(0.22), radius: 16, x: 0, y: 7)
+        // Subtle press-down feedback: scale to 0.92 while the finger is held,
+        // spring back on release / cancel (concept doc Section 3).
+        .scaleEffect(isPressingChat ? 0.92 : 1.0)
+        .animation(.easeOut(duration: 0.1), value: isPressingChat)
+        .contentShape(Circle())
+        // Long-press FIRST so its `pressing` callback drives the scale and a
+        // successful hold cancels the tap below.
+        .onLongPressGesture(
+            minimumDuration: 0.6,
+            perform: {
+                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                router.showVoiceOverlay = true
+            },
+            onPressingChanged: { pressing in
+                isPressingChat = pressing
+            }
+        )
+        .onTapGesture {
+            router.popToChat()
+        }
+        .accessibilityElement(children: .ignore)
         .accessibilityLabel("Chat")
-        .accessibilityAddTraits(isActive ? [.isSelected] : [])
+        .accessibilityHint("Double tap to open chat. Touch and hold to start voice input.")
+        .accessibilityAddTraits(isActive ? [.isSelected, .isButton] : [.isButton])
     }
 }


### PR DESCRIPTION
## Summary
- Press-and-hold the AI button in the bottom nav opens a full-screen, on-device voice capture experience; a normal tap still opens chat for typing.
- Auto-execute flow: listening with a live transcript and an amplitude-reactive InkOrb animation, then on ~1.5s of silence a short "Got it" safety window (with Cancel) before the command runs through the AI, then a success summary and auto-dismiss back to the same page.
- Voice state lives in a root-level `VoiceCaptureViewModel` that owns a single `SpeechTranscriber`, so the overlay is reachable from every tab and shares one transcriber with the chat input mic.
- Glass-style controls (Cancel / Stop Now / Done). On-device speech only; the animation reads mic amplitude off the existing recognition audio tap, so no extra permission.
- Hardened `SpeechTranscriber` against a concurrent double-start that crashed AVAudioEngine ("nullptr == Tap()"): synchronous `isStarting` guard plus a defensive `removeTap` before `installTap`.

Design spec: `docs/design/202606 - Voice Capture Overlay - Concept.md`.

Closes #150

## Test plan
Verified on device (iPhone 16 Pro Max, iOS 26). Full acceptance-criteria walkthrough with evidence is in the [QA comment on #150](https://github.com/akshaydotsharma/Dexter/issues/150#issuecomment-4846289393).
- [x] Tap opens chat; hold opens voice (release does not navigate)
- [x] Live transcription + InkOrb reacts to voice
- [x] Silence -> safety window -> auto-execute -> success -> dismiss to same page
- [x] Stop Now / Cancel behave correctly
- [x] No crash on repeat hold while the cover is open
- [x] Clean static build on latest `main` (rebased onto b47e39c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)