### PR TITLE
fix(ios): make voice capture one-shot and stateless per utterance

### DIFF
--- a/mobile/PersonalDashboard/Design/Buttons.swift
+++ b/mobile/PersonalDashboard/Design/Buttons.swift
@@ -142,26 +142,41 @@ struct EdSendButtonStyle: ButtonStyle {
 struct GlassButtonStyle: ButtonStyle {
     /// `.edBodyMedium` for primary action labels, `.edCaption` for secondary.
     var font: Font = .edBodyMedium
+    /// When true, renders as a filled ink capsule with paper text so it reads as
+    /// the primary action in a group (voice overlay "Stop Recording", #156). Keeps
+    /// the same capsule shape, press-scale, and haptic as the frosted variant so
+    /// the two sit in one family.
+    var prominent: Bool = false
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(font)
-            .foregroundStyle(Tokens.ink)
+            .foregroundStyle(prominent ? Tokens.paper : Tokens.ink)
             .padding(.vertical, Space.sm)
-            .padding(.horizontal, Space.lg)
+            .padding(.horizontal, prominent ? Space.xl : Space.lg)
             .frame(minWidth: 44, minHeight: 44)
             .background {
-                Capsule(style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        Capsule(style: .continuous)
-                            .fill(Tokens.surface.opacity(0.5))
-                    )
-                    .overlay(
-                        Capsule(style: .continuous)
-                            .strokeBorder(Color.white.opacity(0.35), lineWidth: 0.5)
-                    )
-                    .shadow(color: Tokens.ink.opacity(0.08), radius: 8, x: 0, y: 2)
+                if prominent {
+                    Capsule(style: .continuous)
+                        .fill(Tokens.ink)
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .strokeBorder(Color.white.opacity(0.12), lineWidth: 0.5)
+                        )
+                        .shadow(color: Tokens.ink.opacity(0.22), radius: 12, x: 0, y: 4)
+                } else {
+                    Capsule(style: .continuous)
+                        .fill(.ultraThinMaterial)
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .fill(Tokens.surface.opacity(0.5))
+                        )
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .strokeBorder(Color.white.opacity(0.35), lineWidth: 0.5)
+                        )
+                        .shadow(color: Tokens.ink.opacity(0.08), radius: 8, x: 0, y: 2)
+                }
             }
             .contentShape(Capsule(style: .continuous))
             .scaleEffect(configuration.isPressed ? 0.96 : 1.0)

--- a/mobile/PersonalDashboard/Services/SpeechTranscriber.swift
+++ b/mobile/PersonalDashboard/Services/SpeechTranscriber.swift
@@ -84,6 +84,16 @@ final class SpeechTranscriber {
     /// field and to swap the mic icon for a recording indicator.
     private(set) var isRecording: Bool = false
 
+    /// Fired once per finalized-and-normalized utterance (issue #156). server_vad
+    /// segments each pause into its own `…completed`; the continuous voice
+    /// overlay consumes these as DISCRETE captures so it can execute them one at
+    /// a time. The payload is the same Devanagari-normalized text that gets
+    /// folded into `committedTranscript`, so callers of this stream never see raw
+    /// Urdu. Set by `VoiceCaptureViewModel` for the duration of a session; nil
+    /// for the inline chat bar (which only reads the accumulated `transcript`).
+    /// Invoked on the @MainActor.
+    var onUtteranceFinalized: ((String) -> Void)?
+
     /// Surfaced inline above the input bar when permission is denied or
     /// the audio engine fails. Cleared on the next successful `toggle()`.
     var errorMessage: String?
@@ -122,6 +132,21 @@ final class SpeechTranscriber {
     private let audioEngine = AVAudioEngine()
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
+
+    /// End-of-utterance debounce for the on-device engine (issue #156). SFSpeech
+    /// has NO VAD segmentation — it runs one continuous `recognitionTask` and only
+    /// hands back a final on `endAudio()`. To make the on-device path fire
+    /// `onUtteranceFinalized` per pause like the OpenAI server_vad path does, we
+    /// synthesize the segmentation: when the recognized text stops changing for
+    /// this long, we treat the pause as an utterance boundary. Slightly longer
+    /// than OpenAI's 700ms server-VAD window because the on-device partials update
+    /// less smoothly, so a shorter window would clip mid-phrase.
+    private let onDeviceSilenceDebounce: TimeInterval = 0.9
+
+    /// The armed silence timer for the on-device engine. Re-armed on every partial
+    /// that carries new text; fires `finalizeOnDeviceUtterance()` when it elapses.
+    /// Cancelled on every new partial and on `stop()`.
+    private var onDeviceSilenceTimer: Task<Void, Never>?
 
     // -- OpenAI Realtime state --
     private let openAI = OpenAIRealtimeTranscriber()
@@ -195,6 +220,12 @@ final class SpeechTranscriber {
             let socket = openAI
             Task { await socket.finish() }
         case .onDevice:
+            // Cancel the synthesized silence-segmentation timer so no pending
+            // finalize fires after teardown (issue #156). Any in-progress partial
+            // is intentionally discarded here — a mid-word utterance interrupted
+            // by Done shouldn't fire a stray `onUtteranceFinalized`.
+            onDeviceSilenceTimer?.cancel()
+            onDeviceSilenceTimer = nil
             // End-of-audio first, then tear down. `endAudio()` lets SFSpeech
             // finalize a "best result" partial; cancelling would discard it.
             request?.endAudio()
@@ -351,6 +382,12 @@ final class SpeechTranscriber {
                             : self.committedTranscript + " " + normalized
                         self.transcript = self.committedTranscript
                         self.didFinalizeTranscript &+= 1
+                        // Surface THIS utterance as a discrete event (issue #156).
+                        // The continuous voice overlay consumes these one at a
+                        // time; the inline chat bar leaves the hook nil and reads
+                        // only the accumulated `transcript` above. Fired after
+                        // normalization so the payload is never raw Urdu.
+                        self.onUtteranceFinalized?(normalized)
                         Self.log.info("transcript updated from completed (len=\(self.transcript.count, privacy: .public)); didFinalizeTranscript bumped to \(self.didFinalizeTranscript, privacy: .public)")
                         // idevicesyslog-visible. Length only, never the text.
                         NSLog("[voice] transcript set len=%d", self.transcript.count)
@@ -532,16 +569,35 @@ final class SpeechTranscriber {
 
         isRecording = true
 
+        startOnDeviceTask(with: request)
+    }
+
+    /// Attach a `recognitionTask` to `request` and wire the partial-result
+    /// callback. Factored out of `startOnDevice()` so it can be called again to
+    /// rotate the recognition after each finalized utterance (issue #156) WITHOUT
+    /// touching the audio engine or the mic tap.
+    private func startOnDeviceTask(with request: SFSpeechAudioBufferRecognitionRequest) {
+        guard let recognizer else { return }
         task = recognizer.recognitionTask(with: request) { [weak self] result, error in
             guard let self else { return }
             // `recognitionTask` callback isn't main-actor isolated, so hop.
             Task { @MainActor in
+                // Ignore callbacks from a task we've already rotated away from
+                // (a late partial from the previous utterance's task): only the
+                // request currently wired to the tap is authoritative.
+                guard self.request === request else { return }
                 if let result {
                     self.transcript = result.bestTranscription.formattedString
-                    if result.isFinal {
-                        // Final result lands when `endAudio()` is called
-                        // from `stop()`. Nothing to do here — `stop()`
-                        // already set `isRecording = false`.
+                    // Synthesized VAD (issue #156): each non-empty partial arms /
+                    // re-arms a silence timer. When the text stops changing for
+                    // `onDeviceSilenceDebounce`, we treat the pause as an utterance
+                    // boundary, fire `onUtteranceFinalized`, and rotate to a fresh
+                    // request+task so the next utterance starts clean. `isFinal`
+                    // only ever lands when `stop()` calls `endAudio()`, so we do
+                    // NOT depend on it for per-utterance segmentation.
+                    let trimmed = self.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                        self.armOnDeviceSilenceTimer()
                     }
                 }
                 if let error {
@@ -561,6 +617,67 @@ final class SpeechTranscriber {
                 }
             }
         }
+    }
+
+    /// (Re)arm the on-device silence timer. Cancels any pending timer and starts a
+    /// fresh `onDeviceSilenceDebounce`-long sleep; if no new partial re-arms it in
+    /// that window, `finalizeOnDeviceUtterance()` fires. Task-based to match the
+    /// file's structured-concurrency style; cancellation makes the re-arm cheap.
+    private func armOnDeviceSilenceTimer() {
+        onDeviceSilenceTimer?.cancel()
+        let delay = onDeviceSilenceDebounce
+        onDeviceSilenceTimer = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await self?.finalizeOnDeviceUtterance()
+        }
+    }
+
+    /// Finalize the current on-device utterance: fire `onUtteranceFinalized` with
+    /// the accumulated text (if non-empty) and rotate the recognition so the NEXT
+    /// utterance is recognized fresh rather than accumulated on top (issue #156).
+    ///
+    /// The rotation ends the current `request`/`task` and starts a new pair, but
+    /// KEEPS `audioEngine` + the input tap running. The tap appends to whatever
+    /// `self.request` currently is, so re-pointing it is all that's needed to
+    /// route audio into the new segment — we never stop/restart the engine or
+    /// reinstall the tap (which risks the `nullptr == Tap()` crash, issue #150).
+    private func finalizeOnDeviceUtterance() {
+        onDeviceSilenceTimer = nil
+        guard isRecording, engine == .onDevice else { return }
+
+        let finalized = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // End the current recognition segment.
+        request?.endAudio()
+        task?.cancel()
+        task = nil
+        request = nil
+
+        // Empty/whitespace-only utterance: don't fire, but still rotate so a long
+        // silence doesn't wedge us on a stale request.
+        if !finalized.isEmpty {
+            didFinalizeTranscript &+= 1
+            // Mirror the OpenAI `onCompleted` contract: fire the discrete event on
+            // the main actor with the finalized text (issue #156).
+            onUtteranceFinalized?(finalized)
+            Self.log.info("on-device utterance finalized (len=\(finalized.count, privacy: .public)); didFinalizeTranscript bumped to \(self.didFinalizeTranscript, privacy: .public)")
+            NSLog("[voice] on-device finalize len=%d", finalized.count)
+        }
+
+        // Reset the running transcript and spin up a fresh request+task. The tap
+        // is untouched and will start appending buffers to the new request as soon
+        // as it's assigned below.
+        transcript = ""
+        let fresh = SFSpeechAudioBufferRecognitionRequest()
+        fresh.shouldReportPartialResults = true
+        fresh.requiresOnDeviceRecognition = true
+        if #available(iOS 16.0, *) {
+            fresh.addsPunctuation = true
+        }
+        fresh.taskHint = .dictation
+        self.request = fresh
+        startOnDeviceTask(with: fresh)
     }
 
     // MARK: Audio level metering

--- a/mobile/PersonalDashboard/ViewModels/ChatViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ChatViewModel.swift
@@ -74,6 +74,20 @@ final class ChatViewModel {
         }
     }
 
+    /// Wipe conversation state so the next `send()` replays NO prior history.
+    /// Used by the voice-capture overlay, where each spoken utterance must be a
+    /// fully independent, stateless capture (issue #156): without this, `send()`
+    /// snapshots the accumulated `turns` into its history array and replays the
+    /// whole session to Claude, which then re-issues earlier tool calls and
+    /// duplicates items. The regular chat surface never calls this — it keeps
+    /// its multi-turn history.
+    func reset() {
+        turns = []
+        isSending = false
+        errorMessage = nil
+        draftInput = ""
+    }
+
     func send() async {
         let input = draftInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !input.isEmpty else { return }

--- a/mobile/PersonalDashboard/ViewModels/VoiceCaptureViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/VoiceCaptureViewModel.swift
@@ -5,34 +5,50 @@ import Speech
 import AVFoundation
 import UIKit
 
-/// Drives the global full-screen voice-capture overlay (issue #150, revised
-/// auto-execute concept).
+/// Drives the global full-screen voice-capture overlay (issue #150 → #156,
+/// one-shot capture per open).
 ///
-/// Owns the SINGLE `SpeechTranscriber` instance for the whole app, the 1.5s
-/// silence-finalize timer, the 1.5s safety-window timer, and the AI execute
-/// path. Injected into the SwiftUI environment from `ContentView` so the
-/// overlay (attached once at the root via `.fullScreenCover`) and `ChatView`'s
-/// inline mic button both drive the same transcriber — there is never a second
-/// instance that could install a duplicate audio tap and crash the engine (the
-/// re-entry guard in `SpeechTranscriber` backs this up).
+/// Owns the SINGLE `SpeechTranscriber` instance for the whole app and the AI
+/// execute path. Injected into the SwiftUI environment from `ContentView` so
+/// the overlay (attached once at the root via `.fullScreenCover`) and
+/// `ChatView`'s inline mic button both drive the same transcriber — there is
+/// never a second instance that could install a duplicate audio tap and crash
+/// the engine (the re-entry guard in `SpeechTranscriber` backs this up).
+///
+/// ### One-shot capture (issue #156)
+///
+/// Each long-press opens the overlay for EXACTLY ONE action, then closes itself.
+/// The transcriber (OpenAI server_vad OR on-device synthesized VAD) hands us the
+/// FIRST finalized utterance via `SpeechTranscriber.onUtteranceFinalized`. The
+/// instant that first utterance lands we `transcriber.stop()` so no second
+/// utterance can be captured, and a `hasConsumedUtterance` latch drops anything
+/// that slipped into the queue before the stop took effect. That one utterance
+/// executes standalone (`chat.reset()` then `chat.send()`), its result rows flash
+/// for ~1.2s, and then the overlay AUTO-DISMISSES (`shouldDismiss` flips true,
+/// the view sets `isPresented = false`). To do another action the user
+/// long-presses again.
+///
+/// Empty (silence) and error do NOT auto-dismiss: the user retries via Try Again
+/// or bails via Done / Cancel. Every close path — auto-dismiss OR manual — funnels
+/// through the cover's `onDismiss` → `teardown()`, which is idempotent.
 ///
 /// The state machine is the source of truth for the overlay UI:
-///   listening → safetyWindow → executing → success
-///   listening → empty
-///   (any) → error / permissionDenied
+///   listening → executing → flashSuccess → (auto-dismiss)   (the happy path)
+///   listening → empty / error / permissionDenied            (recoverable via resume)
 @Observable
 @MainActor
 final class VoiceCaptureViewModel {
 
-    /// The auto-execute state machine (concept doc Section 4).
+    /// The one-shot state machine (issue #156). `.flashSuccess` is terminal for
+    /// the session: it does NOT return to `.listening`; instead the overlay
+    /// auto-dismisses after the flash. `.empty` / `.error` stay open for retry.
     enum State: Equatable {
-        case listening          // A  — recording, InkOrb reactive, live transcript
-        case safetyWindow       // A1 — "Got it", 1.5s escape hatch before execute
-        case executing          // C  — AI processing
-        case success            // D  — confirmation rows + auto-dismiss
-        case empty              // E  — silence detected, no speech
-        case permissionDenied   // F  — mic / speech permission denied
-        case error(String)      // G  — transcription or AI failure (message)
+        case listening          // recording, InkOrb reactive, socket alive
+        case executing          // the one utterance's AI call is in flight
+        case flashSuccess       // its result rows, ~1.2s, then auto-dismiss
+        case empty              // silence / nothing captured yet (informational)
+        case permissionDenied   // mic / speech permission denied
+        case error(String)      // transcription or AI failure (message)
     }
 
     /// Voice-pipeline diagnostics (issue #151). Same subsystem as the
@@ -54,32 +70,39 @@ final class VoiceCaptureViewModel {
         }
     }
 
-    /// Success rows for State D — one per applied action.
+    /// Success rows for the current flash — one per applied action of the
+    /// utterance that just executed. Cleared when the flash ends.
     private(set) var successLabels: [String] = []
 
-    /// Error/AI message surfaced in State G.
+    /// Error/AI message surfaced in the error state.
     private(set) var errorMessageText: String?
 
+    /// One-shot auto-dismiss signal (issue #156). Flipped true after the success
+    /// flash elapses; the overlay observes it via `.onChange` and sets
+    /// `isPresented = false`, which closes the cover and funnels through
+    /// `teardown()`. The VM never touches the router/binding directly — it only
+    /// publishes intent, the view owns the presentation binding. Empty / error
+    /// states never set this, so they stay open for retry.
+    private(set) var shouldDismiss: Bool = false
+
     /// Live transcript convenience (reads through to the transcriber). The
-    /// overlay binds to this for State A; the finalized text is snapshotted
-    /// into `finalizedTranscript` when listening stops.
+    /// overlay binds to this while listening to show the running text.
     var transcript: String { transcriber.transcript }
 
     /// Normalized mic amplitude (0–1) for the InkOrb.
     var audioLevel: Float { transcriber.audioLevel }
 
-    /// Snapshot of the transcript captured when listening stops (A → A1). This
-    /// is what gets executed; the live `transcriber.transcript` is cleared on
-    /// the next start so we can't rely on it past finalize.
-    private(set) var finalizedTranscript: String = ""
+    /// The text of the utterance currently executing / just flashed. Shown muted
+    /// under the working / success rows so the user sees which command it maps to.
+    private(set) var currentUtterance: String = ""
 
-    /// Swipe-to-dismiss is allowed only in the terminal states (concept doc
-    /// Section 10). The overlay binds `interactiveDismissDisabled` to the
-    /// inverse of this.
+    /// Swipe-to-dismiss is disabled while capturing / executing / flashing so a
+    /// stray swipe never drops the mic mid-command (the overlay auto-dismisses on
+    /// success anyway). Permission / hard-error states allow it as an escape hatch.
     var allowsInteractiveDismiss: Bool {
         switch state {
-        case .listening, .safetyWindow, .executing: return false
-        case .success, .empty, .permissionDenied, .error: return true
+        case .listening, .executing, .flashSuccess, .empty: return false
+        case .permissionDenied, .error: return true
         }
     }
 
@@ -90,276 +113,293 @@ final class VoiceCaptureViewModel {
     /// without coupling to `ChatView`'s on-screen conversation.
     private let chat = ChatViewModel()
 
-    private var silenceTimer: Timer?
-    /// 1.5s silence window per the revised concept doc.
-    private let silenceDelay: TimeInterval = 1.5
-    /// 1.5s safety window before auto-execute.
-    private let safetyWindowDelay: TimeInterval = 1.5
+    /// How long the one utterance's result rows stay on screen before the
+    /// overlay auto-dismisses (issue #156). Kept brief so the green-check
+    /// confirmation registers without making the user wait to do the next thing.
+    private let successFlashDelay: TimeInterval = 1.2
 
-    private var safetyTask: Task<Void, Never>?
-    private var executeTask: Task<Void, Never>?
-    /// Awaits the async final transcript after a manual stop that raced the
-    /// network (issue #151). Cancelled by teardown / restart.
-    private var awaitFinalTask: Task<Void, Never>?
-    /// Max time to wait for the async `…completed` after a manual stop before
-    /// giving up. Comfortably covers the transcriber's own ~2s socket drain.
-    private let finalTranscriptTimeout: TimeInterval = 2.5
+    /// One-shot latch (issue #156). Set true the instant the FIRST finalized
+    /// utterance is accepted. Guards the enqueue hook AND the drain loop so a
+    /// second utterance that slipped into the queue before `transcriber.stop()`
+    /// took effect is dropped rather than executed. Reset by `begin()`.
+    private var hasConsumedUtterance = false
+
+    /// Unbounded queue of finalized-and-normalized utterances (issue #156).
+    /// `SpeechTranscriber.onUtteranceFinalized` yields into this the instant a
+    /// server_vad segment finalizes; `processingLoop` drains it serially. The
+    /// stream buffers utterances spoken while an execution is in flight, so none
+    /// is ever dropped and two never overlap.
+    private var utteranceContinuation: AsyncStream<String>.Continuation?
+
+    /// The single serial task that pulls utterances off the queue and executes
+    /// them one at a time. Runs for the life of the session; cancelled by
+    /// `teardown()`. Awaiting each `runUtterance` before the next `for await`
+    /// iteration is what serializes execution.
+    private var processingLoop: Task<Void, Never>?
 
     // MARK: Lifecycle
 
-    /// Called when the overlay appears. Starts a fresh recording session.
+    /// Called when the overlay appears. Starts a fresh continuous session:
+    /// wires the per-utterance queue, kicks off the serial processing loop, and
+    /// starts listening.
     func begin() {
         successLabels = []
         errorMessageText = nil
-        finalizedTranscript = ""
-        // Reset to .listening SYNCHRONOUSLY. This VM is a single shared
-        // instance, so after a prior capture `state` is still a terminal value
-        // (e.g. .success). `startListening()` runs in a Task (one runloop
-        // later), so without this the overlay's first render on re-open shows
-        // the stale terminal state — which mounts the success auto-dismiss line
-        // and schedules a 2s dismiss that closes the overlay right after it
-        // opens (issue #151, second-open bug).
+        currentUtterance = ""
+        // Fresh one-shot session: clear the consumed latch and the auto-dismiss
+        // signal so the previous open's flags never leak into this one (issue #156).
+        hasConsumedUtterance = false
+        shouldDismiss = false
+        // Reset to .listening SYNCHRONOUSLY so the first render on (re)open never
+        // shows a stale terminal state from a prior session (issue #151).
         state = .listening
+        startProcessingLoop()
         Task { await startListening() }
     }
 
-    /// Start (or restart) recording — used by `begin()` and Try Again (E/G).
-    /// The transcriber's own re-entry guard makes a redundant start a no-op.
+    /// Wire the utterance queue + serial drain loop (issue #156, one-shot).
+    /// Only the FIRST finalized utterance is accepted: the enqueue hook latches
+    /// `hasConsumedUtterance` and stops the transcriber the instant it lands, and
+    /// the drain loop consumes exactly one utterance then returns. A second
+    /// utterance that raced past the stop is dropped by BOTH the hook guard and
+    /// the loop's post-drain break, so it can never execute.
+    private func startProcessingLoop() {
+        processingLoop?.cancel()
+        // Build the stream + continuation. Unbounded buffering is harmless here —
+        // the latch drops everything after the first, so at most one is consumed.
+        let (stream, continuation) = AsyncStream<String>.makeStream(
+            bufferingPolicy: .unbounded
+        )
+        utteranceContinuation = continuation
+
+        // The transcriber fires this on the main actor for every finalized,
+        // Devanagari-normalized utterance. Accept the FIRST non-empty one only:
+        // latch immediately and STOP the transcriber so no further audio is
+        // captured or segmented. Empties (silence) don't latch — the user may
+        // still speak. Anything after the latch is ignored here.
+        transcriber.onUtteranceFinalized = { [weak self] text in
+            guard let self else { return }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            guard !self.hasConsumedUtterance else {
+                Self.log.info("utterance ignored — already consumed one this session")
+                return
+            }
+            self.hasConsumedUtterance = true
+            // Stop capture on the FIRST finalize so the recognizer can't produce
+            // (or enqueue) a second utterance. `stop()` is idempotent and safe to
+            // call while an execute is about to run.
+            self.transcriber.stop()
+            Self.log.info("first utterance accepted (len=\(trimmed.count, privacy: .public)); transcriber stopped")
+            self.utteranceContinuation?.yield(trimmed)
+        }
+
+        processingLoop = Task { [weak self] in
+            for await utterance in stream {
+                if Task.isCancelled { return }
+                guard let self else { return }
+                await self.runUtterance(utterance)
+                // One-shot: after the single utterance executes and flashes we're
+                // done consuming — break so any buffered straggler never runs.
+                // `runUtterance` triggers the auto-dismiss on success.
+                return
+            }
+        }
+    }
+
+    /// Start (or resume) recording. Used by `begin()` and by Try Again after an
+    /// empty / error state. The transcriber's own re-entry guard makes a
+    /// redundant start a no-op, and the socket stays alive across utterances so
+    /// this is only a real start at session open (or after a hard failure).
     func startListening() async {
-        cancelTimers()
         successLabels = []
         errorMessageText = nil
-        finalizedTranscript = ""
+        currentUtterance = ""
         state = .listening
 
-        // Permission gate up front so denial routes to State F, not the
-        // generic error path (concept doc State F vs G).
+        // Permission gate up front so denial routes to the permission state.
         if Self.permissionDenied {
             state = .permissionDenied
             return
         }
-        await transcriber.toggle()
         if !transcriber.isRecording {
-            routeStartFailure()
+            await transcriber.toggle()
+            if !transcriber.isRecording {
+                routeStartFailure()
+            }
         }
     }
 
-    /// A transcriber error surfaced asynchronously while we were listening (most
-    /// commonly a connection failure: the WebSocket never came up on a weak
-    /// link, issue #151). The transcriber has already torn its socket down and
-    /// flipped `isRecording` false, so there will be no transcript. Route the
-    /// overlay to its error state (State G) with the friendly message rather
-    /// than hanging in `.listening` forever. Only acts from the live "before
-    /// finalize" states — once we're past finalize the execute path owns errors.
+    /// A transcriber error surfaced asynchronously (most commonly a connection
+    /// failure: the WebSocket never came up on a weak link, issue #151). The
+    /// transcriber has already torn its socket down and flipped `isRecording`
+    /// false, so listening can't continue. Route the overlay to its error state
+    /// with the friendly message rather than hanging. Doesn't override an
+    /// in-flight execute / flash (that cycle owns the UI and will return to
+    /// listening on its own — but with the socket dead there'll be no further
+    /// utterances, which is an acceptable degrade; the user can Try Again).
     func handleTranscriberError(_ message: String) {
         switch state {
-        case .listening, .safetyWindow:
-            cancelTimers()
-            Self.log.info("transcriber error while pre-finalize → State G")
+        case .listening, .empty:
+            Self.log.info("transcriber error while idle-listening → error state")
             errorMessageText = Self.stripTechnicalPrefix(message)
             state = .error(errorMessageText ?? "Something went wrong.")
-        case .executing, .success, .empty, .permissionDenied, .error:
-            // Past finalize (or already terminal): the execute path / existing
-            // terminal state owns the UI. Don't override it.
+        case .executing, .flashSuccess, .permissionDenied, .error:
+            // A live execute/flash owns the UI; a terminal state already shows a
+            // message. Don't stomp either.
             break
         }
     }
 
-    /// Re-arm the 1.5s silence countdown. Called by the overlay on every
-    /// transcript partial while in State A. Resets on each word; when it fires
-    /// with a non-empty transcript we enter the safety window, with an empty
-    /// one we go to State E.
-    func scheduleSilenceFinalize() {
-        guard state == .listening else { return }
-        // Never arm on an empty transcript. With the OpenAI engine the
-        // transcript is empty — and stays empty — WHILE the user is still
-        // speaking (server VAD only emits text after a pause). The overlay
-        // arms this on every transcript change, including the empty reset at
-        // open, which fired the timer mid-speech and killed the session before
-        // it captured anything ("stops as soon as it opens", issue #151). Arm
-        // only once real text exists; server VAD's own turn detection is what
-        // produces that text after the user pauses.
-        guard !transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        silenceTimer?.invalidate()
-        silenceTimer = Timer.scheduledTimer(
-            withTimeInterval: silenceDelay,
-            repeats: false
-        ) { [weak self] _ in
-            Task { @MainActor in self?.onSilenceElapsed() }
-        }
-    }
+    /// Execute the one accepted utterance end-to-end, flash its result, then
+    /// auto-dismiss the overlay (issue #156, one-shot). Called exactly once per
+    /// session by `processingLoop`. The transcriber was already stopped by the
+    /// enqueue hook when this utterance was accepted, so no more audio flows.
+    private func runUtterance(_ utterance: String) async {
+        let input = utterance.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !input.isEmpty else { return }
 
-    private func onSilenceElapsed() {
-        guard state == .listening else { return }
-        Self.log.info("silence timer fired")
-        let text = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        if text.isEmpty {
-            transcriber.stop()
-            state = .empty
-        } else {
-            enterSafetyWindow()
-        }
-    }
-
-    /// "Stop Now" (State A): skip the silence wait and finalize immediately.
-    ///
-    /// With server VAD the transcript arrives async (issue #151): if the user
-    /// taps Stop before pausing, no `…completed` has landed yet and a
-    /// synchronous snapshot would be empty. So when the snapshot is empty we
-    /// commit (via `stop()`) and AWAIT the async final transcript before
-    /// deciding between the safety window and State E, rather than racing the
-    /// network. When the snapshot is already non-empty (the user paused first,
-    /// so `…completed` landed) we proceed straight to the safety window.
-    func stopNow() {
-        guard state == .listening else { return }
-        let text = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        if text.isEmpty {
-            awaitFinalThenFinalize()
-        } else {
-            enterSafetyWindow()
-        }
-    }
-
-    /// Stop the mic (commits + drains the socket) and wait for the async final
-    /// transcript. Used by the manual-stop path that can race the network. If a
-    /// non-empty transcript lands before the timeout we enter the safety
-    /// window; otherwise State E (silence detected, no speech).
-    private func awaitFinalThenFinalize() {
-        cancelTimers()
-        // Show the "Got it" safety window immediately so the UI isn't frozen
-        // while we wait for the network, but DON'T snapshot/execute yet — the
-        // safety countdown is (re)started once the real transcript lands.
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-        transcriber.stop() // commit + drain; transcript lands async
-        state = .safetyWindow
-
-        let baseline = transcriber.didFinalizeTranscript
-        awaitFinalTask?.cancel()
-        awaitFinalTask = Task { [finalTranscriptTimeout] in
-            let deadline = Date().addingTimeInterval(finalTranscriptTimeout)
-            // Poll for a finalize signal or non-empty transcript. Cheap: a few
-            // 100ms ticks over at most ~2.5s, cancelled as soon as we resolve.
-            while Date() < deadline {
-                if Task.isCancelled { return }
-                if transcriber.didFinalizeTranscript != baseline
-                    || !transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    break
-                }
-                try? await Task.sleep(nanoseconds: 100_000_000)
-            }
-            if Task.isCancelled { return }
-            let text = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-            if text.isEmpty {
-                state = .empty
-            } else {
-                // Snapshot the now-arrived transcript and start the real safety
-                // countdown to auto-execute.
-                finalizedTranscript = text
-                Self.log.info("finalize snapshot (async after manual stop): len=\(text.count, privacy: .public)")
-                startSafetyCountdown()
-            }
-        }
-    }
-
-    /// A → A1. Stop the mic, snapshot the (already-present) transcript, fire a
-    /// light haptic, and start the 1.5s safety countdown that auto-executes
-    /// unless cancelled. Used when the transcript is already non-empty (natural
-    /// pause: `…completed` has landed). The racy manual-stop case goes through
-    /// `awaitFinalThenFinalize()` instead.
-    private func enterSafetyWindow() {
-        cancelTimers()
-        finalizedTranscript = transcriber.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        Self.log.info("finalize snapshot (natural pause): len=\(self.finalizedTranscript.count, privacy: .public)")
-        let snapshotFinalize = transcriber.didFinalizeTranscript
-        transcriber.stop()
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-        state = .safetyWindow
-        startSafetyCountdown()
-        // If the snapshot is still in Urdu script, the Devanagari-normalized
-        // final may land during the socket drain (issue #151). Watch for the
-        // next `…completed` within the safety window and adopt the normalized
-        // text so both the preview and the parsed input use Hindi, not Urdu.
-        // Only for the Urdu case — English / Devanagari snapshots are final.
-        if HindiScriptNormalizer.containsPersoArabic(finalizedTranscript) {
-            awaitFinalTask?.cancel()
-            awaitFinalTask = Task { [safetyWindowDelay] in
-                let deadline = Date().addingTimeInterval(safetyWindowDelay)
-                while Date() < deadline {
-                    if Task.isCancelled { return }
-                    if transcriber.didFinalizeTranscript != snapshotFinalize {
-                        let updated = transcriber.transcript
-                            .trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !updated.isEmpty { finalizedTranscript = updated }
-                        return
-                    }
-                    try? await Task.sleep(nanoseconds: 100_000_000)
-                }
-            }
-        }
-    }
-
-    /// Start (or restart) the 1.5s safety countdown that auto-executes
-    /// `finalizedTranscript` unless cancelled. Assumes `state == .safetyWindow`
-    /// and `finalizedTranscript` is set.
-    private func startSafetyCountdown() {
-        safetyTask?.cancel()
-        safetyTask = Task { [safetyWindowDelay] in
-            try? await Task.sleep(nanoseconds: UInt64(safetyWindowDelay * 1_000_000_000))
-            if Task.isCancelled { return }
-            execute()
-        }
-    }
-
-    /// A1 → C. Run the finalized transcript through the AI pipeline, then D or G.
-    private func execute() {
-        let input = finalizedTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !input.isEmpty else { state = .empty; return }
-        state = .executing
+        currentUtterance = input
         successLabels = []
         errorMessageText = nil
+        state = .executing
+        Self.log.info("executing utterance (len=\(input.count, privacy: .public))")
 
-        executeTask = Task {
-            chat.draftInput = input
-            await chat.send()
-            if Task.isCancelled { return }
-            if let err = chat.errorMessage {
-                errorMessageText = Self.stripTechnicalPrefix(err)
-                state = .error(errorMessageText ?? "Something went wrong.")
-                return
-            }
-            let results = chat.turns.last(where: { $0.role == .assistant })?.results ?? []
-            let applied = results.filter { !$0.isFailure }
-            if applied.isEmpty {
-                successLabels = ["Message sent"]
-            } else {
-                successLabels = applied.map(Self.successLabel(for:))
-            }
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
-            state = .success
-        }
-    }
+        // Each utterance is a standalone, stateless capture (issue #156):
+        // `reset()` clears the overlay's own conversation so `send()` replays NO
+        // prior history. Otherwise earlier utterances re-issue their tool calls
+        // and duplicate items. The queue serializes calls, so this reset can
+        // never race a concurrent send.
+        chat.reset()
+        chat.draftInput = input
+        await chat.send()
 
-    /// Try Again on an AI error (State G) — re-run the same transcript.
-    func retryExecute() {
-        guard !finalizedTranscript.isEmpty else {
-            Task { await startListening() }
+        if Task.isCancelled { return }
+
+        if let err = chat.errorMessage {
+            errorMessageText = Self.stripTechnicalPrefix(err)
+            state = .error(errorMessageText ?? "Something went wrong.")
             return
         }
-        execute()
+
+        let results = chat.turns.last(where: { $0.role == .assistant })?.results ?? []
+        let applied = results.filter { !$0.isFailure }
+        successLabels = applied.isEmpty ? ["Message sent"] : applied.map(Self.successLabel(for:))
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        state = .flashSuccess
+
+        // Hold the result rows briefly so the user sees the green-check
+        // confirmation, then AUTO-DISMISS (issue #156, one-shot). Cancellation
+        // (teardown — e.g. the user tapped Done during the flash) short-circuits
+        // the wait; we then skip the dismiss signal since the cover is already
+        // closing.
+        try? await Task.sleep(nanoseconds: UInt64(successFlashDelay * 1_000_000_000))
+        if Task.isCancelled { return }
+
+        // Signal the overlay to close itself. Only if we're still on the success
+        // flash (a transcriber error arriving during the flash would have flipped
+        // us to .error, which stays open for retry). The view observes
+        // `shouldDismiss` and sets `isPresented = false`, funnelling through the
+        // single `teardown()` path.
+        if case .flashSuccess = state {
+            shouldDismiss = true
+        }
     }
 
-    /// Cancel from any state with no side effect. Best-effort cancels an
-    /// in-flight AI task in State C. This is the single teardown path, called
-    /// from the `.fullScreenCover` `onDismiss` regardless of how it closed.
+    /// Manual "Stop Recording" (issue #156). Ends capture immediately and runs
+    /// whatever the user has said SO FAR, rather than waiting for the automatic
+    /// server_vad / silence-timer finalize. Only meaningful while `.listening`.
+    ///
+    /// Race guard: the automatic finalize (`onUtteranceFinalized`) may fire at
+    /// nearly the same instant. Both paths funnel through the SAME
+    /// `hasConsumedUtterance` latch, checked-and-set on the @MainActor here with
+    /// no `await` in between, so exactly one wins. Whichever set the latch first
+    /// executes its utterance; the loser bails. This method takes a synchronous
+    /// snapshot of the live `transcript` BEFORE latching so the spoken text can't
+    /// be lost to a concurrent reset.
+    ///
+    /// - Non-empty snapshot → latch, stop the transcriber, and yield the snapshot
+    ///   to the same queue the auto-path uses (`processingLoop` runs it: executing
+    ///   → flash → auto-dismiss).
+    /// - Empty snapshot (stopped before speaking) → do NOT latch (the user may
+    ///   still be about to speak on a retry); stop the transcriber and route to
+    ///   `.empty` so they get Try Again / Done rather than a silent close.
+    func stopRecordingAndExecute() {
+        // Only act while listening — in executing / flashSuccess the capture is
+        // already done and the button isn't shown; guard defensively anyway.
+        guard case .listening = state else { return }
+
+        // Snapshot the live partial transcript BEFORE any latch/stop so a
+        // near-simultaneous auto-finalize (which clears/rotates transcript) can't
+        // race the text out from under us.
+        let snapshot = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // If the auto-path already consumed an utterance this session, it owns the
+        // execution — do nothing (no double-run, no double-dismiss). This is the
+        // same latch the enqueue hook checks; both run on the @MainActor so the
+        // check-and-set below is atomic w.r.t. the auto-path.
+        guard !hasConsumedUtterance else {
+            Self.log.info("manual stop ignored — auto-finalize already consumed the utterance")
+            return
+        }
+
+        if snapshot.isEmpty {
+            // Nothing said yet. Stop capture and surface the informational empty
+            // state (Try Again / Done) — never latch, never silently close.
+            Self.log.info("manual stop with empty transcript → empty state")
+            transcriber.stop()
+            successLabels = []
+            errorMessageText = nil
+            state = .empty
+            return
+        }
+
+        // Win the race: latch first so the auto-path's enqueue hook drops any
+        // finalize that lands after this point, then stop the transcriber and hand
+        // the snapshot to the shared queue. Same downstream path as the automatic
+        // finalize — the processing loop executes it exactly once.
+        hasConsumedUtterance = true
+        transcriber.stop()
+        Self.log.info("manual stop accepted (len=\(snapshot.count, privacy: .public)); transcriber stopped, yielding to queue")
+        utteranceContinuation?.yield(snapshot)
+    }
+
+    /// Try Again after an empty / error state — re-arm a fresh one-shot capture
+    /// (issue #156). The socket may be dead (a connection failure tore it down)
+    /// and, if we'd already accepted an utterance, the processing loop has
+    /// returned and the transcriber is stopped. So fully re-arm: clear the
+    /// consumed latch, rebuild the processing loop + enqueue hook, and start
+    /// listening (which reopens the socket). This mirrors `begin()` minus the
+    /// synchronous state reset, which `startListening()` handles.
+    func retryExecute() {
+        hasConsumedUtterance = false
+        shouldDismiss = false
+        startProcessingLoop()
+        Task { await startListening() }
+    }
+
+    /// End the session. The single teardown path, called from the
+    /// `.fullScreenCover` `onDismiss` regardless of how it closed: the one-shot
+    /// auto-dismiss (success), Done / Cancel, or a permission/error escape.
+    /// Idempotent — detaches the transcriber hook, finishes the utterance stream
+    /// (so the loop's `for await` completes), cancels the loop (which also cancels
+    /// any in-flight execute/flash `await`), and stops the mic + socket (a no-op
+    /// if the one-shot already stopped it on first finalize).
     func teardown() {
-        cancelTimers()
-        safetyTask?.cancel(); safetyTask = nil
-        executeTask?.cancel(); executeTask = nil
-        awaitFinalTask?.cancel(); awaitFinalTask = nil
+        Self.log.info("teardown: ending session")
+        // Detach first so no late `…completed` enqueues after we finish.
+        transcriber.onUtteranceFinalized = nil
+        // Finishing the stream lets the loop's `for await` exit cleanly; also
+        // cancel it so a currently-executing `runUtterance` (mid chat.send() or
+        // mid flash-sleep) stops promptly rather than draining the queue.
+        utteranceContinuation?.finish()
+        utteranceContinuation = nil
+        processingLoop?.cancel()
+        processingLoop = nil
         transcriber.stop()
     }
 
-    /// Open the system Settings app (State F).
+    /// Open the system Settings app (permission-denied state).
     func openSettings() {
         if let url = URL(string: UIApplication.openSettingsURLString) {
             UIApplication.shared.open(url)
@@ -368,15 +408,6 @@ final class VoiceCaptureViewModel {
 
     // MARK: Helpers
 
-    private func cancelTimers() {
-        silenceTimer?.invalidate()
-        silenceTimer = nil
-        safetyTask?.cancel()
-        safetyTask = nil
-        awaitFinalTask?.cancel()
-        awaitFinalTask = nil
-    }
-
     private func routeStartFailure() {
         if Self.permissionDenied {
             state = .permissionDenied
@@ -384,8 +415,8 @@ final class VoiceCaptureViewModel {
             errorMessageText = msg
             state = .error(msg)
         }
-        // Otherwise (e.g. SFSpeech "no speech" already silenced) stay in
-        // .listening; the silence timer routes to State E.
+        // Otherwise stay in .listening; a later utterance / transcriber error
+        // will drive the next transition.
     }
 
     /// True when speech recognition OR microphone access is denied/restricted.

--- a/mobile/PersonalDashboard/Views/Chat/VoiceCaptureOverlay.swift
+++ b/mobile/PersonalDashboard/Views/Chat/VoiceCaptureOverlay.swift
@@ -1,17 +1,20 @@
 import SwiftUI
 import UIKit
 
-/// Global full-screen voice-capture overlay (issue #150, auto-execute concept).
+/// Global full-screen voice-capture overlay (issue #150 → #156, one-shot).
 ///
 /// Presented once from `ContentView`'s root via `.fullScreenCover` bound to
 /// `AppRouter.showVoiceOverlay`, so it covers whatever tab the user was on
 /// without navigating — dismiss returns to the same page/scroll. Renders the
-/// state machine in `VoiceCaptureViewModel` (A / A1 / C / D / E / F / G) as a
-/// pure projection of `vm.state`. All teardown funnels through the cover's
-/// `onDismiss` → `vm.teardown()`.
+/// one-shot state machine in `VoiceCaptureViewModel` (listening → executing →
+/// flashSuccess → auto-dismiss; plus empty / error / permissionDenied) as a pure
+/// projection of `vm.state`. On success the overlay AUTO-DISMISSES: the VM flips
+/// `vm.shouldDismiss`, an `.onChange` here sets `isPresented = false`, and the
+/// cover's `onDismiss` → `vm.teardown()` cleans up. Empty / error stay open for
+/// Try Again; Done / Cancel bail through the same `onDismiss`.
 ///
-/// Layout (concept doc Section 3): top bar (status + Cancel), animation zone
-/// (InkOrb, upper portion), divider, transcript zone, bottom control zone.
+/// Layout: top bar (status + Done), animation zone (InkOrb, upper portion),
+/// divider, transcript zone, bottom control zone.
 struct VoiceCaptureOverlay: View {
     @Bindable var vm: VoiceCaptureViewModel
     /// Bound to `router.showVoiceOverlay`; set false to dismiss the cover.
@@ -58,10 +61,7 @@ struct VoiceCaptureOverlay: View {
         .interactiveDismissDisabled(!vm.allowsInteractiveDismiss)
         .onAppear {
             vm.begin()
-            UIAccessibility.post(notification: .announcement, argument: "Recording in progress.")
-        }
-        .onChange(of: vm.transcript) { _, _ in
-            vm.scheduleSilenceFinalize()
+            UIAccessibility.post(notification: .announcement, argument: "Listening. Speak one command.")
         }
         .onChange(of: vm.transcriber.errorMessage) { _, message in
             // A connection failure (or other transcriber error) arriving async
@@ -76,6 +76,12 @@ struct VoiceCaptureOverlay: View {
             if newState != .listening, !vm.transcript.isEmpty, !hasSeenVoiceHint {
                 hasSeenVoiceHint = true
             }
+        }
+        // One-shot auto-dismiss (issue #156): after the success flash the VM flips
+        // `shouldDismiss`; close the cover, which funnels through `onDismiss` →
+        // `vm.teardown()`. The VM never touches this binding directly.
+        .onChange(of: vm.shouldDismiss) { _, shouldDismiss in
+            if shouldDismiss { isPresented = false }
         }
         .animation(.easeOut(duration: reduceMotion ? 0.15 : 0.2), value: vm.state)
     }
@@ -104,9 +110,8 @@ struct VoiceCaptureOverlay: View {
     private var statusLabel: String {
         switch vm.state {
         case .listening:        return "Listening"
-        case .safetyWindow:     return "Got it"
         case .executing:        return "Working…"
-        case .success:          return "Done"
+        case .flashSuccess:     return "Done"
         case .empty:            return "Nothing heard"
         case .permissionDenied: return "Microphone access needed"
         case .error:            return "Something went wrong"
@@ -114,18 +119,21 @@ struct VoiceCaptureOverlay: View {
     }
 
     /// (title, accessibility label, action) for the top-right glass control.
+    /// While `.listening` this is "Cancel" — it bails WITHOUT executing, kept
+    /// clearly distinct from the primary "Stop Recording" button below (which
+    /// runs the command). Labelled "Done" in the passive executing / flash /
+    /// empty states where there's nothing to cancel. On success the overlay
+    /// auto-dismisses, so this is an escape hatch, not the only way out (#156).
     private var topRightControl: (title: String, a11y: String, run: () -> Void)? {
         switch vm.state {
-        case .listening, .safetyWindow, .executing:
-            return ("Cancel", "Cancel voice capture", { isPresented = false })
-        case .empty:
-            return ("Cancel", "Cancel voice capture", { isPresented = false })
+        case .listening:
+            return ("Cancel", "Cancel, close voice capture without running anything", { isPresented = false })
+        case .executing, .flashSuccess, .empty:
+            return ("Done", "Done, close voice capture", { isPresented = false })
         case .permissionDenied:
             return ("Not now", "Not now", { isPresented = false })
         case .error:
             return ("Dismiss", "Dismiss", { isPresented = false })
-        case .success:
-            return nil  // no buttons in Done
         }
     }
 
@@ -136,14 +144,12 @@ struct VoiceCaptureOverlay: View {
         switch vm.state {
         case .listening:
             transcriptScroll(static: false)
-        case .safetyWindow:
-            transcriptScroll(static: true)
         case .executing:
             executingBody
-        case .success:
+        case .flashSuccess:
             successBody
         case .empty:
-            centeredMessage("Try speaking, or tap the mic to record again.")
+            centeredMessage("Try speaking, or tap Try Again to keep listening.")
         case .permissionDenied:
             centeredMessage("Dexter needs microphone and speech access to record your voice. Turn them on in Settings to continue.")
         case .error(let message):
@@ -189,10 +195,10 @@ struct VoiceCaptureOverlay: View {
         }
     }
 
-    // State C — muted static transcript + typing indicator.
+    // Executing — the utterance being processed, muted, + typing indicator.
     private var executingBody: some View {
         VStack(alignment: .leading, spacing: Space.lg) {
-            Text(vm.finalizedTranscript)
+            Text(vm.currentUtterance)
                 .font(.edBody)
                 .foregroundStyle(Tokens.muted)
                 .fixedSize(horizontal: false, vertical: true)
@@ -208,7 +214,8 @@ struct VoiceCaptureOverlay: View {
         .padding(.top, Space.lg)
     }
 
-    // State D — success rows.
+    // Flash — this utterance's success rows (cleared automatically after ~1.5s
+    // by the view model, which then returns to .listening).
     private var successBody: some View {
         VStack(alignment: .leading, spacing: Space.md) {
             ForEach(Array(vm.successLabels.enumerated()), id: \.offset) { _, label in
@@ -246,40 +253,28 @@ struct VoiceCaptureOverlay: View {
     private var bottomZone: some View {
         switch vm.state {
         case .listening:
-            // Stop Now, centered.
+            // Primary "Stop Recording" — ends capture NOW and runs the command
+            // spoken so far, instead of waiting for the automatic pause/VAD
+            // finalize (issue #156). Prominent, centered. Bailing without running
+            // is the top-right "Cancel"; the two are deliberately distinct.
             HStack {
                 Spacer()
-                Button("Stop Now") { vm.stopNow() }
-                    .buttonStyle(GlassButtonStyle())
-                    .accessibilityLabel("Stop and execute")
+                Button("Stop Recording") { vm.stopRecordingAndExecute() }
+                    .buttonStyle(GlassButtonStyle(prominent: true))
+                    .accessibilityLabel("Stop recording and run what you said")
+                    .accessibilityHint("Ends listening and processes your command now")
                 Spacer()
             }
 
-        case .safetyWindow:
-            // Secondary Cancel (thumb reach) + sweeping progress bar.
-            HStack(spacing: Space.lg) {
-                Button("Cancel") { isPresented = false }
-                    .buttonStyle(GlassButtonStyle())
-                    .accessibilityLabel("Cancel voice capture")
-                SafetyProgressBar(duration: 1.5)
-                    .accessibilityHidden(true)
-            }
-
-        case .executing:
-            // No bottom control — only the top Cancel.
+        case .executing, .flashSuccess:
+            // No bottom control mid-cycle — the top Done still bails, and the
+            // overlay auto-dismisses once the flash elapses.
             Color.clear.frame(height: 1)
-
-        case .success:
-            // Auto-dismiss progress line.
-            AutoDismissProgressLine(reduceMotion: reduceMotion) {
-                isPresented = false
-            }
-            .accessibilityHidden(true)
 
         case .empty:
             twoGlass(
-                left: ("Cancel", "Cancel voice capture", { isPresented = false }),
-                right: ("Try Again", "Try again", { Task { await vm.startListening() } })
+                left: ("Done", "Done, close voice capture", { isPresented = false }),
+                right: ("Try Again", "Try again", { vm.retryExecute() })
             )
 
         case .permissionDenied:
@@ -316,9 +311,8 @@ struct VoiceCaptureOverlay: View {
     private var orbMode: InkOrb.Mode {
         switch vm.state {
         case .listening:        return .listening
-        case .safetyWindow:     return .settled
         case .executing:        return .thinking
-        case .success:          return .rest
+        case .flashSuccess:     return .rest
         case .empty:            return .idle
         case .permissionDenied: return .dim
         case .error:            return .dim
@@ -329,12 +323,9 @@ struct VoiceCaptureOverlay: View {
 
     private func announce(for state: VoiceCaptureViewModel.State) {
         switch state {
-        case .safetyWindow:
-            UIAccessibility.post(notification: .announcement,
-                                 argument: "Executing in 1.5 seconds. Double tap Cancel to abort.")
         case .executing:
             UIAccessibility.post(notification: .announcement, argument: "Processing your request.")
-        case .success:
+        case .flashSuccess:
             for (idx, label) in vm.successLabels.enumerated() {
                 DispatchQueue.main.asyncAfter(deadline: .now() + Double(idx) * 0.5) {
                     UIAccessibility.post(notification: .announcement, argument: label)
@@ -342,8 +333,10 @@ struct VoiceCaptureOverlay: View {
             }
             let after = Double(vm.successLabels.count) * 0.5
             DispatchQueue.main.asyncAfter(deadline: .now() + after) {
-                UIAccessibility.post(notification: .announcement, argument: "Closing in 2 seconds.")
+                UIAccessibility.post(notification: .announcement, argument: "Done. Closing voice capture.")
             }
+        case .listening:
+            UIAccessibility.post(notification: .announcement, argument: "Listening.")
         default:
             break
         }
@@ -371,59 +364,3 @@ private struct BlinkingCursor: View {
     }
 }
 
-// MARK: - Safety-window sweeping progress bar (A1)
-
-/// 1pt ink-30% bar that sweeps 0 → full width over `duration` (linear). It is
-/// informational, so it animates even under reduce-motion (Apple's guidance).
-private struct SafetyProgressBar: View {
-    let duration: Double
-    @State private var progress: CGFloat = 0
-
-    var body: some View {
-        GeometryReader { geo in
-            Rectangle()
-                .fill(Tokens.ink.opacity(0.30))
-                .frame(width: geo.size.width * progress, height: 1)
-                .frame(maxHeight: .infinity, alignment: .center)
-        }
-        .frame(height: 44)
-        .onAppear {
-            withAnimation(.linear(duration: duration)) { progress = 1 }
-        }
-    }
-}
-
-// MARK: - Auto-dismiss progress line (D)
-
-/// 1pt ink-20% line that depletes over 2.0s, then dismisses. Informational, so
-/// it animates under reduce-motion too.
-private struct AutoDismissProgressLine: View {
-    let reduceMotion: Bool
-    let onComplete: () -> Void
-    @State private var progress: CGFloat = 0
-    /// The pending dismissal, held so it can be cancelled if this line is
-    /// removed from the tree before it fires (e.g. a stale success state mounts
-    /// it for one frame on re-open). Without cancellation the dismiss fired
-    /// anyway and closed a freshly-opened overlay (issue #151).
-    @State private var pendingDismiss: DispatchWorkItem?
-
-    var body: some View {
-        GeometryReader { geo in
-            Rectangle()
-                .fill(Tokens.ink.opacity(0.2))
-                .frame(width: geo.size.width * progress, height: 1)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .frame(height: 1)
-        .onAppear {
-            withAnimation(.linear(duration: 2.0)) { progress = 1 }
-            let work = DispatchWorkItem { onComplete() }
-            pendingDismiss = work
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: work)
-        }
-        .onDisappear {
-            pendingDismiss?.cancel()
-            pendingDismiss = nil
-        }
-    }
-}

--- a/mobile/ota/ship-lan.sh
+++ b/mobile/ota/ship-lan.sh
@@ -75,7 +75,10 @@ echo "-> ANTHROPIC_API_KEY resolved (length=${#ANTHROPIC_API_KEY})"
 # NOT abort the build.
 if [ -z "${OPENAI_API_KEY:-}" ]; then
     if [ -f "${MOBILE_DIR}/../server/.env" ]; then
-        OPENAI_API_KEY="$(grep -E '^OPENAI_API_KEY=' "${MOBILE_DIR}/../server/.env" | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'")"
+        # `|| true`: under `set -euo pipefail` a grep no-match returns 1 and the
+        # pipeline would abort the script. OpenAI is optional (we warn below), so
+        # swallow the miss and let the empty-key fallback handle it.
+        OPENAI_API_KEY="$(grep -E '^OPENAI_API_KEY=' "${MOBILE_DIR}/../server/.env" | head -1 | cut -d= -f2- | tr -d '"' | tr -d "'" || true)"
     fi
 fi
 if [ -n "${OPENAI_API_KEY:-}" ]; then


### PR DESCRIPTION
## Summary
- Reworks the full-screen voice capture overlay from a batching, context-accumulating flow into a one-shot, per-utterance capture: each long-press captures exactly one command, executes it statelessly, flashes the result, then auto-closes.
- Fixes duplicate/re-executed commands and the ever-growing results list by resetting chat history before each send (`ChatViewModel.reset()`), so no prior conversation is replayed to Claude.
- Adds a 900ms silence finalizer to the on-device SFSpeech engine (it has no VAD), surfacing each utterance via `onUtteranceFinalized` like the OpenAI server_vad path.
- Adds a manual **Stop Recording** control that finalizes + executes the current transcript immediately, race-guarded against the automatic finalize (`hasConsumedUtterance` latch) so a command runs exactly once. **Cancel** (top-right while listening) closes without executing.
- Fixes `ship-lan.sh` aborting under `set -euo pipefail` when `OPENAI_API_KEY` is absent (grep no-match); OpenAI is optional, so it now warns and falls back to on-device English.

Closes #156

## Test plan
Device QA on iPhone 16 Pro Max (both engines), evidence walked with the user:
- [x] One command per long-press → executes → flashes → auto-closes; long-press again for next.
- [x] No duplicate execution / no growing results list across a session.
- [x] Stop Recording finalizes + executes immediately; automatic pause-finalize still runs exactly once (no double-up).
- [x] Stop Recording with no speech → empty state (not a silent close); Cancel closes without executing.
- [x] Hindi transcription restored with the OpenAI key baked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)