### PR TITLE
fix(ios): make the typing indicator dots actually animate

### DIFF
--- a/mobile/PersonalDashboard/Views/Chat/ChatComponents.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatComponents.swift
@@ -47,25 +47,54 @@ struct AIProse: View {
 
 struct TypingIndicator: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var phase: Double = 0
+
+    // A single, fixed reference date. Each frame's offset is derived from the
+    // elapsed time since this date, not from an animatable @State property.
+    // This sidesteps the SwiftUI endpoint-interpolation trap: an implicit/
+    // explicit animation on a plain State value only interpolates between its
+    // start and end values, so a full sin() cycle (which starts and ends at
+    // ~0) collapses to a visually static offset even while "running". Driving
+    // the curve from TimelineView's sampled date instead means there are no
+    // endpoints to interpolate between — every tick recomputes sin() fresh
+    // from continuous elapsed time, so the dots actually move on-device.
+    private let start = Date()
 
     var body: some View {
-        HStack(spacing: 6) {
-            ForEach(0..<3) { i in
-                Circle()
-                    .fill(Tokens.muted)
-                    .frame(width: 6, height: 6)
-                    .offset(y: reduceMotion ? 0 : sin((phase + Double(i) * 0.33) * .pi * 2) * 3)
+        Group {
+            if reduceMotion {
+                HStack(spacing: 6) {
+                    ForEach(0..<3, id: \.self) { _ in
+                        Circle()
+                            .fill(Tokens.muted)
+                            .frame(width: 6, height: 6)
+                    }
+                }
+            } else {
+                TimelineView(.animation) { timeline in
+                    let elapsed = timeline.date.timeIntervalSince(start)
+                    HStack(spacing: 6) {
+                        ForEach(0..<3, id: \.self) { i in
+                            Circle()
+                                .fill(Tokens.muted)
+                                .frame(width: 6, height: 6)
+                                .offset(y: dotOffset(elapsed: elapsed, index: i))
+                        }
+                    }
+                }
             }
         }
         .frame(height: 16)
         .accessibilityLabel("Assistant is typing")
-        .onAppear {
-            guard !reduceMotion else { return }
-            withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: false)) {
-                phase = 1
-            }
-        }
+    }
+
+    /// Staggered bob: each dot lags the previous by a fixed phase so the
+    /// motion reads as a wave sweeping left to right, the classic
+    /// typing-indicator look.
+    private func dotOffset(elapsed: TimeInterval, index: Int) -> Double {
+        let period = 0.9
+        let stagger = 0.15
+        let t = (elapsed - Double(index) * stagger) / period * (.pi * 2)
+        return sin(t) * 3
     }
 }
 


### PR DESCRIPTION
## Summary
- The three-dot processing indicator (`TypingIndicator`) rendered static in both the chat surface and the voice overlay's executing state.
- Root cause: it animated a single `phase` 0→1 and derived each dot's offset as `sin(phase·2π)`; SwiftUI only interpolates the offset between endpoints (phase 0 and 1), both ~0, so the dots never moved.
- Fix: drive the motion with `TimelineView(.animation)`, computing each dot's offset directly from elapsed time (0.9s period, 0.15s per-dot stagger) so it samples the curve every frame instead of interpolating between two zero endpoints.
- Reduce Motion renders a fully static branch (no `TimelineView`); accessibility label preserved.

Closes #158

## Test plan
Device QA on iPhone 16 Pro Max, walked with the user:
- [x] Dots visibly bob in a staggered wave in the voice overlay executing state.
- [x] Dots animate in the chat surface while the assistant responds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)