### PR TITLE
fix(ios): present item delete confirmation as a centered alert

### DIFF
--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -687,10 +687,9 @@ struct ItineraryItemEditorSheet: View {
                     .foregroundStyle(trimmedTitle.isEmpty ? Tokens.muted : Tokens.ink)
                 }
             }
-            .confirmationDialog(
+            .alert(
                 "Delete this item?",
-                isPresented: $showingDeleteConfirmation,
-                titleVisibility: .visible
+                isPresented: $showingDeleteConfirmation
             ) {
                 Button("Delete", role: .destructive) {
                     deleteItem()


### PR DESCRIPTION
## Summary
- The "Delete this item?" confirmation on the itinerary item editor was rendering as a popover bubble pinned to the top of the screen instead of a proper confirmation.
- Root cause: `.confirmationDialog` mis-adapts to an anchored popover when it lives inside the sheet's `NavigationStack`. Swapped it for a native `.alert`, which always presents centered and modal and is the idiomatic pattern for a single destructive confirmation.

Closes #160

## Test plan
- [x] Clean static build (`xcodebuild ... build`) passes.
- [x] Installed to device (iPhone 16 Pro Max) via `devicectl`.
- [ ] Device QA: tapping "Delete item" shows a centered alert (not top-anchored); "Delete" removes the item and dismisses the sheet; "Cancel" deletes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)