### PR TITLE
feat(ios): re-scan reconciles existing itinerary items, not just adds missing

### DIFF
--- a/mobile/PersonalDashboard/AI/EmailItemDedupe.swift
+++ b/mobile/PersonalDashboard/AI/EmailItemDedupe.swift
@@ -110,6 +110,68 @@ enum EmailItemDedupe {
         return false
     }
 
+    /// Find the existing row a proposed item is equivalent to, and report
+    /// whether the match was made on the confirmation code (the strong signal)
+    /// or only structurally. Mirrors `exists`'s matching order, but returns the
+    /// row instead of a bool so the reconcile-update path (#165) can update it.
+    ///
+    /// `byConfirmation` is true ONLY when the proposed item carries a
+    /// confirmation code AND that normalized code equals the row's stored
+    /// `sourceConfirmation`. A `dedupeKey` fast-path hit or a structural
+    /// fallback match both return `byConfirmation == false`, so the caller can
+    /// keep today's SKIP behaviour for anything short of a confirmation match.
+    @MainActor
+    static func match(signature: String, proposed: Proposed, tripUUID: UUID, context: ModelContext) -> (row: LocalItineraryItem, byConfirmation: Bool)? {
+        // Confirmation match first (the only path allowed to trigger an update).
+        // A row that stored the same normalized code is the same reservation
+        // regardless of how its title/dates render across two emails.
+        if !proposed.confirmation.isEmpty {
+            let conf = normalizeConfirmation(proposed.confirmation)
+            if !conf.isEmpty,
+               let row = try? context.fetch(
+                FetchDescriptor<LocalItineraryItem>(
+                    predicate: #Predicate { $0.tripUUID == tripUUID && $0.sourceConfirmation == conf }
+                )
+               ).first {
+                return (row, true)
+            }
+        }
+
+        // Fast path: a previously-ingested item carrying the same dedupeKey.
+        // This is a structural identity, not a confirmation identity.
+        let sig = signature
+        if let row = try? context.fetch(
+            FetchDescriptor<LocalItineraryItem>(
+                predicate: #Predicate { $0.dedupeKey == sig }
+            )
+        ).first {
+            return (row, false)
+        }
+
+        // Structural fallback: compare against all items on the trip (covers
+        // chat-created or pre-field rows that have no dedupeKey). In memory
+        // because normalized-title equality isn't expressible in a #Predicate.
+        let fk = tripUUID
+        let rows = (try? context.fetch(
+            FetchDescriptor<LocalItineraryItem>(predicate: #Predicate { $0.tripUUID == fk })
+        )) ?? []
+        let targetKind = proposed.kind
+        let targetDay = dayKey(proposed.dayDate)
+        let targetTitle = normalizeTitle(proposed.title)
+        let targetEnd = proposed.endDate.map(dayKey)
+        for row in rows {
+            guard row.kind.lowercased() == targetKind else { continue }
+            guard dayKey(row.dayDate) == targetDay else { continue }
+            guard normalizeTitle(row.title) == targetTitle else { continue }
+            if targetKind == "stay" {
+                let rowEnd = row.endDate.map(dayKey)
+                guard rowEnd == targetEnd else { continue }
+            }
+            return (row, false)
+        }
+        return nil
+    }
+
     // MARK: - Normalisation
 
     static func normalizeTitle(_ title: String) -> String {

--- a/mobile/PersonalDashboard/AI/EmailToItinerary.swift
+++ b/mobile/PersonalDashboard/AI/EmailToItinerary.swift
@@ -8,6 +8,11 @@ struct EmailIngestResult: Sendable {
     let tripName: String?
     /// UUIDs of itinerary items that were actually inserted (for undo).
     let addedItemUUIDs: [UUID]
+    /// UUIDs of existing items that were reconcile-updated in place (#165).
+    /// Only the explicit Re-scan path can populate this; v1 does NOT undo
+    /// these, so undo still only targets `addedItemUUIDs`. Additive default so
+    /// existing call sites don't have to pass it.
+    var updatedItemUUIDs: [UUID] = []
     /// Human summary for the ingest log + notification.
     let summary: String
     /// Diagnostics (#143): the parsed body the model received (capped) and the
@@ -67,7 +72,12 @@ struct EmailToItinerary {
         ToolDefinitions.allTools.filter { $0.name == "add_itinerary_item" }
     }
 
-    func run(message: EmailMessage, timezone: String) async throws -> EmailIngestResult {
+    /// - Parameter reconcile: when true (the explicit "Re-scan (ignore
+    ///   processed)" action, #165), a proposed item that matches an existing
+    ///   row by CONFIRMATION CODE updates that row's detail fields in place
+    ///   instead of being skipped. Never set on the automatic background
+    ///   cycle, so background fetches keep today's add-missing-only behaviour.
+    func run(message: EmailMessage, timezone: String, reconcile: Bool = false) async throws -> EmailIngestResult {
         // Process attachments (PDF text via PDFKit, .ics parse, image/PDF
         // native blocks). Bookings often live entirely in a PDF attachment
         // with a near-empty body, so this is the primary content source.
@@ -123,6 +133,10 @@ struct EmailToItinerary {
         let confirmation = EmailItemDedupe.extractConfirmation(from: fullText)
 
         var addedItemUUIDs: [UUID] = []
+        // Existing rows reconcile-updated in place on the explicit Re-scan
+        // (#165). Deduped so the same row updated by two proposed items in one
+        // run is counted once.
+        var updatedItemUUIDs: [UUID] = []
         var matchedTripUUID: UUID?
         var matchedTripName: String?
         var assistantText: String?
@@ -174,7 +188,27 @@ struct EmailToItinerary {
                     let proposed = Self.proposedItem(from: dict, confirmation: confirmation)
                     let sig = EmailItemDedupe.signature(tripUUID: tripUUID, proposed: proposed)
                     if EmailItemDedupe.exists(signature: sig, proposed: proposed, tripUUID: tripUUID, context: store.context) {
-                        skippedDuplicates += 1
+                        // A matching row already exists. On the explicit
+                        // Re-scan (#165) ONLY, try to reconcile-update it from
+                        // the email's parsed detail fields. Everything short of
+                        // a confirmation-code match still resolves to a skip.
+                        if reconcile,
+                           let updatedUUID = try await reconcileUpdate(
+                               dict: dict,
+                               signature: sig,
+                               proposed: proposed,
+                               tripUUID: tripUUID
+                           ) {
+                            matchedTripUUID = tripUUID
+                            if matchedTripName == nil {
+                                matchedTripName = Self.tripName(tripUUID, store: store)
+                            }
+                            if !updatedItemUUIDs.contains(updatedUUID) {
+                                updatedItemUUIDs.append(updatedUUID)
+                            }
+                        } else {
+                            skippedDuplicates += 1
+                        }
                         continue
                     }
                     // Guard against duplicates WITHIN this same batch too.
@@ -246,19 +280,23 @@ struct EmailToItinerary {
             }
         }
 
-        if !addedItemUUIDs.isEmpty, let tripUUID = matchedTripUUID {
+        // A change was made if we added items and/or reconcile-updated any.
+        // Both surface as the `.added` outcome so the log/notification treat
+        // it as a change, not a bare skip.
+        if (!addedItemUUIDs.isEmpty || !updatedItemUUIDs.isEmpty), let tripUUID = matchedTripUUID {
             let name = matchedTripName ?? "your trip"
-            var summary = addedItemUUIDs.count == 1
-                ? "Added 1 item to \(name)."
-                : "Added \(addedItemUUIDs.count) items to \(name)."
-            if skippedDuplicates > 0 {
-                summary += " (\(skippedDuplicates) already present, skipped.)"
-            }
+            let summary = Self.changeSummary(
+                added: addedItemUUIDs.count,
+                updated: updatedItemUUIDs.count,
+                skipped: skippedDuplicates,
+                tripName: name
+            )
             return EmailIngestResult(
                 outcome: .added,
                 tripUUID: tripUUID,
                 tripName: name,
                 addedItemUUIDs: addedItemUUIDs,
+                updatedItemUUIDs: updatedItemUUIDs,
                 summary: summary,
                 debugBody: debugBody,
                 debugTripContext: contextBlock
@@ -294,6 +332,116 @@ struct EmailToItinerary {
             debugBody: debugBody,
             debugTripContext: contextBlock
         )
+    }
+
+    // MARK: - Reconcile-update (#165)
+
+    /// Reconcile-update an existing itinerary row from a proposed email item.
+    ///
+    /// Safeguards (all enforced here):
+    ///  - Only updates on a CONFIRMATION-code match (`byConfirmation == true`).
+    ///    A dedupeKey or structural match returns nil → caller skips.
+    ///  - Only updates a row whose `sourceConfirmation` is non-empty (an
+    ///    email-sourced row); a purely manual row is never touched.
+    ///  - Only the detail fields the email provides are sent
+    ///    (start_time / end_time / end_date / notes / google_maps_link),
+    ///    routed through `ExecuteDraftAction.updateItineraryItem` so date/time
+    ///    parsing is identical to the add path (post-#163). Never title, kind,
+    ///    or day_date.
+    ///  - Returns the row UUID ONLY when a field actually changed (snapshot
+    ///    compare); a no-op edit returns nil so the caller counts it as a skip.
+    private func reconcileUpdate(
+        dict: [String: AnthropicJSONValue],
+        signature: String,
+        proposed: EmailItemDedupe.Proposed,
+        tripUUID: UUID
+    ) async throws -> UUID? {
+        guard let (row, byConfirmation) = EmailItemDedupe.match(
+            signature: signature,
+            proposed: proposed,
+            tripUUID: tripUUID,
+            context: store.context
+        ) else {
+            return nil
+        }
+        // Safeguards 2 & 3: confirmation match against an email-sourced row.
+        guard byConfirmation, !row.sourceConfirmation.isEmpty else { return nil }
+
+        // Build the edit input from ONLY the detail fields the email provides.
+        // Keys must match what `updateItineraryItem` reads. Empty string = keep
+        // (its tri-state), so a field the email omits is left untouched. We
+        // never send title / kind / day_date (safeguard 4). `address` is
+        // intentionally not sent: `updateItineraryItem` doesn't read it and the
+        // email add-path doesn't populate it, so there's nothing to reconcile.
+        let itemUUID = row.clientUUID
+        var editInput: [String: AnthropicJSONValue] = [
+            "id": .string(itemUUID.uuidString.lowercased())
+        ]
+        // Only include a detail key when the email actually supplied a value,
+        // so we rely on "keep" semantics rather than emitting empty strings.
+        for key in ["start_time", "end_time", "end_date", "notes", "google_maps_link"] {
+            if let raw = dict[key]?.stringValue {
+                let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { continue }
+                editInput[key] = .string(trimmed)
+            }
+        }
+        // Nothing to potentially change beyond the id → skip.
+        guard editInput.count > 1 else { return nil }
+
+        // Snapshot the fields the edit could touch, so we can tell a real
+        // change from a write that set a field to its current value
+        // (safeguard 6 — updateItineraryItem's own `changed` flag is coarser).
+        let before = (
+            row.startTime,
+            row.endTime,
+            row.endDate,
+            row.notes,
+            row.googleMapsLink
+        )
+
+        do {
+            _ = try await executor.run(actionType: .updateItineraryItem, input: editInput)
+        } catch let err as DraftExecutionError {
+            // "no changes provided" is a benign no-op → treat as skip.
+            NSLog("EmailToItinerary: reconcile edit skipped: %@", err.errorDescription ?? "unknown")
+            return nil
+        }
+
+        // Re-read the row and compare. If nothing actually moved, it's a skip.
+        guard let after = try? store.context.fetch(
+            FetchDescriptor<LocalItineraryItem>(predicate: #Predicate { $0.clientUUID == itemUUID })
+        ).first else {
+            return nil
+        }
+        let changed = after.startTime != before.0
+            || after.endTime != before.1
+            || after.endDate != before.2
+            || after.notes != before.3
+            || after.googleMapsLink != before.4
+        return changed ? itemUUID : nil
+    }
+
+    /// Build the user-facing change summary. Mentions only non-zero counts;
+    /// only-updates still reads as a change (not a bare skip).
+    static func changeSummary(added: Int, updated: Int, skipped: Int, tripName: String) -> String {
+        var parts: [String] = []
+        if added > 0 {
+            parts.append(added == 1 ? "added 1 item" : "added \(added) items")
+        }
+        if updated > 0 {
+            parts.append(updated == 1 ? "updated 1 item" : "updated \(updated) items")
+        }
+        // Capitalise the first verb for a clean sentence start.
+        var body = parts.joined(separator: ", ")
+        if let first = body.first {
+            body = first.uppercased() + body.dropFirst()
+        }
+        var summary = "\(body) in \(tripName)."
+        if skipped > 0 {
+            summary += " (\(skipped) already present, skipped.)"
+        }
+        return summary
     }
 
     // MARK: - Helpers

--- a/mobile/PersonalDashboard/Services/EmailIngestNotifications.swift
+++ b/mobile/PersonalDashboard/Services/EmailIngestNotifications.swift
@@ -55,17 +55,34 @@ enum EmailIngestNotifications {
         _ = try? await center.requestAuthorization(options: [.alert, .sound, .badge])
     }
 
-    /// Post the "items added" notification with an Undo action.
-    static func postAdded(tripName: String, itemCount: Int, logUUID: UUID) async {
+    /// Post the "items added / updated" notification with an Undo action.
+    ///
+    /// `updatedCount` (#165) covers rows the explicit Re-scan reconciled in
+    /// place. The automatic cycle never updates, so it always passes 0 and the
+    /// body reads exactly as before. Undo still only removes the ADDED items;
+    /// updated items are left in place.
+    static func postAdded(tripName: String, itemCount: Int, updatedCount: Int = 0, logUUID: UUID) async {
         let content = UNMutableNotificationContent()
-        content.title = "Added to \(tripName)"
-        content.body = itemCount == 1
-            ? "1 item added from a forwarded email."
-            : "\(itemCount) items added from a forwarded email."
+        content.title = itemCount > 0 ? "Added to \(tripName)" : "Updated \(tripName)"
+        content.body = Self.addedBody(added: itemCount, updated: updatedCount)
         content.sound = .default
         content.categoryIdentifier = addedCategoryId
         content.userInfo = [logUUIDKey: logUUID.uuidString.lowercased()]
         await post(content)
+    }
+
+    /// Build the notification body for an added/updated outcome. Mentions only
+    /// non-zero counts so an updates-only Re-scan never reads "0 items added".
+    private static func addedBody(added: Int, updated: Int) -> String {
+        var parts: [String] = []
+        if added > 0 {
+            parts.append(added == 1 ? "1 item added" : "\(added) items added")
+        }
+        if updated > 0 {
+            parts.append(updated == 1 ? "1 item updated" : "\(updated) items updated")
+        }
+        if parts.isEmpty { parts.append("nothing changed") }
+        return parts.joined(separator: ", ") + " from a forwarded email."
     }
 
     /// Post the "skipped, no matching trip" notification.

--- a/mobile/PersonalDashboard/Services/EmailIngestService.swift
+++ b/mobile/PersonalDashboard/Services/EmailIngestService.swift
@@ -32,12 +32,12 @@ struct EmailIngestService {
     /// the re-run messages are also cleared so a subsequent normal cycle won't
     /// see stale entries. Idempotency for normal cycles is unaffected.
     @discardableResult
-    func runFetchCycle(ignoreProcessed: Bool = false) async -> (added: Int, skipped: Int, failed: Int) {
+    func runFetchCycle(ignoreProcessed: Bool = false) async -> (added: Int, updated: Int, skipped: Int, failed: Int) {
         guard EmailInboxConfig.isReady else {
-            return (0, 0, 0)
+            return (0, 0, 0, 0)
         }
         guard let password = EmailInboxConfig.readPassword(), !password.isEmpty else {
-            return (0, 0, 0)
+            return (0, 0, 0, 0)
         }
 
         let settings = EmailInboxConfig.settings
@@ -48,7 +48,7 @@ struct EmailIngestService {
             appPassword: password
         ))
 
-        var counts = (added: 0, skipped: 0, failed: 0)
+        var counts = (added: 0, updated: 0, skipped: 0, failed: 0)
 
         do {
             try await client.connectAndLogin()
@@ -88,14 +88,29 @@ struct EmailIngestService {
 
                     let result = try await EmailToItinerary.default().run(
                         message: message,
-                        timezone: TimeZone.current.identifier
+                        timezone: TimeZone.current.identifier,
+                        // Reconcile-update existing items ONLY on the explicit
+                        // Re-scan; the automatic cycle keeps add-missing-only.
+                        reconcile: ignoreProcessed
                     )
 
                     writeLog(message: message, result: result)
 
                     switch result.outcome {
                     case .added:
-                        counts.added += 1
+                        // `.added` covers adds and/or reconcile-updates (#165).
+                        // Split the counters so the summary can report both.
+                        if !result.addedItemUUIDs.isEmpty {
+                            counts.added += 1
+                        }
+                        if !result.updatedItemUUIDs.isEmpty {
+                            counts.updated += 1
+                        }
+                        // A change with neither list populated shouldn't happen,
+                        // but guard so the run is never silently uncounted.
+                        if result.addedItemUUIDs.isEmpty && result.updatedItemUUIDs.isEmpty {
+                            counts.added += 1
+                        }
                     case .skipped:
                         counts.skipped += 1
                     case .failed:
@@ -232,7 +247,8 @@ struct EmailIngestService {
         case .added:
             let name = result.tripName ?? "your trip"
             let count = result.addedItemUUIDs.count
-            Task { await EmailIngestNotifications.postAdded(tripName: name, itemCount: count, logUUID: logUUID) }
+            let updated = result.updatedItemUUIDs.count
+            Task { await EmailIngestNotifications.postAdded(tripName: name, itemCount: count, updatedCount: updated, logUUID: logUUID) }
         case .skipped:
             Task { await EmailIngestNotifications.postSkipped(subject: message.subject) }
         case .failed:

--- a/mobile/PersonalDashboard/Views/Settings/EmailInboxView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/EmailInboxView.swift
@@ -329,7 +329,10 @@ struct EmailInboxView: View {
             await MainActor.run {
                 isFetching = false
                 let prefix = ignoreProcessed ? "Re-scanned. " : ""
-                fetchSummary = "\(prefix)Added \(result.added), skipped \(result.skipped), failed \(result.failed)."
+                // Re-scan can update existing items in place (#165); the
+                // automatic cycle never does, so `updated` is 0 there.
+                let updatedPart = result.updated > 0 ? "updated \(result.updated), " : ""
+                fetchSummary = "\(prefix)Added \(result.added), \(updatedPart)skipped \(result.skipped), failed \(result.failed)."
             }
         }
     }


### PR DESCRIPTION
## Summary
- The explicit **Re-scan (ignore processed)** email action now UPDATES an existing itinerary item when the forwarded email's parsed detail fields differ, instead of only adding missing items. This lets corrected values (e.g. a time fixed by #163) reach an item that was already on the itinerary.
- Adds a `EmailItemDedupe.match(...)` helper (returns the matched row + whether it matched by confirmation code), threads a `reconcile` flag from the explicit re-scan through `EmailToItinerary.run`, and routes updates through the shared `ExecuteDraftAction` update path so time parsing matches the add path.
- Re-scan now reports added / updated / skipped / failed separately in the toast, notification, and log.

Safeguards (bound the data-loss risk):
- Explicit only — reconcile never runs on the automatic background fetch (unchanged, add-missing-only).
- Email-sourced rows only; confirmation-code match required (fuzzy structural matches keep skipping).
- Detail fields only (`start_time`/`end_time`/`end_date`/`notes`/`google_maps_link`); never `title`/`kind`/`day_date`.
- Unchanged rows are a no-op skip (before/after field snapshot).

Note: `address` is not reconciled — neither the executor update path nor the email add-path handles an address field, so there is nothing to sync.

Closes #165

## Test plan
- [x] Clean static build (`xcodegen generate` + `xcodebuild build`).
- [x] Device QA on iPhone 16 Pro Max — see the QA comment on #165 for ticked AC.
- [x] Stacked on #163 (merged); rebased onto main so the diff is the reconcile change only.