### PR TITLE
fix(ios): anchor itinerary times to UTC so they never drift with device timezone

### DIFF
--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -1116,11 +1116,11 @@ struct ExecuteDraftAction {
     /// Parse an ISO 8601 datetime as a FLOATING wall-clock time. Itinerary
     /// times are wall-clock at the destination: a 14:00 check-in in Milan must
     /// read 14:00 no matter where the phone is. The AI emits the destination
-    /// offset (e.g. "...T14:00:00+02:00"); we drop the offset and reinterpret
-    /// the wall-clock in the device timezone so
-    /// `.formatted(.dateTime.hour().minute())` (which renders in device time)
-    /// shows the stated time. Returns nil for date-only or unparseable input
-    /// (→ untimed item).
+    /// offset (e.g. "...T14:00:00+02:00"); we drop the offset and anchor the
+    /// wall-clock to UTC (a FIXED internal anchor, never shown to the user)
+    /// so a UTC-pinned display formatter always renders the stated H:M
+    /// regardless of the device's current timezone. Returns nil for date-only
+    /// or unparseable input (→ untimed item).
     private func parseWallClockTime(_ raw: String?) -> Date? {
         guard let raw, raw != "null" else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1130,7 +1130,7 @@ struct ExecuteDraftAction {
             of: "(Z|[+-]\\d{2}(:?\\d{2})?)$",
             with: "",
             options: .regularExpression)
-        // Reinterpret the wall clock in the device timezone.
+        // Anchor the wall clock to UTC (fixed internal anchor).
         for fmt in Self.wallClockFormatters {
             if let d = fmt.date(from: noOffset) { return d }
         }
@@ -1191,16 +1191,19 @@ struct ExecuteDraftAction {
         return f
     }()
 
-    /// Wall-clock parsers for itinerary time-of-day fields. Both use the
-    /// DEVICE timezone (`.current`) so an offset-stripped datetime like
-    /// "2026-09-02T14:00:00" is reinterpreted as 14:00 local, i.e. the time
-    /// the booking stated. One shape with fractional seconds, one without.
+    /// Wall-clock parsers for itinerary time-of-day fields. Both anchor to
+    /// UTC so an offset-stripped datetime like "2026-09-02T14:00:00" parses
+    /// to 14:00:00 UTC, i.e. the time the booking stated. UTC is a FIXED
+    /// internal anchor (never shown to the user); a UTC-pinned display
+    /// formatter then renders the stated H:M no matter the device timezone,
+    /// so itinerary times never drift when the phone changes zones. One shape
+    /// with fractional seconds, one without.
     private static let wallClockFormatters: [DateFormatter] = {
         ["yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd'T'HH:mm:ss.SSS"].map { pattern in
             let f = DateFormatter()
             f.calendar = Calendar(identifier: .gregorian)
             f.locale = Locale(identifier: "en_US_POSIX")
-            f.timeZone = .current
+            f.timeZone = TimeZone(identifier: "UTC")
             f.dateFormat = pattern
             return f
         }

--- a/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
+++ b/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
@@ -54,6 +54,76 @@ final class SwiftDataStore {
         } catch {
             fatalError("Failed to bootstrap SwiftData container: \(error)")
         }
+        // Runs once at first launch after the UTC-wall-clock change (#168),
+        // before any itinerary UI can query. Guarded internally.
+        migrateItineraryTimesToUTC()
+    }
+
+    /// One-time migration (#168): convert existing itinerary item times from
+    /// the old device-local-wall-clock scheme to the new UTC-wall-clock scheme.
+    ///
+    /// Before #168, `startTime`/`endTime` stored a Date whose DEVICE-local H:M
+    /// equalled the stated booking time. After #168 the app displays times with
+    /// a UTC-pinned formatter, so those rows would render shifted. This pass
+    /// rebuilds each stored Date so its UTC components equal the old device-local
+    /// components (i.e. the stated H:M is preserved under the new anchor).
+    ///
+    /// Assumption: correct when the device timezone now equals the timezone in
+    /// effect when the item was created (the common case — items created and
+    /// migrated on the same phone in the same zone). Rare items created while
+    /// the phone was in a different timezone can be corrected by re-scan (#165)
+    /// or a manual edit, both of which re-anchor to UTC wall-clock directly.
+    ///
+    /// Gated by a `UserDefaults` flag so it runs exactly once. Wrapped in
+    /// do/catch — never crashes launch.
+    private func migrateItineraryTimesToUTC() {
+        let flagKey = "itineraryTimesUTCMigrated_v1"
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: flagKey) else { return }
+
+        let ctx = container.mainContext
+        let local = Calendar.current
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(identifier: "UTC")!
+
+        // Rebuild `stored` (a device-local wall-clock Date) as a UTC wall-clock
+        // Date preserving all components. Returns nil if reconstruction fails.
+        func rebased(_ stored: Date) -> Date? {
+            let c = local.dateComponents(
+                [.year, .month, .day, .hour, .minute, .second],
+                from: stored
+            )
+            var out = DateComponents()
+            out.year = c.year
+            out.month = c.month
+            out.day = c.day
+            out.hour = c.hour
+            out.minute = c.minute
+            out.second = c.second
+            return utc.date(from: out)
+        }
+
+        do {
+            let items = try ctx.fetch(FetchDescriptor<LocalItineraryItem>())
+            var didChange = false
+            for item in items where item.startTime != nil || item.endTime != nil {
+                if let start = item.startTime, let r = rebased(start) {
+                    item.startTime = r
+                    didChange = true
+                }
+                if let end = item.endTime, let r = rebased(end) {
+                    item.endTime = r
+                    didChange = true
+                }
+            }
+            if didChange {
+                try ctx.save()
+            }
+            defaults.set(true, forKey: flagKey)
+        } catch {
+            // Leave the flag unset so a future launch can retry. Never crash.
+            NSLog("SwiftDataStore: itinerary UTC time migration failed: %@", String(describing: error))
+        }
     }
 
     /// Build an in-memory container for tests or previews.

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -333,10 +333,23 @@ enum TimelineEntry: Identifiable {
         }
     }
 
+    /// Locale-aware hour:minute formatter PINNED to UTC. Itinerary
+    /// `startTime`/`endTime` are stored as UTC wall-clock (their UTC H:M
+    /// equals the booking's stated local time), so rendering in UTC shows the
+    /// stated time and never drifts when the device timezone changes. The
+    /// "jmm" template keeps the user's 12/24-hour locale preference.
+    static let itineraryTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .current
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.setLocalizedDateFormatFromTemplate("jmm")
+        return f
+    }()
+
     /// The "Anytime / Check-in / Check-out · HH:mm" line shown inside the
     /// card below the kind chip.
     var dateTimeLine: String {
-        let timeFormat: (Date) -> String = { $0.formatted(.dateTime.hour().minute()) }
+        let timeFormat: (Date) -> String = { TimelineEntry.itineraryTimeFormatter.string(from: $0) }
         switch self {
         case .single(let item):
             if let t = item.startTime { return timeFormat(t) }
@@ -846,6 +859,44 @@ struct ItineraryItemEditorSheet: View {
         }
     }
 
+    /// Storage boundary → UTC. Read the (hour, minute) of `timeFrom` in the
+    /// DEVICE calendar (what the picker shows), then build a Date on `onDay`'s
+    /// calendar day with those same components anchored in UTC. The result's
+    /// UTC H:M equals the picked local H:M, so a UTC-pinned display formatter
+    /// renders exactly what the user picked, regardless of timezone.
+    private func utcWallClock(onDay: Date, timeFrom: Date) -> Date {
+        let local = Calendar.current
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(identifier: "UTC")!
+        let day = local.dateComponents([.year, .month, .day], from: onDay)
+        let time = local.dateComponents([.hour, .minute], from: timeFrom)
+        var comps = DateComponents()
+        comps.year = day.year
+        comps.month = day.month
+        comps.day = day.day
+        comps.hour = time.hour
+        comps.minute = time.minute
+        comps.second = 0
+        return utc.date(from: comps) ?? timeFrom
+    }
+
+    /// Storage boundary → picker. Inverse of `utcWallClock`: read the
+    /// (hour, minute) of a stored UTC wall-clock Date in a UTC calendar, then
+    /// build a DEVICE-local Date carrying those same components on `onDay`'s
+    /// local calendar day, so the DatePicker surfaces the stated time.
+    private func deviceLocalPickerDate(onDay: Date, utcWallClock: Date) -> Date {
+        let local = Calendar.current
+        var utc = Calendar(identifier: .gregorian)
+        utc.timeZone = TimeZone(identifier: "UTC")!
+        let time = utc.dateComponents([.hour, .minute], from: utcWallClock)
+        return local.date(
+            bySettingHour: time.hour ?? 0,
+            minute: time.minute ?? 0,
+            second: 0,
+            of: onDay
+        ) ?? onDay
+    }
+
     /// Returns `existing` with the time-of-day replaced by `defaultHour:00` if
     /// the existing time is midnight; otherwise leaves it as-is. Used when
     /// the "Include time" toggle flips on so the picker doesn't surface 12:00 AM.
@@ -1077,14 +1128,17 @@ struct ItineraryItemEditorSheet: View {
                 address = existing.address
                 googleMapsLink = existing.googleMapsLink
                 if let start = existing.startTime {
+                    // Stored as UTC wall-clock; seed the (device-local) picker
+                    // with a Date carrying the same H:M on the item's day, so
+                    // the picker surfaces the stated time.
                     hasTime = true
-                    dayDate = start
+                    dayDate = deviceLocalPickerDate(onDay: existing.dayDate, utcWallClock: start)
                 }
                 if let end = existing.endDate {
                     endDate = end
                     if let endT = existing.endTime {
                         hasEndTime = true
-                        endDate = endT
+                        endDate = deviceLocalPickerDate(onDay: end, utcWallClock: endT)
                     }
                 } else if existing.kindEnum == .stay {
                     // Stay with no persisted endDate (legacy item before the
@@ -1104,14 +1158,22 @@ struct ItineraryItemEditorSheet: View {
         let cal = Calendar.current
         let normalisedDay = cal.startOfDay(for: dayDate)
 
+        // Times are persisted as UTC wall-clock: the picker carries a
+        // device-local H:M, and we store a Date whose UTC H:M equals what the
+        // user picked, anchored on the item's day. This makes itinerary times
+        // timezone-independent (what you pick is what shows, forever). The day
+        // bucket (`normalisedDay`) stays device-local start-of-day so grouping
+        // is unaffected.
+        //
         // For non-stay or when "Include time" is off: persist only the day.
-        // For non-stay with time on: persist the full date+time as `startTime`,
-        // dayDate stays start-of-day so the grouping bucket is unambiguous.
-        let startTimeValue: Date? = hasTime ? dayDate : nil
+        // For non-stay with time on: persist startTime as UTC wall-clock on
+        // the item's day; dayDate stays start-of-day so the grouping bucket is
+        // unambiguous.
+        let startTimeValue: Date? = hasTime ? utcWallClock(onDay: dayDate, timeFrom: dayDate) : nil
 
         // Stay-only end fields. Other kinds clear both.
         let endDateValue: Date? = kind == .stay ? cal.startOfDay(for: endDate) : nil
-        let endTimeValue: Date? = (kind == .stay && hasEndTime) ? endDate : nil
+        let endTimeValue: Date? = (kind == .stay && hasEndTime) ? utcWallClock(onDay: endDate, timeFrom: endDate) : nil
 
         switch target {
         case .new:


### PR DESCRIPTION
## Summary
- After #163, itinerary times showed the stated wall-clock but were anchored to the device timezone at import and rendered with a device-timezone formatter, so they drifted when the phone's timezone changed (import in India, view in Dubai: 10:00 → 08:30).
- Anchors all itinerary start/end times to a fixed UTC wall-clock (never surfaced to the user — only H:M shows): parse offset-stripped times in UTC, display with a UTC-pinned locale-aware (12/24h) formatter, and convert the manual picker at the storage boundary (pick device-local → store UTC wall-clock → read back device-local).
- One-time, flag-gated migration converts existing rows from device-local to UTC wall-clock so items stay correct with no re-scan.
- Day grouping stays on `dayDate`; sorting via `effectiveTime` is a raw Date comparison (zone-independent) and unchanged.

Closes #168

## Test plan
- [x] Clean static build (`xcodegen generate` + `xcodebuild build`).
- [x] Device QA on iPhone 16 Pro Max incl. a timezone-switch test — see QA comment on #168 for ticked AC.
- [x] Only itinerary-time display site (`TripDetailView.dateTimeLine`) audited + pinned; trip-date displays unaffected.