### PR TITLE
feat(ios): attach Google Maps location to email-parsed itinerary items

### DIFF
--- a/mobile/PersonalDashboard/AI/EmailToItinerary.swift
+++ b/mobile/PersonalDashboard/AI/EmailToItinerary.swift
@@ -280,6 +280,14 @@ struct EmailToItinerary {
             }
         }
 
+        // #174: upgrade name+address search links on this trip to exact-coordinate
+        // pins via on-device forward geocoding. Runs AFTER execution, is fully
+        // best-effort, and never affects the ingest outcome (its own errors are
+        // swallowed inside). Skipped when nothing matched a trip.
+        if let tripUUID = matchedTripUUID {
+            await enrichMapLinks(tripUUID: tripUUID)
+        }
+
         // A change was made if we added items and/or reconcile-updated any.
         // Both surface as the `.added` outcome so the log/notification treat
         // it as a change, not a bare skip.
@@ -344,8 +352,9 @@ struct EmailToItinerary {
     ///  - Only updates a row whose `sourceConfirmation` is non-empty (an
     ///    email-sourced row); a purely manual row is never touched.
     ///  - Only the detail fields the email provides are sent
-    ///    (start_time / end_time / end_date / notes / google_maps_link),
-    ///    routed through `ExecuteDraftAction.updateItineraryItem` so date/time
+    ///    (start_time / end_time / end_date / notes / address /
+    ///    google_maps_link), routed through
+    ///    `ExecuteDraftAction.updateItineraryItem` so date/time
     ///    parsing is identical to the add path (post-#163). Never title, kind,
     ///    or day_date.
     ///  - Returns the row UUID ONLY when a field actually changed (snapshot
@@ -371,15 +380,15 @@ struct EmailToItinerary {
         // Keys must match what `updateItineraryItem` reads. Empty string = keep
         // (its tri-state), so a field the email omits is left untouched. We
         // never send title / kind / day_date (safeguard 4). `address` is
-        // intentionally not sent: `updateItineraryItem` doesn't read it and the
-        // email add-path doesn't populate it, so there's nothing to reconcile.
+        // included so a re-scan can backfill it onto items created before the
+        // add-path populated it (#169).
         let itemUUID = row.clientUUID
         var editInput: [String: AnthropicJSONValue] = [
             "id": .string(itemUUID.uuidString.lowercased())
         ]
         // Only include a detail key when the email actually supplied a value,
         // so we rely on "keep" semantics rather than emitting empty strings.
-        for key in ["start_time", "end_time", "end_date", "notes", "google_maps_link"] {
+        for key in ["start_time", "end_time", "end_date", "notes", "address", "google_maps_link"] {
             if let raw = dict[key]?.stringValue {
                 let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty else { continue }
@@ -397,6 +406,7 @@ struct EmailToItinerary {
             row.endTime,
             row.endDate,
             row.notes,
+            row.address,
             row.googleMapsLink
         )
 
@@ -418,7 +428,8 @@ struct EmailToItinerary {
             || after.endTime != before.1
             || after.endDate != before.2
             || after.notes != before.3
-            || after.googleMapsLink != before.4
+            || after.address != before.4
+            || after.googleMapsLink != before.5
         return changed ? itemUUID : nil
     }
 
@@ -442,6 +453,86 @@ struct EmailToItinerary {
             summary += " (\(skipped) already present, skipped.)"
         }
         return summary
+    }
+
+    // MARK: - Map-link enrichment (#174)
+
+    /// Max items forward-geocoded per run. `CLGeocoder` rate-limits to ~1
+    /// request/sec, so a large trip could otherwise blow the ~22s capture
+    /// budget. The rest keep their working name+address search links.
+    private static let maxGeocodesPerRun = 8
+
+    /// Upgrade name+address search links on the matched trip to exact-coordinate
+    /// pins. Idempotent and best-effort:
+    ///  - Targets only items whose `googleMapsLink` is a name+address SEARCH
+    ///    link (`/maps/search/?api=1&query=`) whose `query` is NOT already a
+    ///    bare `lat,lng` pair, and which have a non-empty `address`. This picks
+    ///    up freshly-added AND reconcile-backfilled items, skips explicit email
+    ///    links, and skips already-resolved coordinate pins so a re-scan never
+    ///    re-geocodes.
+    ///  - Geocodes SEQUENTIALLY (concurrent CLGeocoder requests get cancelled)
+    ///    and caps the batch, so it can't stall ingestion.
+    ///  - On a coordinate hit, rewrites `googleMapsLink` to the pin URL and
+    ///    saves; on a miss the search link is left untouched.
+    /// The whole pass is wrapped so a thrown error can never affect the ingest
+    /// result — geocoding is a pure enrichment.
+    private func enrichMapLinks(tripUUID: UUID) async {
+        let fk = tripUUID
+        let items = (try? store.context.fetch(
+            FetchDescriptor<LocalItineraryItem>(predicate: #Predicate { $0.tripUUID == fk })
+        )) ?? []
+
+        // Only search-link items with an address are candidates.
+        let candidates = items.filter { item in
+            !item.address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && Self.isUpgradableSearchLink(item.googleMapsLink)
+        }
+        guard !candidates.isEmpty else { return }
+
+        let geocoder = AddressGeocoder()
+        var geocoded = 0
+        for item in candidates {
+            if geocoded >= Self.maxGeocodesPerRun {
+                NSLog("EmailToItinerary: geocode cap (%d) reached; %d item(s) left with search links",
+                      Self.maxGeocodesPerRun, candidates.count - geocoded)
+                break
+            }
+            geocoded += 1
+            guard let coordinate = await geocoder.resolveCoordinate(
+                address: item.address,
+                name: item.title
+            ), let pin = AddressGeocoder.pinURL(for: coordinate) else {
+                // No result / timeout / error: keep the working search link.
+                continue
+            }
+            item.googleMapsLink = pin.absoluteString
+            item.updatedAt = Date()
+            try? store.context.save()
+        }
+    }
+
+    /// `true` when the stored link is a name+address Google Maps SEARCH link
+    /// that has NOT yet been resolved to a coordinate pin — i.e. it contains
+    /// `/maps/search/?api=1&query=` and its `query` value is not a bare
+    /// `lat,lng` pair. Empty links and explicit non-search email links (which
+    /// take a different URL shape) both return `false`.
+    static func isUpgradableSearchLink(_ link: String) -> Bool {
+        let trimmed = link.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.contains("/maps/search/"),
+              let components = URLComponents(string: trimmed),
+              let query = components.queryItems?.first(where: { $0.name == "query" })?.value,
+              !query.isEmpty else {
+            return false
+        }
+        // A coordinate pin's query is already `lat,lng` — leave it alone.
+        return !isCoordinatePair(query)
+    }
+
+    /// `true` when the string is just `lat,lng`. Mirrors the check in
+    /// `MapsLinkResolver`; used to skip items already resolved to a pin.
+    private static func isCoordinatePair(_ string: String) -> Bool {
+        let pattern = "^-?\\d{1,3}\\.\\d+,\\s*-?\\d{1,3}\\.\\d+$"
+        return string.range(of: pattern, options: .regularExpression) != nil
     }
 
     // MARK: - Helpers
@@ -575,14 +666,14 @@ struct EmailToItinerary {
 
         YOUR JOB:
         1. Read the forwarded email and work out what it is: a hotel/accommodation booking (stay), a flight or other transport (activity), a tour/event/ticket (activity), a restaurant reservation (restaurant), or a place to visit (place).
-        2. Find the ONE trip in the EXISTING TRIPS list whose date range CONTAINS the booking's date(s) AND whose destination plausibly matches. Both must hold.
+        2. Find the ONE trip in the EXISTING TRIPS list whose dates OVERLAP the booking's date(s) AND whose destination plausibly matches. Both must hold. OVERLAP, not strict containment: a booking matches when its stay/travel window intersects the trip's date range OR sits within about a day of either edge. Bookings routinely straddle a trip's boundaries — a hotel's LAST night commonly checks OUT the morning AFTER the trip's nominal end date, and an arrival hotel may check IN the night BEFORE the trip formally starts. Treat these as matching; do NOT reject a booking merely because its check-out is a day past the trip end or its check-in is a day before the trip start, as long as the stay clearly belongs to that trip.
         3. DESTINATION MATCHING IS LENIENT. The trip name is usually a country or region ("Italy"); the booking names a city, airport code, hotel, or neighbourhood. Treat the booking as matching when its location is plausibly inside the trip's destination: a flight to Rome (FCO) or Milan, or a hotel in Florence, all match an "Italy" trip. An IATA airport/city code counts (FCO/MXP/CIA → Italy, NRT/HND → Japan). When the date range fits and the destination is plausibly within the trip's region, MATCH IT — do not hold out for an exact city-name string match. Only refuse on destination when the location clearly belongs to a different country/region than every trip (a Tokyo hotel against a Vietnam trip).
         4. If exactly one trip matches, call add_itinerary_item with that trip_id and the item(s) parsed from the email.
-        5. If NO trip matches (dates clearly outside every range, or destination clearly in a different region), add NOTHING. Respond with one short sentence saying it didn't match and naming the booking's dates + destination so the user can see why. Do NOT force a match.
+        5. If NO trip matches (the booking's dates are clearly well outside every trip's range — not merely a day over an edge — or the destination is clearly in a different region), add NOTHING. Respond with one short sentence saying it didn't match and naming the booking's dates + destination so the user can see why. Do NOT force a match.
         6. If the email is not a booking/reservation at all (newsletter, receipt for something unrelated, spam), add nothing and say so briefly.
 
         YEAR INFERENCE (important):
-        Booking documents often show dates WITHOUT a year ("Mon, 7 Sept", "Check-in 7 Sept", "7–9 Sept"). NEVER emit a date with a missing or wrong year (no year 0, 0001, 1970, or blindly "this year"). Resolve the year from the MATCHED trip's date range first: if the trip runs 2026-09-05 → 2026-09-12 and the booking says "7 Sept", the date is 2026-09-07. If you cannot match a trip, resolve the year as the next future occurrence relative to the current date. The day_date you emit MUST fall inside the matched trip's date range; if "7 Sept" only fits one trip's range once you apply that trip's year, that is your match.
+        Booking documents often show dates WITHOUT a year ("Mon, 7 Sept", "Check-in 7 Sept", "7–9 Sept"). NEVER emit a date with a missing or wrong year (no year 0, 0001, 1970, or blindly "this year"). Resolve the year from the MATCHED trip's date range first: if the trip runs 2026-09-05 → 2026-09-12 and the booking says "7 Sept", the date is 2026-09-07. If you cannot match a trip, resolve the year as the next future occurrence relative to the current date. The day_date you emit should fall on or within the matched trip's date range (a stay's check-in on the trip's FINAL day is valid even when its check-out lands the day after the trip ends); if "7 Sept" only fits one trip's range once you apply that trip's year, that is your match.
 
         MAPPING RULES:
         - Hotel / accommodation / Airbnb confirmation -> kind "stay". Set day_date to the check-in date and end_date to the check-out date (stays require end_date). Include the hotel name in the title.
@@ -592,12 +683,13 @@ struct EmailToItinerary {
         - Sightseeing place with no booking -> kind "place".
 
         ITEM FIELDS:
-        - day_date: the date the item happens, ISO 8601 (yyyy-MM-dd is fine). MUST fall inside the matched trip's date range.
+        - day_date: the date the item happens, ISO 8601 (yyyy-MM-dd is fine). It should fall within the matched trip's date range. For a stay, day_date is the check-in date; the check-out (end_date) may be up to about a day after the trip's end — that is expected for a last-night booking, not a reason to skip.
         - title: concise and specific (vendor / flight number / hotel name).
-        - notes: confirmation number, address, times, and any other useful detail from the email. Keep it factual.
+        - notes: confirmation/booking number, times, and any other useful detail from the email. Keep it factual. The physical address goes in the address field (below), not here, so don't duplicate it verbatim into notes.
         - start_time: full ISO 8601 datetime with timezone when the email gives a clear time; otherwise omit.
         - For stays only: end_date (check-out) is required; end_time optional.
-        - google_maps_link: if the email or attachment contains an explicit Google Maps URL for the location (maps.app.goo.gl, goo.gl/maps, google.com/maps, maps.google.com), copy it verbatim into this field. Do NOT invent, guess, or construct a link from an address; omit the field when no real link is present.
+        - address: the venue's physical/postal address when the email or attachment contains one (hotel or Airbnb address for a stay, restaurant address, activity venue, the airport or terminal for a flight-as-activity). Applies to every kind, since they are all physical locations. Copy the address text as written; omit or use empty string when the source gives no address.
+        - google_maps_link: if the email or attachment contains an explicit Google Maps URL for the location (maps.app.goo.gl, goo.gl/maps, google.com/maps, maps.google.com), copy it verbatim into this field. Do NOT invent, guess, or construct a link from an address. The device builds the map link from the address field automatically, so focus on getting the address text right and leave google_maps_link empty unless a real link is present in the source.
 
         Be conservative. A wrong auto-add is worse than a miss — when the destination or dates are ambiguous, add nothing and explain in one sentence.
         \(contextBlock)

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -792,12 +792,22 @@ struct ExecuteDraftAction {
                 endTimeValue = parseWallClockTime(dict["end_time"]?.stringValue)
             }
 
-            // Optional Google Maps link. A bare/empty value or the "null"
-            // sentinel both store as empty (the UI still offers a search
-            // fallback). We don't validate the URL here.
+            // Optional postal address. A bare/empty value or the "null"
+            // sentinel both store as empty.
+            let addressRaw = (dict["address"]?.stringValue ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let address = addressRaw == "null" ? "" : addressRaw
+
+            // Google Maps link. An explicit link from the email always wins.
+            // When the email carried none, build and STORE a search link from
+            // the venue name + address so the item's map field is populated
+            // (not just derived at render time). We don't validate the URL.
             let mapsRaw = (dict["google_maps_link"]?.stringValue ?? "")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            let mapsLink = mapsRaw == "null" ? "" : mapsRaw
+            let explicitMapsLink = mapsRaw == "null" ? "" : mapsRaw
+            let mapsLink = explicitMapsLink.isEmpty
+                ? (LocalItineraryItem.googleMapsSearchURL(name: title, address: address)?.absoluteString ?? "")
+                : explicitMapsLink
 
             let maxForDay = existing
                 .filter { cal.isDate($0.dayDate, inSameDayAs: dayStart) }
@@ -814,6 +824,7 @@ struct ExecuteDraftAction {
                 endDate: endDateValue,
                 endTime: endTimeValue,
                 sortOrder: maxForDay + 1,
+                address: address,
                 googleMapsLink: mapsLink,
                 createdAt: now,
                 updatedAt: now
@@ -965,6 +976,17 @@ struct ExecuteDraftAction {
                 row.endTime = nil; changed = true
             } else if !trimmed.isEmpty, let parsed = parseWallClockTime(trimmed) {
                 row.endTime = parsed; changed = true
+            }
+        }
+        // address: same empty/"null"/value tri-state as notes. Empty = keep,
+        // "null" = clear, anything else = set. The map link is derived from
+        // this at render time (LocalItineraryItem.mapsURL).
+        if let raw = input["address"]?.stringValue {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == "null" {
+                row.address = ""; changed = true
+            } else if !trimmed.isEmpty {
+                row.address = trimmed; changed = true
             }
         }
         // google_maps_link: same empty/"null"/value tri-state as notes.

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -302,9 +302,13 @@ enum ToolDefinitions {
                 "type": .string("string"),
                 "description": .string("STAY ONLY, OPTIONAL: check-out time as a full ISO 8601 datetime with timezone (e.g., 2026-06-17T11:00:00-04:00). The DATE portion MUST match end_date. Set this when the user mentions a check-out time; otherwise omit.")
             ]),
+            "address": .object([
+                "type": .string("string"),
+                "description": .string("OPTIONAL postal address / location text for this item as it appears in the booking (e.g. the hotel, Airbnb, restaurant, or activity venue address). Used to locate the place on a map. The device builds the map link from this automatically, so extract the address text accurately. Omit or use empty string if none.")
+            ]),
             "google_maps_link": .object([
                 "type": .string("string"),
-                "description": .string("OPTIONAL Google Maps URL for the location (e.g., https://maps.app.goo.gl/abc or https://www.google.com/maps/place/...). Extract it ONLY if the source explicitly contains one; do NOT invent or guess a link. Omit (or use empty string) when there is no link.")
+                "description": .string("OPTIONAL Google Maps URL for the location (e.g., https://maps.app.goo.gl/abc or https://www.google.com/maps/place/...). Extract it ONLY if the source explicitly contains one; do NOT invent or guess a link (the device derives one from address instead). Omit (or use empty string) when there is no link.")
             ])
         ]),
         "required": .array([.string("day_date"), .string("kind"), .string("title"), .string("notes")])
@@ -362,7 +366,7 @@ enum ToolDefinitions {
 
     private static let editItineraryItem = AnthropicTool(
         name: "edit_itinerary_item",
-        description: "Edit an EXISTING itinerary item's day, kind, title, notes, start time, (for stays) check-out date / time, or Google Maps link. Requires the item UUID. IMPORTANT: At least one field must actually change. Use empty string for fields to keep unchanged. Use the literal string \"null\" for notes, start_time, end_date, end_time, or google_maps_link to CLEAR them. day_date, kind, and title cannot be cleared.",
+        description: "Edit an EXISTING itinerary item's day, kind, title, notes, start time, (for stays) check-out date / time, address, or Google Maps link. Requires the item UUID. IMPORTANT: At least one field must actually change. Use empty string for fields to keep unchanged. Use the literal string \"null\" for notes, start_time, end_date, end_time, address, or google_maps_link to CLEAR them. day_date, kind, and title cannot be cleared.",
         input_schema: object(
             properties: [
                 "id": string("The UUID of the existing itinerary item to edit (from EXISTING TRIPS context)."),
@@ -373,6 +377,7 @@ enum ToolDefinitions {
                 "start_time": string("New start time as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T19:00:00-04:00). The date portion should match day_date. Use empty string to keep unchanged, or the literal \"null\" to clear (make the item untimed)."),
                 "end_date": string("STAY ONLY: new check-out date in ISO 8601 (e.g., 2026-06-17). Must be > day_date. Use empty string to keep unchanged, or the literal \"null\" to clear."),
                 "end_time": string("STAY ONLY: new check-out time as a full ISO 8601 datetime with timezone (e.g., 2026-06-17T11:00:00-04:00). The date portion should match end_date. Use empty string to keep unchanged, or the literal \"null\" to clear."),
+                "address": string("New postal address / location text for the location (e.g. hotel or restaurant address). The device builds the map link from this automatically. Use empty string to keep unchanged, or the literal \"null\" to clear."),
                 "google_maps_link": string("New Google Maps URL for the location. Use empty string to keep unchanged, or the literal \"null\" to clear.")
             ],
             required: ["id", "day_date", "kind", "title", "notes"]

--- a/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
@@ -154,22 +154,55 @@ final class LocalItineraryItem {
         set { kind = newValue.rawValue }
     }
 
-    /// `true` when a real maps link has been stored. The maps pin only renders
-    /// for items where this is true: no link means no pin (and no fallback
-    /// search).
+    /// `true` when an explicit maps link has been stored. Distinct from
+    /// `mapsURL != nil`, which is also true when the URL is derived from
+    /// `address` (see below): this stays `false` for address-only items.
     var hasExplicitMapsLink: Bool {
-        mapsURL != nil
+        explicitMapsURL != nil
     }
 
     /// The stored Google Maps URL, coercing a bare host (e.g.
     /// "maps.app.goo.gl/…") into an https URL. `nil` when no link is saved or
-    /// the stored string can't form a URL.
-    var mapsURL: URL? {
+    /// the stored string can't form a URL. This is the explicit link only; it
+    /// does NOT fall back to `address` (that's `mapsURL`).
+    private var explicitMapsURL: URL? {
         let stored = googleMapsLink.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !stored.isEmpty else { return nil }
         if let url = URL(string: stored), url.scheme != nil {
             return url
         }
         return URL(string: "https://\(stored)")
+    }
+
+    /// A tappable maps URL for this item, used to render the "MAP" chip.
+    /// Prefers the explicit `googleMapsLink` when present; otherwise DERIVES a
+    /// Google Maps search URL from the title + `address`. This keeps a working
+    /// map pin for any item that has an address but no stored link (e.g. items
+    /// created before the link was persisted). `nil` only when there is no
+    /// explicit link and no address.
+    var mapsURL: URL? {
+        if let explicit = explicitMapsURL { return explicit }
+        return Self.googleMapsSearchURL(name: title, address: address)
+    }
+
+    /// Builds a Google Maps *search* URL that resolves to a specific place,
+    /// combining the place name with the address so Google lands on the named
+    /// venue (e.g. "207 Inn, Via Nazionale, Rome") rather than just the street.
+    /// Returns `nil` when there is NO address: a bare title (e.g. "Lunch",
+    /// "Free day") is not a reliable map target, so an item with no real
+    /// location gets no link — and therefore no MAP chip. Dependency-free: no
+    /// geocoding, no API call, no location permission.
+    static func googleMapsSearchURL(name: String, address: String) -> URL? {
+        let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedAddress.isEmpty else { return nil }
+        let query = [name.trimmingCharacters(in: .whitespacesAndNewlines), trimmedAddress]
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+        var components = URLComponents(string: "https://www.google.com/maps/search/")
+        components?.queryItems = [
+            URLQueryItem(name: "api", value: "1"),
+            URLQueryItem(name: "query", value: query)
+        ]
+        return components?.url
     }
 }

--- a/mobile/PersonalDashboard/Services/AddressGeocoder.swift
+++ b/mobile/PersonalDashboard/Services/AddressGeocoder.swift
@@ -1,0 +1,108 @@
+import Foundation
+import CoreLocation
+
+/// Forward-geocodes a postal address into an exact coordinate, entirely with
+/// free, built-in iOS APIs — no Google Maps Platform key, no billing, and no
+/// location permission (`CLGeocoder`'s forward direction geocodes an arbitrary
+/// address string; it does NOT require `CLLocationManager` authorization).
+///
+/// The mirror image of `MapsLinkResolver`, which reverse-geocodes a coordinate
+/// into an address. This one goes address -> coordinate, then builds a Google
+/// Maps *pin* URL (`?api=1&query=<lat>,<lng>`) that lands on an exact point
+/// rather than a name+address search that Google has to re-resolve.
+///
+/// Everything degrades to `nil`: any error, empty result, rate-limit, or a
+/// slow geocode past the timeout returns `nil` so the caller can keep the
+/// existing search link untouched. Nothing throws.
+struct AddressGeocoder {
+
+    /// How long a single forward-geocode may run before we give up. Apple's
+    /// geocoder is a shared, rate-limited network service; a slow one must not
+    /// stall the ~22s email-capture budget, so we cap each request.
+    private let timeout: TimeInterval
+
+    init(timeout: TimeInterval = 6) {
+        self.timeout = timeout
+    }
+
+    /// Forward-geocode an address to a coordinate. Prefers the ADDRESS string
+    /// (Apple's geocoder is address-oriented; a bare POI name confuses it).
+    /// When the address alone yields nothing and a venue `name` is available,
+    /// retries once with "name, address". Returns `nil` on any failure.
+    func resolveCoordinate(address: String, name: String? = nil) async -> CLLocationCoordinate2D? {
+        let trimmedAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedAddress.isEmpty else { return nil }
+
+        if let coordinate = await geocode(trimmedAddress) {
+            return coordinate
+        }
+
+        // Retry with the venue name prepended — helps when the raw address is
+        // partial (e.g. "Via Nazionale 207, Rome" missing a house-level pin).
+        if let name = name?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            let combined = "\(name), \(trimmedAddress)"
+            if combined != trimmedAddress, let coordinate = await geocode(combined) {
+                return coordinate
+            }
+        }
+
+        return nil
+    }
+
+    /// Builds a Google Maps *pin* URL from an exact coordinate:
+    /// `https://www.google.com/maps/search/?api=1&query=<lat>,<lng>`.
+    /// Sits alongside `LocalItineraryItem.googleMapsSearchURL` (same host and
+    /// `?api=1&query=` shape) so the two link forms stay consistent — the only
+    /// difference is the `query` value is a coordinate, not a name+address.
+    /// Lat/lng are formatted to 6 decimals with an `en_US_POSIX` locale so the
+    /// device locale can never substitute a comma for the decimal separator.
+    static func pinURL(for coordinate: CLLocationCoordinate2D) -> URL? {
+        let lat = posixDecimal(coordinate.latitude)
+        let lng = posixDecimal(coordinate.longitude)
+        var components = URLComponents(string: "https://www.google.com/maps/search/")
+        components?.queryItems = [
+            URLQueryItem(name: "api", value: "1"),
+            URLQueryItem(name: "query", value: "\(lat),\(lng)")
+        ]
+        return components?.url
+    }
+
+    // MARK: - Geocoding
+
+    /// One forward-geocode with a hard timeout. `CLGeocoder`'s only async
+    /// entry point is the completion-handler API, so we wrap it in a
+    /// continuation and race it against `Task.sleep`. On timeout we cancel the
+    /// in-flight geocode and return `nil`. Any thrown error (network failure,
+    /// `.geocodeFoundNoResult`, `.geocodeCanceled`, rate-limit) also -> `nil`.
+    private func geocode(_ addressString: String) async -> CLLocationCoordinate2D? {
+        let geocoder = CLGeocoder()
+        return await withTaskGroup(of: CLLocationCoordinate2D?.self) { group in
+            group.addTask {
+                await withCheckedContinuation { continuation in
+                    geocoder.geocodeAddressString(addressString) { placemarks, _ in
+                        continuation.resume(returning: placemarks?.first?.location?.coordinate)
+                    }
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(self.timeout * 1_000_000_000))
+                return nil
+            }
+
+            // First task to finish wins. If the timeout returns first, cancel
+            // the outstanding geocode so it can't leak past the deadline.
+            let result = await group.next() ?? nil
+            group.cancelAll()
+            geocoder.cancelGeocode()
+            return result
+        }
+    }
+
+    // MARK: - Formatting
+
+    /// Fixed 6-decimal formatting with a POSIX locale — guarantees a `.` decimal
+    /// separator regardless of the device's regional settings.
+    private static func posixDecimal(_ value: Double) -> String {
+        String(format: "%.6f", locale: Locale(identifier: "en_US_POSIX"), value)
+    }
+}


### PR DESCRIPTION
## Summary
Booking emails forwarded to the itinerary pipeline now capture a location and get a tappable MAP chip, and trip-matching no longer drops bookings that straddle a trip's edge.

- **#169** — Extract the venue address into a structured field when parsing booking emails, and store a Google Maps link so location-bearing items (stay/check-in-check-out, activity, place, restaurant) show a tappable MAP chip. Explicit maps URLs in the email are used verbatim.
- **#172** — Match bookings that straddle a trip's edge (a hotel's last night checking out the morning after the trip ends, or an arrival hotel the night before) via date overlap + a ~1-day grace instead of strict containment. Fixes the 207 Inn / Rome booking being skipped against a Sep 1-11 Italy trip.
- **#174** — Upgrade the link to an exact-coordinate pin on-device via Apple `CLGeocoder` (free, no API key, no billing, no location permission), falling back to a name+address search link when geocoding is unavailable. Idempotent: re-scans don't re-geocode already-resolved pins.
- MAP chip only shows when an item has a real location (an explicit link or a non-empty address), never from a bare title.

## Notes
- No SwiftData model field changes (`address`/`googleMapsLink` already existed) — no migration risk.
- No new secrets; the paid Places API route (#173) was closed in favour of the free on-device geocoder.
- `CLGeocoder` shows an iOS 26 deprecation warning (MapKit is the successor); it still functions and matches the existing `MapsLinkResolver` usage. Migrating both to `MKGeocodingRequest` is a sensible future follow-up.

Closes #169
Closes #172
Closes #174

## Test plan
Device QA on iPhone 16 Pro Max (iOS 26), confirmed by the user:
- [x] Booking email with a plain-text address (207 Inn, Rome) matches the Italy trip and adds a stay with a working MAP chip.
- [x] Address populates on the item detail sheet.
- [x] Map link resolves to an exact pin at the venue.
- [x] Title-only activities (no address/link) no longer show a MAP chip.
- [x] Re-scan backfills address without creating duplicates.
- [x] Clean static build (`xcodebuild`) on top of current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)