### PR TITLE
feat(ios): attach emailed receipts, zoomable receipt viewer, trim recent activity

### DIFF
--- a/mobile/PersonalDashboard/AI/EmailToItinerary.swift
+++ b/mobile/PersonalDashboard/AI/EmailToItinerary.swift
@@ -143,6 +143,14 @@ struct EmailToItinerary {
         // and stamped with dedupeKey/sourceReference/tripUUID after execution.
         var addedExpenseUUIDs: [UUID] = []
         var skippedExpenseDuplicates = 0
+        // Receipt attachment linkage (#180). We attach the best available
+        // asset (image preferred, else first PDF) to the FIRST expense actually
+        // created this run. Saved lazily inside `handleExpenseCall` right before
+        // stamping, so a run that creates NO new expense (all deduped / nothing
+        // to log) never writes an orphan file. Once set, later expenses in the
+        // same run don't get a second copy — one receipt, one link.
+        let receiptAsset = Self.bestReceiptAsset(from: message.attachments)
+        var receiptAttached = false
         // Existing rows reconcile-updated in place on the explicit Re-scan
         // (#165). Deduped so the same row updated by two proposed items in one
         // run is counted once.
@@ -184,6 +192,8 @@ struct EmailToItinerary {
                     let block = await handleExpenseCall(
                         call: call,
                         confirmation: confirmation,
+                        receiptAsset: receiptAsset,
+                        receiptAttached: &receiptAttached,
                         addedExpenseUUIDs: &addedExpenseUUIDs,
                         skippedExpenseDuplicates: &skippedExpenseDuplicates
                     )
@@ -392,6 +402,8 @@ struct EmailToItinerary {
     private func handleExpenseCall(
         call: (id: String, name: String, input: [String: AnthropicJSONValue]),
         confirmation: String,
+        receiptAsset: ReceiptAsset?,
+        receiptAttached: inout Bool,
         addedExpenseUUIDs: inout [UUID],
         skippedExpenseDuplicates: inout Int
     ) async -> AnthropicContentBlock {
@@ -423,6 +435,18 @@ struct EmailToItinerary {
                     reference: proposed.sourceReference,
                     store: store
                 )
+                // #180: attach the forwarded receipt to the FIRST newly-created
+                // expense only. Saved lazily here (not before the loop) so a
+                // run that creates no new expense writes no orphan file. If the
+                // save succeeds but the stamp can't find the row, the file is
+                // deleted so we never leak an unreferenced receipt.
+                if !receiptAttached, let asset = receiptAsset {
+                    receiptAttached = Self.attachReceipt(
+                        asset: asset,
+                        toExpense: expenseUUID,
+                        store: store
+                    )
+                }
             }
             return .toolResult(
                 toolUseId: call.id,
@@ -467,6 +491,76 @@ struct EmailToItinerary {
             originalCurrency: currency,
             sourceReference: reference
         )
+    }
+
+    // MARK: - Receipt attachment (#180)
+
+    /// The receipt asset chosen from an email's attachments: the raw bytes plus
+    /// whether they're a PDF (so `attachReceipt` picks the right save path).
+    struct ReceiptAsset {
+        let data: Data
+        let isPDF: Bool
+    }
+
+    /// Pick the best receipt asset from an email's attachments. Prefer an image
+    /// (image/*) since it renders inline and compresses cleanly for the viewer;
+    /// otherwise fall back to the first PDF. Calendar (.ics) and everything else
+    /// are ignored. Returns nil when there's nothing attachable.
+    private static func bestReceiptAsset(from attachments: [EmailMessage.Attachment]) -> ReceiptAsset? {
+        if let image = attachments.first(where: { $0.isImage }) {
+            return ReceiptAsset(data: image.data, isPDF: false)
+        }
+        if let pdf = attachments.first(where: { $0.isPDF }) {
+            return ReceiptAsset(data: pdf.data, isPDF: true)
+        }
+        return nil
+    }
+
+    /// Save the receipt asset to `ReceiptStorage` and stamp its relative path
+    /// onto the given expense's `receiptImagePath`. Returns true only when both
+    /// the save AND the stamp succeeded (so the caller flips `receiptAttached`
+    /// and no later expense in the run gets a second copy).
+    ///
+    /// Orphan safety: if the file is written but the expense row can't be found
+    /// to stamp it, the file is deleted so we never leak an unreferenced
+    /// receipt. A save failure returns false and writes nothing.
+    private static func attachReceipt(
+        asset: ReceiptAsset,
+        toExpense expenseUUID: UUID,
+        store: SwiftDataStore
+    ) -> Bool {
+        let receiptStore = ReceiptStorage.shared
+        let relativePath: String
+        do {
+            relativePath = asset.isPDF
+                ? try receiptStore.save(pdfData: asset.data)
+                // Images are normalised to a compressed JPEG (same pipeline as
+                // camera captures) so the viewer + any future Vision use stay
+                // within Anthropic's size limits.
+                : try receiptStore.saveCompressedJpeg(receiptStore.compress(imageData: asset.data))
+        } catch {
+            NSLog("EmailToItinerary: receipt save failed: %@", error.localizedDescription)
+            return false
+        }
+
+        let key = expenseUUID.uuidString.lowercased()
+        guard let row = try? store.context.fetch(
+            FetchDescriptor<LocalExpense>(predicate: #Predicate { $0.clientUUID == key })
+        ).first else {
+            // Couldn't find the row we just created — clean up the orphan file.
+            NSLog("EmailToItinerary: expense row not found for receipt stamp; deleting orphan")
+            try? receiptStore.delete(relativePath: relativePath)
+            return false
+        }
+        row.receiptImagePath = relativePath
+        do {
+            try store.context.save()
+        } catch {
+            NSLog("EmailToItinerary: receipt stamp save failed: %@", error.localizedDescription)
+            try? receiptStore.delete(relativePath: relativePath)
+            return false
+        }
+        return true
     }
 
     /// Stamp the dedupe signature + normalised reference onto a just-created

--- a/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
+++ b/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import SwiftData
+import PDFKit
+import UIKit
 
 /// Editor target for the AddExpense / EditExpense sheet.
 ///
@@ -565,12 +567,20 @@ struct ReceiptThumbnailImage: View {
 }
 
 /// Full-screen receipt viewer. Sheet presented from AddExpenseSheet when
-/// the user taps the thumbnail. For PDFs we point Quick Look-style at the
-/// file URL via `PDFKit` would be ideal, but the simpler `Link`-to-URL
-/// flow isn't available inside a sheet; we render a placeholder with the
-/// filename instead and link the user out to Files for a real preview
-/// when needed. Images render full-size with pinch-to-zoom via the
-/// built-in `ScrollView` + `magnification`.
+/// the user taps the thumbnail.
+///
+/// Both branches are UIKit-backed for a native, smooth zoom that doesn't
+/// fight the sheet's own gestures:
+///  - Images: a `UIScrollView` + `UIImageView` with `viewForZooming`, so
+///    pinch-to-zoom, drag-to-pan-while-zoomed, and double-tap-to-toggle
+///    (fit ↔ 2.5×) all come from the platform. Fixed hand-rolled gesture
+///    math would jank and clip; the scroll view gets it right for free.
+///  - PDFs: a `PDFView` with `autoScales = true`, which gives native
+///    pinch-zoom and page scrolling.
+///
+/// Branch is chosen by the receipt's file extension (.pdf ⇒ PDF viewer).
+/// State resets on every present because the viewer is rebuilt each time
+/// the sheet opens (the `UIViewRepresentable`s make fresh views).
 struct ReceiptFullViewer: View {
     let relativePath: String
 
@@ -580,16 +590,7 @@ struct ReceiptFullViewer: View {
         NavigationStack {
             ZStack {
                 Tokens.paper.ignoresSafeArea()
-                if relativePath.lowercased().hasSuffix(".pdf") {
-                    pdfNote
-                } else if let url = ReceiptStorage.shared.load(relativePath: relativePath),
-                          let image = UIImage(contentsOfFile: url.path) {
-                    imageViewer(image)
-                } else {
-                    Text("Receipt is no longer available.")
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.muted)
-                }
+                content
             }
             .navigationTitle("Receipt")
             .navigationBarTitleDisplayMode(.inline)
@@ -602,28 +603,177 @@ struct ReceiptFullViewer: View {
         }
     }
 
-    private func imageViewer(_ image: UIImage) -> some View {
-        ScrollView([.horizontal, .vertical], showsIndicators: false) {
-            Image(uiImage: image)
-                .resizable()
-                .scaledToFit()
-                .padding()
+    @ViewBuilder
+    private var content: some View {
+        if let url = ReceiptStorage.shared.load(relativePath: relativePath) {
+            if relativePath.lowercased().hasSuffix(".pdf") {
+                PDFKitView(url: url)
+                    .ignoresSafeArea(edges: .bottom)
+            } else if let image = UIImage(contentsOfFile: url.path) {
+                ZoomableImageView(image: image)
+                    .ignoresSafeArea(edges: .bottom)
+            } else {
+                unavailable
+            }
+        } else {
+            unavailable
         }
     }
 
-    private var pdfNote: some View {
-        VStack(spacing: Space.md) {
-            Image(systemName: "doc.text.fill")
-                .font(.system(size: 44, weight: .regular))
-                .foregroundStyle(Tokens.accentFinance)
-            Text("PDF attached")
-                .font(.edHeading)
-                .foregroundStyle(Tokens.ink)
-            Text("Open the expense's source app to view this PDF in full.")
-                .font(.edSubheadline)
-                .foregroundStyle(Tokens.muted)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, Space.xl)
+    private var unavailable: some View {
+        Text("Receipt is no longer available.")
+            .font(.edBody)
+            .foregroundStyle(Tokens.muted)
+    }
+}
+
+// MARK: - Zoomable image (UIScrollView-backed)
+
+/// A `UIScrollView` wrapping a `UIImageView`, exposing native pinch-to-zoom,
+/// pan-while-zoomed, and double-tap-to-toggle. `viewForZooming` is what makes
+/// the scroll view drive the zoom; the image is centred in `layoutSubviews`
+/// so it stays anchored while fit and while zoomed out.
+private struct ZoomableImageView: UIViewRepresentable {
+    let image: UIImage
+
+    func makeUIView(context: Context) -> CenteringScrollView {
+        let scrollView = CenteringScrollView()
+        scrollView.delegate = context.coordinator
+        scrollView.backgroundColor = .clear
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.bouncesZoom = true
+        // Minimum is set to fit in `updateZoomScales`; start at 1.0.
+        scrollView.minimumZoomScale = 1.0
+        scrollView.maximumZoomScale = 5.0
+
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFit
+        imageView.isUserInteractionEnabled = true
+        scrollView.imageView = imageView
+        scrollView.addSubview(imageView)
+
+        // Double-tap toggles between fit and a comfortable zoom.
+        let doubleTap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleDoubleTap(_:))
+        )
+        doubleTap.numberOfTapsRequired = 2
+        scrollView.addGestureRecognizer(doubleTap)
+
+        return scrollView
+    }
+
+    func updateUIView(_ uiView: CenteringScrollView, context: Context) {
+        // No dynamic props to sync; the image is fixed for the viewer's life.
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator: NSObject, UIScrollViewDelegate {
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            (scrollView as? CenteringScrollView)?.imageView
+        }
+
+        func scrollViewDidZoom(_ scrollView: UIScrollView) {
+            (scrollView as? CenteringScrollView)?.centerImage()
+        }
+
+        @objc func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
+            guard let scrollView = recognizer.view as? CenteringScrollView else { return }
+            if scrollView.zoomScale > scrollView.minimumZoomScale + 0.01 {
+                // Zoomed in → reset to fit.
+                scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
+            } else {
+                // At fit → zoom toward the tapped point.
+                let target = min(scrollView.minimumZoomScale * 2.5, scrollView.maximumZoomScale)
+                let point = recognizer.location(in: scrollView.imageView)
+                let size = scrollView.bounds.size
+                let w = size.width / target
+                let h = size.height / target
+                let rect = CGRect(x: point.x - w / 2, y: point.y - h / 2, width: w, height: h)
+                scrollView.zoom(to: rect, animated: true)
+            }
+        }
+    }
+}
+
+/// A `UIScrollView` that keeps its single `imageView` sized to fit and
+/// centred. The minimum zoom scale is the aspect-fit scale, so "fit" is the
+/// true zoomed-out state and pinch-out never leaves dead space. Recomputes on
+/// bounds changes (rotation, sheet resize).
+private final class CenteringScrollView: UIScrollView {
+    var imageView: UIImageView?
+    private var lastBoundsSize: CGSize = .zero
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Recompute fit only when the bounds actually change, so a zoom
+        // (which triggers layout) doesn't clobber the user's current scale.
+        if bounds.size != lastBoundsSize {
+            lastBoundsSize = bounds.size
+            configureForFit()
+        }
+        centerImage()
+    }
+
+    /// Size the image view to the image's natural size, set the content size,
+    /// and derive the aspect-fit scale as the minimum zoom (and initial zoom).
+    private func configureForFit() {
+        guard let imageView, let image = imageView.image, bounds.width > 0, bounds.height > 0 else { return }
+        let imageSize = image.size
+        guard imageSize.width > 0, imageSize.height > 0 else { return }
+
+        imageView.frame = CGRect(origin: .zero, size: imageSize)
+        contentSize = imageSize
+
+        let scaleW = bounds.width / imageSize.width
+        let scaleH = bounds.height / imageSize.height
+        let fitScale = min(scaleW, scaleH)
+
+        minimumZoomScale = fitScale
+        maximumZoomScale = max(fitScale * 5, fitScale)
+        zoomScale = fitScale
+    }
+
+    /// Keep the image centred when it's smaller than the viewport (fit /
+    /// zoomed-out), and pinned to the edges once it overflows (zoomed-in).
+    func centerImage() {
+        guard let imageView else { return }
+        let boundsSize = bounds.size
+        var frame = imageView.frame
+        frame.origin.x = frame.width < boundsSize.width
+            ? (boundsSize.width - frame.width) / 2
+            : 0
+        frame.origin.y = frame.height < boundsSize.height
+            ? (boundsSize.height - frame.height) / 2
+            : 0
+        imageView.frame = frame
+    }
+}
+
+// MARK: - PDF (PDFKit-backed)
+
+/// A `PDFView` with `autoScales = true`, which gives native pinch-zoom,
+/// page scrolling, and a fit-to-width initial layout. Loaded from the
+/// on-disk receipt URL.
+private struct PDFKitView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> PDFView {
+        let pdfView = PDFView()
+        pdfView.autoScales = true
+        pdfView.displayMode = .singlePageContinuous
+        pdfView.displayDirection = .vertical
+        pdfView.backgroundColor = .clear
+        pdfView.document = PDFDocument(url: url)
+        return pdfView
+    }
+
+    func updateUIView(_ uiView: PDFView, context: Context) {
+        if uiView.document == nil {
+            uiView.document = PDFDocument(url: url)
         }
     }
 }

--- a/mobile/PersonalDashboard/Views/Settings/EmailInboxView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/EmailInboxView.swift
@@ -205,7 +205,7 @@ struct EmailInboxView: View {
                     .padding(Space.lg)
             } else {
                 VStack(spacing: 0) {
-                    ForEach(Array(logEntries.prefix(30).enumerated()), id: \.element.clientUUID) { index, entry in
+                    ForEach(Array(logEntries.prefix(10).enumerated()), id: \.element.clientUUID) { index, entry in
                         if index > 0 { divider }
                         logRow(entry)
                     }


### PR DESCRIPTION
Summary
- Recent Activity email log now shows only the 10 most recent entries (#179)
- Email-parsed expenses persist the emailed receipt (image as compressed JPEG, PDF as-is) and link it via the existing receiptImagePath, reusing ReceiptStorage. Saved lazily on new-expense success with orphan cleanup so a deduped re-forward never leaves a stray file. No schema migration (#180)
- Receipt viewer: replaced the fixed-size scroll with pinch-to-zoom, drag-to-pan and double-tap zoom for images (UIScrollView-backed), plus a PDFKit viewer for PDF receipts (#181)

Closes #179
Closes #180
Closes #181

Test plan
- [x] Clean static build (xcodegen generate + xcodebuild) — BUILD SUCCEEDED
- [x] Installed to device and QA confirmed by user on all three surfaces: Recent Activity capped at 10; image receipt pinch/pan/double-tap zoom; PDF receipt renders and zooms; forwarded receipt email attaches a viewable receipt to the resulting expense

🤖 Generated with [Claude Code](https://claude.com/claude-code)