### PR TITLE
feat(ios): split an expense N ways and record only my share

### DIFF
--- a/mobile/PersonalDashboard/AI/ChatDraft.swift
+++ b/mobile/PersonalDashboard/AI/ChatDraft.swift
@@ -193,12 +193,21 @@ extension ChatDraft {
             headline = categoryName
         }
 
-        let amountString = String(format: "%@ %.2f", cleanedCurrency, amount)
-        // Base line: headline · amount [· category], skipping the category
-        // when it's already the headline.
+        // Split shares (#188). `amount` from the model is the FULL receipt
+        // total; the stored expense is the user's equal share. Preview the
+        // share (what actually lands) and annotate the fraction.
+        let shares = max(dict["number_of_shares"]?.intValue
+            ?? Int(dict["number_of_shares"]?.stringValue ?? "")
+            ?? 1, 1)
+        let displayAmount = amount / Double(shares)
+
+        let amountString = String(format: "%@ %.2f", cleanedCurrency, displayAmount)
+        let shareSuffix = shares > 1 ? " (your 1/\(shares) share)" : ""
+        // Base line: headline · amount[ (your 1/N share)] [· category],
+        // skipping the category when it's already the headline.
         var line = headline == categoryName
-            ? "\(headline) · \(amountString)"
-            : "\(headline) · \(amountString) · \(categoryName)"
+            ? "\(headline) · \(amountString)\(shareSuffix)"
+            : "\(headline) · \(amountString)\(shareSuffix) · \(categoryName)"
 
         // Person / Event tags (#183) so the confirm card shows what the
         // expense was tagged with before the user commits.

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -131,6 +131,18 @@ struct ExecuteDraftAction {
         let personName = trimmedString(input["person_name"])
         let eventName = trimmedString(input["event_name"])
 
+        // Optional split shares (#188). The model emits the FULL receipt total
+        // in `original_amount` plus a share count; we store the user's equal
+        // share (total / shares). Tolerate a JSON int, double, or numeric
+        // string; clamp to >= 1 so a missing / bogus value behaves as unsplit.
+        let numberOfShares = max(
+            input["number_of_shares"]?.intValue
+                ?? Int(input["number_of_shares"]?.stringValue ?? "")
+                ?? 1,
+            1
+        )
+        let shareAmount = originalAmount / Double(numberOfShares)
+
         // Optional UUID override from the tool input. If the model emitted
         // a valid UUID we use it; otherwise we generate one.
         let providedID = trimmedString(input["id"])
@@ -147,7 +159,7 @@ struct ExecuteDraftAction {
         let fx = FXService(store: store)
         let conversion: (sgdAmount: Double, rate: Double)
         do {
-            conversion = try await fx.convert(originalAmount, from: currency)
+            conversion = try await fx.convert(shareAmount, from: currency)
         } catch {
             throw DraftExecutionError.invalidArgument(
                 field: "original_currency",
@@ -163,12 +175,13 @@ struct ExecuteDraftAction {
                 category: category,
                 merchant: merchant,
                 expenseDescription: descriptionField,
-                originalAmount: originalAmount,
+                originalAmount: shareAmount,
                 originalCurrency: currency,
                 sgdAmount: conversion.sgdAmount,
                 fxRate: conversion.rate,
                 paymentMethod: paymentMethod,
                 source: source,
+                numberOfShares: numberOfShares,
                 clientUUID: clientUUID
             )
         } catch {

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -401,7 +401,7 @@ enum ToolDefinitions {
     /// picks based on merchant + description.
     private static let addExpense = AnthropicTool(
         name: "add_expense",
-        description: "Log a NEW expense. Use this when the user says they spent money (e.g., \"I spent $20 on lunch at Starbucks\", \"add a 67 SGD grocery run yesterday\"). Pick the best-fitting category from the enum. If currency isn't specified, default to SGD. Date defaults to today if the user doesn't say. If the user names a person the expense is for/with (\"dinner with Sarah\") set person_name, and if they name an occasion or trip it belongs to (\"for the Bali trip\") set event_name — reuse the EXACT existing names from the PEOPLE / EVENTS context when they refer to one already there, so you don't create near-duplicates.",
+        description: "Log a NEW expense. Use this when the user says they spent money (e.g., \"I spent $20 on lunch at Starbucks\", \"add a 67 SGD grocery run yesterday\"). Pick the best-fitting category from the enum. If currency isn't specified, default to SGD. Date defaults to today if the user doesn't say. If the user names a person the expense is for/with (\"dinner with Sarah\") set person_name, and if they name an occasion or trip it belongs to (\"for the Bali trip\") set event_name — reuse the EXACT existing names from the PEOPLE / EVENTS context when they refer to one already there, so you don't create near-duplicates. If the user says the bill was split among several people (e.g., \"split 3 ways\", \"between the 4 of us\"), set number_of_shares to that count and pass the FULL receipt total in original_amount — the app records only the user's share.",
         input_schema: object(
             properties: [
                 "id": string("UUID string for the new expense. Generate a fresh one for every call (any valid lowercase UUID, e.g., 9b3a8e1c-2f6f-4a3b-9d2c-7e0a1b4c5d6e)."),
@@ -418,7 +418,11 @@ enum ToolDefinitions {
                 "source": string("How this expense was captured. Use \"receipt\" ONLY when logging from a forwarded purchase/receipt email; leave empty otherwise. Allowed values: manual, text, voice, photo, receipt, pdf, recurring."),
                 "trip_id": string("UUID of the EXISTING trip this expense belongs to, when (and only when) it is a travel fare for a trip in the EXISTING TRIPS context (e.g., a flight or hotel charge). Use empty string for any non-travel purchase."),
                 "person_name": string("Name of the person this expense is for or with (e.g., \"Sarah\"), when the user names one. Reuse the exact name from the PEOPLE context if it already exists. Use empty string if none."),
-                "event_name": string("Name of the occasion, group, or trip this expense belongs to (e.g., \"Bali trip\", \"Diwali gifts\"), when the user names one. Reuse the exact name from the EVENTS context if it already exists. Use empty string if none.")
+                "event_name": string("Name of the occasion, group, or trip this expense belongs to (e.g., \"Bali trip\", \"Diwali gifts\"), when the user names one. Reuse the exact name from the EVENTS context if it already exists. Use empty string if none."),
+                "number_of_shares": .object([
+                    "type": .string("integer"),
+                    "description": .string("How many people the bill was split among, when the user says it was shared (e.g. \"split 3 ways\" => 3). When set, original_amount MUST be the FULL receipt total — the app stores only the user's equal share (total / number_of_shares). Omit or use 1 for a normal unshared expense.")
+                ])
             ],
             required: ["id", "date", "category", "merchant", "description", "original_amount", "original_currency", "payment_method"]
         )

--- a/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
@@ -104,6 +104,18 @@ final class LocalExpense {
     var eventUUID: UUID? = nil
     var eventName: String? = nil
 
+    // MARK: - Split shares (#188)
+    //
+    // How many people the bill was split among. When > 1 this row's
+    // `originalAmount` / `sgdAmount` already hold the USER'S SHARE (receipt
+    // total ÷ shares, computed once at save time), so every aggregation site
+    // keeps reading `sgdAmount` and stays correct without change. The full
+    // receipt total for display is derived: `originalAmount * numberOfShares`.
+    // Additive with a default of 1 so the SwiftData migration on existing
+    // installs stays lightweight (add-with-default, never remove) and every
+    // existing call site behaves exactly as before (unsplit = 1 share).
+    var numberOfShares: Int = 1
+
     // MARK: - Dead-field parity with other LocalModels
     //
     // These are intentionally unused on Phase A. Kept so that the SwiftData
@@ -134,6 +146,7 @@ final class LocalExpense {
         personName: String? = nil,
         eventUUID: UUID? = nil,
         eventName: String? = nil,
+        numberOfShares: Int = 1,
         needsSync: Bool = false,
         version: Int = 0
     ) {
@@ -158,6 +171,7 @@ final class LocalExpense {
         self.personName = personName
         self.eventUUID = eventUUID
         self.eventName = eventName
+        self.numberOfShares = numberOfShares
         self.needsSync = needsSync
         self.version = version
     }
@@ -170,5 +184,25 @@ final class LocalExpense {
 
     var sourceEnum: ExpenseSource {
         ExpenseSource(rawValue: source) ?? .manual
+    }
+
+    /// Whether this expense was split among more than one person (#188).
+    var isSplit: Bool {
+        numberOfShares > 1
+    }
+
+    /// The full receipt total in the original currency, derived from the
+    /// stored per-share `originalAmount`. Cosmetic rounding is accepted on
+    /// uneven splits (e.g. 100 / 3 shows ≈ 99.99). Never stored — always
+    /// recomputed from `originalAmount * numberOfShares`.
+    var receiptTotalOriginal: Double {
+        originalAmount * Double(max(numberOfShares, 1))
+    }
+
+    /// The full receipt total in SGD, derived from the frozen per-share
+    /// `sgdAmount`. Used for the split badge so the displayed total matches
+    /// the home-currency figures elsewhere on the row.
+    var receiptTotalSGD: Double {
+        sgdAmount * Double(max(numberOfShares, 1))
     }
 }

--- a/mobile/PersonalDashboard/Services/ExpenseService.swift
+++ b/mobile/PersonalDashboard/Services/ExpenseService.swift
@@ -93,6 +93,7 @@ struct ExpenseService {
         personName: String? = nil,
         eventUUID: UUID? = nil,
         eventName: String? = nil,
+        numberOfShares: Int = 1,
         clientUUID: String? = nil
     ) throws -> LocalExpense {
         guard originalAmount > 0 else { throw ExpenseServiceError.invalidAmount }
@@ -114,7 +115,8 @@ struct ExpenseService {
             personUUID: personUUID,
             personName: personName?.trimmedNonEmpty,
             eventUUID: eventUUID,
-            eventName: eventName?.trimmedNonEmpty
+            eventName: eventName?.trimmedNonEmpty,
+            numberOfShares: max(numberOfShares, 1)
         )
         store.context.insert(row)
         try save()
@@ -138,7 +140,8 @@ struct ExpenseService {
         fxRate: Double? = nil,
         paymentMethod: String? = nil,
         person: ExpenseTag?? = nil,
-        event: ExpenseTag?? = nil
+        event: ExpenseTag?? = nil,
+        numberOfShares: Int? = nil
     ) throws {
         if let date {
             expense.date = Calendar.current.startOfDay(for: date)
@@ -178,6 +181,12 @@ struct ExpenseService {
         if let event {
             expense.eventUUID = event?.uuid
             expense.eventName = event?.name.trimmedNonEmpty
+        }
+        // Split shares (#188). Clamp to >= 1; the caller passes the stored
+        // per-share `originalAmount` / `sgdAmount` alongside, so no re-division
+        // happens here — the sheet computes the share before calling update.
+        if let numberOfShares {
+            expense.numberOfShares = max(numberOfShares, 1)
         }
         try save()
     }

--- a/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
+++ b/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
@@ -48,6 +48,11 @@ struct AddExpenseSheet: View {
     @State private var showingPersonPicker: Bool = false
     @State private var showingEventPicker: Bool = false
 
+    /// How many people the bill is split among (#188). The amount field holds
+    /// the RECEIPT TOTAL; on save we divide by this to get the stored per-share
+    /// amount. Default 1 = not split. Clamped to 1...50 by the stepper.
+    @State private var numberOfShares: Int = 1
+
     /// Where this expense will be tagged as having come from. Defaults to
     /// `.manual` for `.new`; carried over from the existing row on edit;
     /// set by `PrefilledExpense.source` on prefill.
@@ -87,6 +92,12 @@ struct AddExpenseSheet: View {
         Double(amountText.replacingOccurrences(of: ",", with: ".")) ?? 0
     }
 
+    /// The user's per-person share of the entered receipt total (#188). This
+    /// is what gets stored as `originalAmount`. Equal-split only in v1.
+    private var perShareValue: Double {
+        amountValue / Double(max(numberOfShares, 1))
+    }
+
     private var canSave: Bool {
         amountValue > 0 && !saving
     }
@@ -118,6 +129,7 @@ struct AddExpenseSheet: View {
                         }
                         personField
                         eventField
+                        sharesField
 
                         if let errorMessage {
                             Text(errorMessage)
@@ -444,6 +456,81 @@ struct AddExpenseSheet: View {
         )
     }
 
+    // MARK: - Split shares (#188)
+
+    /// A stepper for how many people the bill is split among, plus a live
+    /// "Your share" readout so the user sees exactly what will be stored
+    /// before saving. The amount field holds the receipt total; the stored
+    /// expense is `total ÷ shares`. Sits below Person / Event because it's the
+    /// same "who was this with" mental model — the split follows the people.
+    private var sharesField: some View {
+        VStack(alignment: .leading, spacing: Space.fieldLabelGap) {
+            HStack {
+                Text("Split").eyebrow()
+                Spacer()
+                Text("Optional")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            VStack(alignment: .leading, spacing: Space.sm) {
+                HStack(spacing: Space.sm) {
+                    Image(systemName: "person.2")
+                        .font(.system(size: 14, weight: .regular))
+                        .foregroundStyle(Tokens.accentFinance)
+                        .frame(width: 24)
+                    Text(numberOfShares == 1 ? "Not split" : "Split \(numberOfShares) ways")
+                        .font(.edBody)
+                        .foregroundStyle(numberOfShares == 1 ? Tokens.inkSoft : Tokens.ink)
+                    Spacer()
+                    Stepper(
+                        "",
+                        value: $numberOfShares,
+                        in: 1...50
+                    )
+                    .labelsHidden()
+                    .tint(Tokens.accentFinance)
+                }
+
+                if numberOfShares > 1 {
+                    shareReadout
+                }
+            }
+            .padding(Space.md)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(numberOfShares == 1 ? "Split: not split" : "Split \(numberOfShares) ways")
+    }
+
+    /// "Your share: CUR X of CUR Y" line shown only when the bill is split.
+    /// Amounts are in the entered currency (pre-FX) so it reads back exactly
+    /// what the user typed divided by the number of people.
+    private var shareReadout: some View {
+        let cur = currency.uppercased()
+        return HStack(spacing: 4) {
+            Text("Your share:")
+                .font(.edCaption)
+                .foregroundStyle(Tokens.muted)
+            Text("\(cur) \(formatShare(perShareValue))")
+                .font(.edCaption)
+                .monospacedDigit()
+                .foregroundStyle(Tokens.ink)
+            Text("of \(cur) \(formatShare(amountValue))")
+                .font(.edCaption)
+                .monospacedDigit()
+                .foregroundStyle(Tokens.mutedSoft)
+        }
+    }
+
+    private func formatShare(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value)
+    }
+
     /// Shared "tappable field that opens a picker" row for Person / Event.
     /// Shows the selected name (or a placeholder), a chevron, and a clear
     /// button when a value is set.
@@ -524,7 +611,12 @@ struct AddExpenseSheet: View {
                 predicate: #Predicate { $0.clientUUID == uuid }
             )
             if let existing = try? modelContext.fetch(descriptor).first {
-                amountText = formatAmountForEdit(existing.originalAmount)
+                // Shares first: the stored `originalAmount` is the per-share
+                // figure, so we reconstruct the RECEIPT TOTAL for the field
+                // (share × shares) — consistent with what the user typed on
+                // entry. Save() re-divides by shares to store the share again.
+                numberOfShares = max(existing.numberOfShares, 1)
+                amountText = formatAmountForEdit(existing.receiptTotalOriginal)
                 currency = existing.originalCurrency
                 category = existing.categoryEnum
                 date = existing.date
@@ -590,9 +682,16 @@ struct AddExpenseSheet: View {
         let fx = FXService(store: store)
         let service = ExpenseService(store: store)
 
+        // The amount field holds the RECEIPT TOTAL; the user's SHARE is what
+        // we store (#188). Divide first, then FX-convert the share so
+        // `originalAmount` / `sgdAmount` are already the per-person figure and
+        // every aggregation site stays correct without change. Equal split only.
+        let shares = max(numberOfShares, 1)
+        let shareAmount = amountValue / Double(shares)
+
         let conversion: (sgdAmount: Double, rate: Double)
         do {
-            conversion = try await fx.convert(amountValue, from: currency)
+            conversion = try await fx.convert(shareAmount, from: currency)
         } catch {
             errorMessage = "Couldn't convert \(currency) to SGD. Try again when online."
             return
@@ -606,7 +705,7 @@ struct AddExpenseSheet: View {
                     category: category,
                     merchant: merchant,
                     expenseDescription: descriptionField,
-                    originalAmount: amountValue,
+                    originalAmount: shareAmount,
                     originalCurrency: currency,
                     sgdAmount: conversion.sgdAmount,
                     fxRate: conversion.rate,
@@ -615,7 +714,8 @@ struct AddExpenseSheet: View {
                     personUUID: selectedPerson?.uuid,
                     personName: selectedPerson?.name,
                     eventUUID: selectedEvent?.uuid,
-                    eventName: selectedEvent?.name
+                    eventName: selectedEvent?.name,
+                    numberOfShares: shares
                 )
                 // ExpenseService.addExpense doesn't take receiptImagePath
                 // (Phase A signature). Set it directly and save again — the
@@ -636,13 +736,14 @@ struct AddExpenseSheet: View {
                         category: category,
                         merchant: merchant,
                         expenseDescription: descriptionField,
-                        originalAmount: amountValue,
+                        originalAmount: shareAmount,
                         originalCurrency: currency,
                         sgdAmount: conversion.sgdAmount,
                         fxRate: conversion.rate,
                         paymentMethod: paymentMethod,
                         person: .some(selectedPerson),
-                        event: .some(selectedEvent)
+                        event: .some(selectedEvent),
+                        numberOfShares: shares
                     )
                     // Persist receipt-path / source changes (e.g. user
                     // removed the image, or scan path → manual edit).

--- a/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
+++ b/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
@@ -46,8 +46,8 @@ struct ExpenseRow: View {
                     .font(.edCaption)
                     .foregroundStyle(Tokens.mutedSoft)
                 }
-                if hasTags {
-                    tagBadges
+                if hasBadges {
+                    badgeRow
                 }
             }
 
@@ -89,6 +89,19 @@ struct ExpenseRow: View {
         personLabel != nil || eventLabel != nil
     }
 
+    /// Whether any badge (person, event, or split) should render on the
+    /// secondary badge row.
+    private var hasBadges: Bool {
+        hasTags || expense.isSplit
+    }
+
+    /// Split badge label, e.g. "1/3 of SGD 90.00" (#188). Shows the user's
+    /// fraction of the derived receipt total in SGD so it lines up with the
+    /// primary SGD amount above it.
+    private var splitLabel: String {
+        "1/\(expense.numberOfShares) of \(FinanceDashboardBand.formatSGD(expense.receiptTotalSGD))"
+    }
+
     /// The tagged person's chip colour, resolved from the live person record
     /// (matched by FK, falling back to name). Defaults to the finance accent
     /// if the person was deleted but its denormalised name survives on the row.
@@ -104,7 +117,7 @@ struct ExpenseRow: View {
         return Tokens.accentFinance
     }
 
-    private var tagBadges: some View {
+    private var badgeRow: some View {
         HStack(spacing: Space.xs) {
             if let personLabel {
                 PersonEventBadge(kind: .person, label: personLabel, tint: personTint)
@@ -112,7 +125,29 @@ struct ExpenseRow: View {
             if let eventLabel {
                 PersonEventBadge(kind: .event, label: eventLabel)
             }
+            if expense.isSplit {
+                splitBadge
+            }
         }
+    }
+
+    /// Split badge (#188). Same capsule shape as `PersonEventBadge` but muted
+    /// (it's a factual annotation, not a colour-coded tag), with a split-bill
+    /// glyph and the "your share of receipt total" label.
+    private var splitBadge: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "person.2.fill")
+                .font(.system(size: 9, weight: .semibold))
+            Text(splitLabel)
+                .font(.edCaption)
+                .monospacedDigit()
+                .lineLimit(1)
+        }
+        .foregroundStyle(Tokens.muted)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(Tokens.muted.opacity(0.12), in: Capsule())
+        .accessibilityLabel("Split \(expense.numberOfShares) ways, your \(splitLabel)")
     }
 
     private var primaryLine: String {
@@ -167,6 +202,7 @@ struct ExpenseRow: View {
         }
         if let personLabel { pieces.append("for \(personLabel)") }
         if let eventLabel { pieces.append("event \(eventLabel)") }
+        if expense.isSplit { pieces.append("split \(expense.numberOfShares) ways, your \(splitLabel)") }
         return pieces.joined(separator: ", ") + ". Tap to edit."
     }
 }


### PR DESCRIPTION
## Summary
- Add a **number of shares** field to expenses so a bill split among several people records only the user's fraction of it.
- New `numberOfShares: Int = 1` on `LocalExpense` (additive, default 1 → SwiftData lightweight migration is safe; existing rows read as 1 share and behave exactly as before).
- `originalAmount`/`sgdAmount` continue to store the **user's share** (receipt total ÷ shares), computed once at save time — so every existing aggregation (month total, category bars, 30-day sparkline, AI context) keeps working unchanged and reflects real spend. Receipt total is derived for display (`share × shares`).
- Add/edit sheet: a **Split** stepper next to Person/Event with a live "Your share: CUR X of CUR Y" readout.
- Expense row: muted **"1/3 of SGD 90.00"** badge when split (renders alongside #190's statement caption).
- `add_expense` AI tool gains an optional `number_of_shares`; chat/email capture divides the receipt total before storing and the chat preview annotates "(your 1/N share)".
- v1 assumes an **equal split**; uneven splits are out of scope.

Rebased onto latest `main` (#190 statement-import + finance UX); one `ExpenseRow` conflict resolved to keep both the statement caption and the split badge.

Closes #188

## Test plan
- [x] Clean build (`xcodegen generate` + `xcodebuild`, simulator) — no errors/warnings in changed files.
- [x] Shipped to device and QA'd on-device by the author.
  - [x] $90 expense, 3 shares → records $30; month total +$30, not +$90.
  - [x] Row shows $30 with "1/3 of SGD 90.00" badge.
  - [x] Edit reconstructs the receipt total ($90) with stepper at 3.
  - [x] Shares = 1 behaves identically to today (regression-safe).
  - [x] Chat "add a $60 dinner split 4 ways" records $15.
  - [x] Split badge and #190 statement caption coexist without crowding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)