### PR TITLE
feat(ios): "all caught up" empty state on Tasks page

### DIFF
--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -179,11 +179,75 @@ struct TasksView: View {
         }
     }
 
+    // MARK: - All caught up
+
+    /// Celebratory empty state shown when every open task is complete but the
+    /// Completed section still holds rows. Without this, `taskGroups` renders
+    /// only the Completed header's hairline + collapsed toggle — a floating
+    /// line with nothing above it that reads as broken. Reuses the inline-draft
+    /// mechanism (`startDraft(in: .noDate)`) for the quick-add affordance, so
+    /// tapping it seeds an undated task via the same path as every other
+    /// section's tap-below.
+    @ViewBuilder
+    private var allCaughtUpRow: some View {
+        VStack(spacing: Space.lg) {
+            // Celebratory block — matches the shared empty-state template
+            // (icon 28pt / muted, .edHeading / ink).
+            VStack(spacing: Space.md) {
+                Image(systemName: "checkmark.seal")
+                    .font(.system(size: 28, weight: .regular))
+                    .foregroundStyle(Tokens.muted)
+                Text("All caught up")
+                    .font(.edHeading)
+                    .foregroundStyle(Tokens.ink)
+                    .multilineTextAlignment(.center)
+            }
+
+            // Quick-add: reuses the inline-draft flow. Tapping flips
+            // draftBucket to .noDate, which hides this state (draftBucket != nil)
+            // and surfaces the DraftTaskRow inside the "No Date" section below.
+            Button {
+                startDraft(in: .noDate)
+            } label: {
+                HStack(spacing: Space.xs) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text("Add a task")
+                        .font(.edBodyMedium)
+                }
+                .foregroundStyle(Tokens.muted)
+                .padding(.vertical, Space.sm)
+                .padding(.horizontal, Space.md)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Add a task")
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.top, Space.xxxl)
+        .padding(.horizontal, Space.lg)
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
+        .listRowInsets(EdgeInsets())
+    }
+
     // MARK: - Grouped tasks
 
     @ViewBuilder
     private var taskGroups: some View {
         let buckets = computeBuckets()
+        // Every open bucket empty, no inline draft in flight, but completed
+        // tasks remain → show the celebratory "all caught up" state above the
+        // Completed section. Guarded on completed being non-empty; the
+        // genuinely-empty case is handled by the body's `todos.isEmpty` branch.
+        let hasOpenTasks = !buckets.overdue.isEmpty
+            || !buckets.today.isEmpty
+            || !buckets.thisWeek.isEmpty
+            || !buckets.later.isEmpty
+            || !buckets.noDate.isEmpty
+        if !hasOpenTasks && draftBucket == nil && !buckets.completed.isEmpty {
+            allCaughtUpRow
+        }
         // Overdue: no tap-below (adding a new overdue task is incoherent).
         if !buckets.overdue.isEmpty {
             taskSection(title: "Overdue", count: buckets.overdue.count, accent: Tokens.danger, soft: Tokens.dangerSoft, todos: buckets.overdue, bucket: nil)


### PR DESCRIPTION
## Summary
- Adds a centered "all caught up" empty state on the Tasks page for when every task is completed
- Previously that case fell through to rendering only the Completed section's hairline + collapsed toggle: a floating line with nothing above it, which read as broken
- The new state shows a checkmark badge, an "All caught up" heading, and an inline "Add a task" affordance that reuses the existing inline-draft flow (seeds an undated task)
- Untouched: the fully-empty state, loading state, and the mixed active + completed grouped view

Closes #192

## Test plan
- [x] Clean `xcodebuild` (simulator, `CODE_SIGNING_ALLOWED=NO`)
- [x] Shipped to device; QA'd on Flightmode 2.0
- [x] Complete all tasks → "All caught up" state renders above Completed, no bare floating line
- [x] Tap "Add a task" → inline draft appears, new task lands as active, empty state clears
- [x] Mixed active + completed view unchanged
- [x] Zero tasks → original "No tasks yet" state still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)