### PR TITLE
feat(ios): read long task/list items and complete/dismiss inline edits

### DIFF
--- a/mobile/PersonalDashboard/Design/Keyboard.swift
+++ b/mobile/PersonalDashboard/Design/Keyboard.swift
@@ -19,6 +19,22 @@ extension View {
     func dismissKeyboardOnTap() -> some View {
         modifier(DismissKeyboardOnTapModifier())
     }
+
+    /// Imperatively resigns the first responder, dismissing whatever `TextField`
+    /// / `TextEditor` is currently focused. Callable from tap handlers on neutral
+    /// chrome (headers, count strips, add bars) so tapping them commits an
+    /// in-progress inline edit uniformly: every editable row and draft commits on
+    /// focus loss via its own `.onChange(of:)`, so resigning first responder here
+    /// routes through those commit paths without the parent needing per-row focus
+    /// state. Wraps the same `sendAction` idiom used inline elsewhere.
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+    }
 }
 
 private struct DismissKeyboardOnTapModifier: ViewModifier {

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -315,7 +315,9 @@ private struct ListDetailContent: View {
                 .padding(.top, Space.lg)
                 .padding(.bottom, Space.sm)
                 .contentShape(Rectangle())
-                .onTapGesture { if draftActive { draftFocused = false } }
+                // Tapping the header strip commits any in-progress edit: draftFocused = false
+                // covers the tap-below draft; hideKeyboard() covers a focused item row.
+                .onTapGesture { draftFocused = false; hideKeyboard() }
 
                 Rectangle().fill(Tokens.divider).frame(height: 0.5)
                     .padding(.horizontal, Space.lg)
@@ -387,19 +389,25 @@ private struct ListDetailContent: View {
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
                         }
-                        // Tap-below zone, always rendered:
-                        // - no draft → tap to start a draft.
-                        // - draft active → tap to dismiss the draft (resigns focus → commitDraft via onChange).
+                        // Add strip — one row-height tap target right after the last item.
+                        // Tapping here starts a new item (or dismisses an active draft).
                         Color.clear
-                            .frame(minHeight: 200)
+                            .frame(height: 44)
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                if draftActive {
-                                    draftFocused = false
-                                } else {
-                                    startDraft()
-                                }
+                                if draftActive { draftFocused = false; hideKeyboard() }
+                                else { startDraft() }
                             }
+                            .listRowBackground(Tokens.paper)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(EdgeInsets())
+
+                        // Dismiss filler — the rest of the empty space below. Tapping here only
+                        // commits/deselects the current inline edit (or draft); it never adds.
+                        Color.clear
+                            .frame(minHeight: 160)
+                            .contentShape(Rectangle())
+                            .onTapGesture { draftFocused = false; hideKeyboard() }
                             .listRowBackground(Tokens.paper)
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets())
@@ -411,10 +419,11 @@ private struct ListDetailContent: View {
                 .scrollDismissesKeyboard(.interactively)
 
                 addItemBar(list: list)
-                    // Tapping the addItemBar while a draft is active dismisses the draft.
+                    // Tapping the addItemBar commits any in-progress edit: draftFocused = false
+                    // covers the tap-below draft; hideKeyboard() covers a focused item row.
                     // simultaneousGesture fires alongside the inner TextField tap so the
                     // bar's own text field can still receive focus normally.
-                    .simultaneousGesture(TapGesture().onEnded { if draftActive { draftFocused = false } })
+                    .simultaneousGesture(TapGesture().onEnded { draftFocused = false; hideKeyboard() })
             }
             .sheet(item: $editingItem) { editing in
                 // Guard against a stale index if the list mutated while the sheet
@@ -575,7 +584,11 @@ private struct ItemRow: View {
 
     var body: some View {
         HStack(spacing: Space.md) {
-            Button(action: onToggle) {
+            // Empty Button action: the high-priority tap gesture below is the single
+            // source of the toggle. This guarantees one toggle per tap even while the
+            // inline field is focused (iOS's "first tap dismisses keyboard" would
+            // otherwise eat a plain row/Button tap).
+            Button(action: {}) {
                 ZStack {
                     Circle()
                         .stroke(item.checked ? Tokens.success : Tokens.borderStrong, lineWidth: 2)
@@ -590,7 +603,7 @@ private struct ItemRow: View {
                 .frame(width: 24, height: 24)
             }
             .buttonStyle(.plain)
-            .disabled(isEditing)
+            .highPriorityGesture(TapGesture().onEnded { handleToggle() })
 
             if isEditing {
                 TextField("", text: $draft)
@@ -683,6 +696,13 @@ private struct ItemRow: View {
         }
         isEditing = false
         focused = false
+    }
+
+    /// Single-tap toggle. If the row is mid inline-edit, persist any rename first
+    /// (commit ends editing), then always toggle checked state.
+    private func handleToggle() {
+        if isEditing { commit() }
+        onToggle()
     }
 }
 

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -47,7 +47,9 @@ struct TasksView: View {
                     Color.clear
                         .frame(height: 96)
                         .contentShape(Rectangle())
-                        .onTapGesture { if draftBucket != nil { draftFocused = false } }
+                        // Commit any in-progress edit: draftFocused = false covers the
+                        // tap-below draft; hideKeyboard() covers a focused task row.
+                        .onTapGesture { draftFocused = false; hideKeyboard() }
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                         .listRowInsets(EdgeInsets())
@@ -416,9 +418,10 @@ struct TasksView: View {
                 .padding(.top, Space.md)
                 .padding(.bottom, Space.xs)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                // Dismiss draft alongside the expand/collapse toggle so keyboard
-                // collapses when the user taps the Completed header.
-                .simultaneousGesture(TapGesture().onEnded { if draftBucket != nil { draftFocused = false } })
+                // Commit any in-progress edit alongside the expand/collapse toggle so the
+                // keyboard collapses when the user taps the Completed header: draftFocused = false
+                // covers the tap-below draft; hideKeyboard() covers a focused task row.
+                .simultaneousGesture(TapGesture().onEnded { draftFocused = false; hideKeyboard() })
             }
             .background(Tokens.paper)
         }
@@ -443,9 +446,10 @@ struct TasksView: View {
         .padding(.bottom, Space.xs)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Tokens.paper)
-        // Tapping a section header while a draft is active dismisses the draft.
+        // Tapping a section header commits any in-progress edit: draftFocused = false
+        // covers the tap-below draft; hideKeyboard() covers a focused task row.
         .contentShape(Rectangle())
-        .onTapGesture { if draftBucket != nil { draftFocused = false } }
+        .onTapGesture { draftFocused = false; hideKeyboard() }
     }
 
     private func placeholderRow(_ text: String) -> some View {
@@ -522,7 +526,11 @@ private struct TaskRow: View {
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Space.md) {
-            Button(action: onToggle) {
+            // Empty Button action: the high-priority tap gesture below is the single
+            // source of the toggle. This guarantees one toggle per tap even while the
+            // inline field is focused (iOS's "first tap dismisses keyboard" would
+            // otherwise eat a plain row/Button tap).
+            Button(action: {}) {
                 ZStack {
                     Circle()
                         .stroke(todo.completed ? Tokens.success : Tokens.borderStrong, lineWidth: 2)
@@ -537,6 +545,7 @@ private struct TaskRow: View {
                 .frame(width: 24, height: 24)
             }
             .buttonStyle(.plain)
+            .highPriorityGesture(TapGesture().onEnded { handleToggle() })
             // Map the circle's center (with a 4pt body-font offset for x-height) to the
             // firstTextBaseline so the bullet visually centers on the title's first line.
             .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
@@ -669,6 +678,13 @@ private struct TaskRow: View {
         }
         guard !trimmed.isEmpty, trimmed != todo.title else { return }
         onTitleCommit(trimmed)
+    }
+
+    /// Single-tap toggle. If the row is mid inline-edit, persist any rename first
+    /// (commitInlineEdit ends editing), then always toggle completion.
+    private func handleToggle() {
+        if isEditing { commitInlineEdit() }
+        onToggle()
     }
 
     private func dueColor(for date: Date) -> Color {


### PR DESCRIPTION
## Summary
- Display-mode task/list titles wrap to full width, so long items are readable without entering edit mode.
- A single tap on the checkbox completes an item even while its text field is focused. Lists no longer disables the checkbox during rename; both surfaces toggle via a high-priority tap that commits any inline edit first.
- Tapping a neutral area (header strip, section/completed headers, add bar, empty space below the last item) commits and deselects the current edit via a global resign-first-responder helper in `Design/Keyboard.swift`.
- The Lists tap-below area is split into a one-row add strip plus a dismiss filler, so only the row-space right after the last item adds a new item; everywhere else below just deselects.

Closes #194

## Test plan
- Device QA on iPhone covering both Tasks and Lists. Evidence and ticked acceptance criteria in the #194 QA comment.