### PR TITLE
feat(ios): show list item count once per Lists row

### DIFF
--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -235,22 +235,12 @@ private struct ListSummaryRow: View {
                     .font(.edBodyMedium)
                     .foregroundStyle(Tokens.ink)
                 Spacer()
-                HStack(spacing: 4) {
-                    Image(systemName: "number")
-                        .font(.system(size: 10, weight: .regular))
-                    Text("\(total)")
-                }
-                .font(.edCaption)
-                .foregroundStyle(Tokens.muted)
-                .padding(.horizontal, Space.sm)
-                .padding(.vertical, 2)
-                .background(Tokens.paper2, in: Capsule())
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(Tokens.mutedSoft)
             }
             if total > 0 {
-                HStack(spacing: 4) {
+                HStack(spacing: Space.xs) {
                     GeometryReader { geo in
                         ZStack(alignment: .leading) {
                             Capsule().fill(Tokens.paper2).frame(height: 4)
@@ -263,6 +253,7 @@ private struct ListSummaryRow: View {
                     Text("\(completed)/\(total)")
                         .font(.edCaption)
                         .foregroundStyle(Tokens.muted)
+                        .monospacedDigit()
                 }
             } else {
                 Text("Empty")


### PR DESCRIPTION
## Summary
- Each populated Lists row previously showed the item total twice: a `#N` capsule badge on the title line and the `completed/total` label beside the progress bar.
- Removes the `#N` badge (a bare total with no context and the noisiest element in the row); keeps `completed/total`, which is the progress bar's legend and still carries the total.
- Title line is now just title + chevron.
- Adds `.monospacedDigit()` to the count label so numerals hold a stable width down the list; tokenizes the progress HStack spacing (`4` -> `Space.xs`, value-identical).
- Empty lists (`total == 0`) continue to show `Empty` with no count chip.

## Test plan
- [x] Clean static build: `xcodegen generate` + `xcodebuild ... build` -> BUILD SUCCEEDED
- [x] Installed to device (iPhone 16 Pro Max) and QA'd on the Lists page
- [x] Count shows once per row; empty state shows `Empty`; card, progress bar, and swipe-to-delete unchanged

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)