### PR TITLE
feat(ios): surface itinerary and finance additions in Activity

### DIFF
--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -89,9 +89,9 @@ struct StatementImporter {
     /// (`StatementExtractionError`); per-line insert failures are caught and
     /// counted in the result, never propagated, so one bad row can't sink the
     /// whole import.
-    func importStatement(pdfData: Data) async throws -> StatementImportResult {
+    func importStatement(pdfData: Data, fileName: String? = nil) async throws -> StatementImportResult {
         let (lines, meta, truncated) = try await anthropic.extractStatement(pdfData: pdfData)
-        return await insert(lines: lines, meta: meta, possiblyTruncated: truncated)
+        return await insert(lines: lines, meta: meta, fileName: fileName, possiblyTruncated: truncated)
     }
 
     /// Bucket + insert already-parsed lines. Split out from `importStatement`
@@ -106,6 +106,7 @@ struct StatementImporter {
     func insert(
         lines: [ExtractedStatementLine],
         meta: ExtractedStatementMeta = ExtractedStatementMeta(issuer: nil, last4: nil, statementMonth: nil, statementYear: nil),
+        fileName: String? = nil,
         possiblyTruncated: Bool
     ) async -> StatementImportResult {
         var imported = 0
@@ -121,6 +122,7 @@ struct StatementImporter {
         // inserted this run (#189). Both are "" when the header couldn't be
         // read, in which case we write nothing rather than a placeholder.
         let statementLabel = meta.attributionLabel
+        let statementFileName = (fileName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let cardLabel = meta.cardLabel
         let paymentMethod = cardLabel.isEmpty ? nil : cardLabel
 
@@ -198,6 +200,10 @@ struct StatementImporter {
                 // Statement attribution (#189): which statement this came off.
                 // Display-only — deliberately NOT part of the dedupe signature.
                 row.statementLabel = statementLabel
+                // File name of the imported PDF (#198). Collapses the whole
+                // statement into a single Activity row titled by its file name,
+                // even when the header couldn't be parsed (empty statementLabel).
+                row.statementFileName = statementFileName
                 try? store.context.save()
 
                 imported += 1

--- a/mobile/PersonalDashboard/Models/ActivityItem.swift
+++ b/mobile/PersonalDashboard/Models/ActivityItem.swift
@@ -10,6 +10,15 @@ struct ActivityItem: Identifiable, Equatable {
         case todo
         case list
         case folder
+        /// One `LocalItineraryItem`. Deep-links into its owning trip.
+        case itinerary
+        /// One standalone `LocalExpense` (manual / chat / voice / photo /
+        /// email receipt). Deep-links into Finance.
+        case expense
+        /// A collapsed PDF statement import: many `LocalExpense` rows sharing a
+        /// `statementLabel` render as ONE row so a single upload doesn't
+        /// explode the feed. Deep-links into Finance.
+        case statement
     }
 
     let id: UUID
@@ -24,5 +33,42 @@ struct ActivityItem: Identifiable, Equatable {
     /// Original creation timestamp for day-grouping and "1h ago" rendering.
     let createdAt: Date
 
-    var rowKey: String { "\(type.rawValue)-\(id.uuidString)" }
+    /// Deep-link target for `.itinerary` rows: the `LocalTrip.clientUUID` the
+    /// tapped item belongs to. The Activity tap handler routes to Itineraries
+    /// and focuses this trip. `nil` for every other type.
+    let tripUUID: UUID?
+
+    /// Stable identity token for rows that don't map 1:1 to a single entity.
+    /// `.statement` rows collapse many `LocalExpense`s sharing a
+    /// `statementLabel` into one row, so their identity is the label rather
+    /// than any single expense UUID. `nil` for every 1:1 row (which key off
+    /// `id`). Keeps `rowKey` unique + stable across recomputes of the feed.
+    let groupKey: String?
+
+    init(
+        id: UUID,
+        type: ItemType,
+        title: String,
+        snippet: String?,
+        parent: String?,
+        sortDate: Date,
+        createdAt: Date,
+        tripUUID: UUID? = nil,
+        groupKey: String? = nil
+    ) {
+        self.id = id
+        self.type = type
+        self.title = title
+        self.snippet = snippet
+        self.parent = parent
+        self.sortDate = sortDate
+        self.createdAt = createdAt
+        self.tripUUID = tripUUID
+        self.groupKey = groupKey
+    }
+
+    var rowKey: String {
+        if let groupKey { return "\(type.rawValue)-\(groupKey)" }
+        return "\(type.rawValue)-\(id.uuidString)"
+    }
 }

--- a/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
@@ -86,6 +86,16 @@ final class LocalExpense {
     // the same statement is treated as a duplicate.
     var statementLabel: String = ""
 
+    // The name of the PDF file this row was imported from, e.g.
+    // "Citi_May2026.pdf". Populated ONLY by the statement-import path; empty for
+    // every other source and for rows imported before this field existed. Used
+    // to collapse a whole statement into a single Activity row titled by its
+    // file name (#198). Additive with a default so the SwiftData migration on
+    // existing installs stays lightweight (add-with-default, never remove) and
+    // every existing call site is unaffected. Display-only — never part of the
+    // dedupe signature.
+    var statementFileName: String = ""
+
     // MARK: - Person / Event tags (#183)
     //
     // Two optional groupings any expense can carry: a Person ("who was this
@@ -142,6 +152,7 @@ final class LocalExpense {
         sourceReference: String = "",
         tripUUID: UUID? = nil,
         statementLabel: String = "",
+        statementFileName: String = "",
         personUUID: UUID? = nil,
         personName: String? = nil,
         eventUUID: UUID? = nil,
@@ -167,6 +178,7 @@ final class LocalExpense {
         self.sourceReference = sourceReference
         self.tripUUID = tripUUID
         self.statementLabel = statementLabel
+        self.statementFileName = statementFileName
         self.personUUID = personUUID
         self.personName = personName
         self.eventUUID = eventUUID

--- a/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
+++ b/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
@@ -10,35 +10,44 @@ import SwiftData
 /// confirm) updates the feed automatically without a pull-to-refresh.
 struct ActivityView: View {
     enum Filter: Equatable, CaseIterable, Identifiable {
-        case all, note, todo, list, folder
+        case all, note, todo, list, folder, trips, finance
 
         var id: String {
             switch self {
-            case .all:    return "all"
-            case .note:   return "note"
-            case .todo:   return "todo"
-            case .list:   return "list"
-            case .folder: return "folder"
+            case .all:     return "all"
+            case .note:    return "note"
+            case .todo:    return "todo"
+            case .list:    return "list"
+            case .folder:  return "folder"
+            case .trips:   return "trips"
+            case .finance: return "finance"
             }
         }
 
         var label: String {
             switch self {
-            case .all:    return "All"
-            case .note:   return "Notes"
-            case .todo:   return "Todos"
-            case .list:   return "Lists"
-            case .folder: return "Folders"
+            case .all:     return "All"
+            case .note:    return "Notes"
+            case .todo:    return "Todos"
+            case .list:    return "Lists"
+            case .folder:  return "Folders"
+            case .trips:   return "Trips"
+            case .finance: return "Finance"
             }
         }
 
-        var typeMatch: ActivityItem.ItemType? {
+        /// Whether a given row type belongs under this chip. Finance folds the
+        /// two expense flavours (individual + collapsed statement) into one
+        /// chip; Trips maps to itinerary rows.
+        func includes(_ type: ActivityItem.ItemType) -> Bool {
             switch self {
-            case .all:    return nil
-            case .note:   return .note
-            case .todo:   return .todo
-            case .list:   return .list
-            case .folder: return .folder
+            case .all:     return true
+            case .note:    return type == .note
+            case .todo:    return type == .todo
+            case .list:    return type == .list
+            case .folder:  return type == .folder
+            case .trips:   return type == .itinerary
+            case .finance: return type == .expense || type == .statement
             }
         }
     }
@@ -56,6 +65,16 @@ struct ActivityView: View {
 
     @Query(filter: #Predicate<LocalNoteFolder> { $0.deletedAt == nil })
     private var folders: [LocalNoteFolder]
+
+    // Expenses and itinerary items are hard-deleted (no `deletedAt` field —
+    // FinanceView / TripDetailView query them the same way), so there are no
+    // soft-deleted rows to exclude. Trips power the itinerary parent-chip
+    // (trip name) + deep-link target lookup.
+    @Query private var expenses: [LocalExpense]
+
+    @Query private var itineraryItems: [LocalItineraryItem]
+
+    @Query private var trips: [LocalTrip]
 
     @State private var filter: Filter = .all
     @State private var visibleCount: Int = pageSize
@@ -219,13 +238,99 @@ struct ActivityView: View {
             ))
         }
 
-        let filtered: [ActivityItem]
-        if let match = filter.typeMatch {
-            filtered = out.filter { $0.type == match }
-        } else {
-            filtered = out
+        // Itinerary items: one row each, parent chip = trip name, deep-link to
+        // the owning trip. Snippet is the kind (+ start time when present).
+        let tripNameByUUID: [UUID: String] = Dictionary(
+            trips.map { ($0.clientUUID, $0.name) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        for item in itineraryItems {
+            let kindLabel = item.kindEnum.displayName
+            let snippet: String? = {
+                guard let start = item.startTime else { return kindLabel }
+                return "\(kindLabel) · \(start.formatted(date: .omitted, time: .shortened))"
+            }()
+            out.append(ActivityItem(
+                id: item.clientUUID,
+                type: .itinerary,
+                title: item.title,
+                snippet: snippet,
+                parent: tripNameByUUID[item.tripUUID],
+                // Activity = when the item was added, like expenses. Using
+                // createdAt (not max with updatedAt) keeps a yesterday booking
+                // from resurfacing at the top of Today when its trip is touched.
+                sortDate: item.createdAt,
+                createdAt: item.createdAt,
+                tripUUID: item.tripUUID
+            ))
         }
 
+        // Expenses. EVERY PDF-source expense collapses into ONE `.statement`
+        // row so a statement upload never explodes the feed — the user only
+        // wants the statement itself, not each parsed line. The group key +
+        // title prefer the imported file name, fall back to the parsed
+        // attribution label, and finally to the import day (rows imported
+        // before file-name capture existed, or statements whose header couldn't
+        // be read, so both fields are empty). Every non-PDF expense (manual /
+        // chat / voice / photo / email receipt) stays an individual `.expense`
+        // row. `groupKey` gives each statement row a stable identity across
+        // feed recomputes.
+        var statementGroups: [String: (title: String, rows: [LocalExpense])] = [:]
+
+        for expense in expenses {
+            if expense.sourceEnum == .pdf {
+                let fileName = expense.statementFileName.trimmingCharacters(in: .whitespacesAndNewlines)
+                let label = expense.statementLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+                let key: String
+                let title: String
+                if !fileName.isEmpty {
+                    key = "file:\(fileName)"; title = fileName
+                } else if !label.isEmpty {
+                    key = "label:\(label)"; title = label
+                } else {
+                    let day = Calendar.current.startOfDay(for: expense.createdAt)
+                    key = "day:\(day.timeIntervalSince1970)"; title = "Statement import"
+                }
+                if statementGroups[key] == nil {
+                    statementGroups[key] = (title, [expense])
+                } else {
+                    statementGroups[key]?.rows.append(expense)
+                }
+                continue
+            }
+            out.append(ActivityItem(
+                id: UUID(uuidString: expense.clientUUID) ?? UUID(),
+                type: .expense,
+                title: expenseTitle(expense),
+                snippet: expenseSnippet(expense),
+                parent: nil,
+                // LocalExpense has no `updatedAt`; createdAt is the only bump.
+                sortDate: expense.createdAt,
+                createdAt: expense.createdAt
+            ))
+        }
+
+        for (key, group) in statementGroups {
+            let rows = group.rows
+            let maxCreated = rows.map(\.createdAt).max() ?? Date()
+            // Representative id = the newest expense in the group (stable across
+            // recomputes); rowKey keys off `key` via groupKey.
+            let representative = rows.max(by: { $0.createdAt < $1.createdAt })
+            let count = rows.count
+            out.append(ActivityItem(
+                id: representative.flatMap { UUID(uuidString: $0.clientUUID) } ?? UUID(),
+                type: .statement,
+                title: group.title,
+                snippet: "\(count) expense\(count == 1 ? "" : "s")",
+                parent: nil,
+                sortDate: maxCreated,
+                createdAt: maxCreated,
+                groupKey: key
+            ))
+        }
+
+        let filtered = out.filter { filter.includes($0.type) }
         return filtered.sorted { $0.sortDate > $1.sortDate }
     }
 
@@ -237,19 +342,55 @@ struct ActivityView: View {
         return Array(all.prefix(visibleCount))
     }
 
+    // MARK: - Expense row text
+
+    /// Title for an individual expense row. Merchant first (task spec); falls
+    /// back to the free-form description, then the category, so a row never
+    /// renders as "Untitled".
+    private func expenseTitle(_ expense: LocalExpense) -> String {
+        if let merchant = expense.merchant?.trimmingCharacters(in: .whitespacesAndNewlines), !merchant.isEmpty {
+            return merchant
+        }
+        if let desc = expense.expenseDescription?.trimmingCharacters(in: .whitespacesAndNewlines), !desc.isEmpty {
+            return desc
+        }
+        return expense.categoryEnum.displayName
+    }
+
+    /// Snippet for an individual expense row: SGD amount + category, matching
+    /// the Finance surface's formatting (`FinanceDashboardBand.formatSGD`).
+    private func expenseSnippet(_ expense: LocalExpense) -> String {
+        "\(FinanceDashboardBand.formatSGD(expense.sgdAmount)) · \(expense.categoryEnum.displayName)"
+    }
+
     // MARK: - Tap → deep-link
 
     private func handleTap(item: ActivityItem) {
-        let target: AppSection
-        let isFolder: Bool
         switch item.type {
-        case .note:   target = .notes; isFolder = false
-        case .todo:   target = .tasks; isFolder = false
-        case .list:   target = .lists; isFolder = false
-        case .folder: target = .notes; isFolder = true
+        case .note:
+            router.focus = ActivityFocus(section: .notes, id: item.id, isFolder: false)
+            router.go(to: .notes)
+        case .todo:
+            router.focus = ActivityFocus(section: .tasks, id: item.id, isFolder: false)
+            router.go(to: .tasks)
+        case .list:
+            router.focus = ActivityFocus(section: .lists, id: item.id, isFolder: false)
+            router.go(to: .lists)
+        case .folder:
+            router.focus = ActivityFocus(section: .notes, id: item.id, isFolder: true)
+            router.go(to: .notes)
+        case .itinerary:
+            // Deep-link into the owning trip. ItinerariesView consumes a
+            // `.itineraries` focus whose id is the trip UUID and opens that
+            // trip's detail. Falls back to the Itineraries root if the trip
+            // can't be resolved.
+            if let tripUUID = item.tripUUID {
+                router.focus = ActivityFocus(section: .itineraries, id: tripUUID, isFolder: false)
+            }
+            router.go(to: .itineraries)
+        case .expense, .statement:
+            router.go(to: .finance)
         }
-        router.focus = ActivityFocus(section: target, id: item.id, isFolder: isFolder)
-        router.go(to: target)
     }
 
     // MARK: - Grouping
@@ -259,9 +400,13 @@ struct ActivityView: View {
         var current: DayGroup?
         let calendar = Calendar.current
         for item in items {
-            // Day-bucket by the visible-row date (createdAt) so the header
-            // matches the "1h ago" / "Yesterday" labels users see.
-            let key = calendar.startOfDay(for: item.createdAt)
+            // Day-bucket by the SAME date the feed is sorted by (sortDate).
+            // Grouping by a different date than the sort produces
+            // non-contiguous day groups that share a `key`; the outer
+            // `ForEach(groups, id: \.key)` then sees duplicate ids and SwiftUI
+            // duplicates / drops rows. Keying on sortDate guarantees contiguous,
+            // uniquely-keyed groups because the list is already sorted by it.
+            let key = calendar.startOfDay(for: item.sortDate)
             if current?.key != key {
                 if let c = current { result.append(c) }
                 current = DayGroup(key: key, items: [item])
@@ -376,9 +521,10 @@ private struct ActivityRow: View {
                                 .lineLimit(1)
                         }
                     }
-                    if item.type == .note, let parent = item.parent, !parent.isEmpty {
+                    if let parent = item.parent, !parent.isEmpty,
+                       item.type == .note || item.type == .itinerary {
                         HStack(spacing: 4) {
-                            Image(systemName: "folder")
+                            Image(systemName: item.type == .itinerary ? "airplane" : "folder")
                                 .font(.system(size: 10))
                             Text(parent)
                                 .lineLimit(1)
@@ -390,10 +536,12 @@ private struct ActivityRow: View {
 
                 Spacer(minLength: Space.sm)
 
-                Text(formatRelative(item.createdAt))
+                // Timestamp mirrors the sort/group key so the row's relative
+                // label always agrees with its day header.
+                Text(formatRelative(item.sortDate))
                     .font(.edCaption)
                     .foregroundStyle(Tokens.mutedSoft)
-                    .accessibilityLabel(formatAbsolute(item.createdAt))
+                    .accessibilityLabel(formatAbsolute(item.sortDate))
             }
             .padding(.horizontal, Space.lg)
             .padding(.vertical, Space.md)
@@ -417,36 +565,48 @@ private struct ActivityRow: View {
 
     private func iconName(for type: ActivityItem.ItemType) -> String {
         switch type {
-        case .note:   return "note.text"
-        case .todo:   return "checkmark.square"
-        case .list:   return "list.bullet"
-        case .folder: return "folder"
+        case .note:      return "note.text"
+        case .todo:      return "checkmark.square"
+        case .list:      return "list.bullet"
+        case .folder:    return "folder"
+        case .itinerary: return "airplane"
+        case .expense:   return "creditcard"
+        case .statement: return "doc.text"
         }
     }
 
     private func iconAccent(for type: ActivityItem.ItemType) -> Color {
         switch type {
-        case .note:   return Tokens.accentNotes
-        case .todo:   return Tokens.accentTasks
-        case .list:   return Tokens.accentLists
-        case .folder: return Tokens.muted
+        case .note:      return Tokens.accentNotes
+        case .todo:      return Tokens.accentTasks
+        case .list:      return Tokens.accentLists
+        case .folder:    return Tokens.muted
+        case .itinerary: return Tokens.accentItineraries
+        case .expense:   return Tokens.accentFinance
+        case .statement: return Tokens.accentFinance
         }
     }
 
     private var accessibilityLabel: String {
         let kind: String
         switch item.type {
-        case .note:   kind = "Note"
-        case .todo:   kind = "Task"
-        case .list:   kind = "List"
-        case .folder: kind = "Folder"
+        case .note:      kind = "Note"
+        case .todo:      kind = "Task"
+        case .list:      kind = "List"
+        case .folder:    kind = "Folder"
+        case .itinerary: kind = "Itinerary item"
+        case .expense:   kind = "Expense"
+        case .statement: kind = "Statement import"
         }
         var parts = ["\(kind) created.", item.title.isEmpty ? "Untitled" : item.title]
         if let s = item.snippet, !s.isEmpty { parts.append(s) }
         if item.type == .note, let p = item.parent, !p.isEmpty {
             parts.append("In \(p) folder.")
         }
-        parts.append(formatAbsolute(item.createdAt))
+        if item.type == .itinerary, let p = item.parent, !p.isEmpty {
+            parts.append("Trip: \(p).")
+        }
+        parts.append(formatAbsolute(item.sortDate))
         return parts.joined(separator: " ")
     }
 }
@@ -480,7 +640,7 @@ private struct EmptyStateView: View {
     }
 
     private var sub: String {
-        if filter == .all { return "Notes, todos, lists, and folders you create will show up here." }
+        if filter == .all { return "Notes, todos, lists, folders, trips, and expenses you capture will show up here." }
         return "Switch to All to see everything."
     }
 }

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -384,7 +384,7 @@ struct FinanceView: View {
         }
 
         do {
-            let result = try await StatementImporter.default().importStatement(pdfData: pdfData)
+            let result = try await StatementImporter.default().importStatement(pdfData: pdfData, fileName: fileName)
             statementImportSummary = result.summaryLine
         } catch {
             let message: String = {

--- a/mobile/PersonalDashboard/Views/Itineraries/ItinerariesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/ItinerariesView.swift
@@ -63,7 +63,11 @@ struct ItinerariesView: View {
             }
         }
         .activeSection(.itineraries)
-        .onAppear { syncBackHandler() }
+        .onAppear {
+            consumeFocus()
+            syncBackHandler()
+        }
+        .onChange(of: router.focus) { _, _ in consumeFocus() }
         .onDisappear {
             if selectedTripUUID != nil {
                 router.leadingEdgeBackHandler = nil
@@ -136,6 +140,20 @@ struct ItinerariesView: View {
         .scrollContentBackground(.hidden)
         .background(Tokens.paper)
         .scrollDismissesKeyboard(.interactively)
+    }
+
+    // MARK: - Activity deep-link consumption
+
+    /// The Activity timeline sets `router.focus` to a `.itineraries` focus whose
+    /// `id` is the trip UUID, then pushes this section. Open that trip's detail
+    /// and clear the focus so it doesn't re-fire. If the trip can't be resolved
+    /// (deleted since), we just clear focus and leave the root list showing.
+    private func consumeFocus() {
+        guard let focus = router.focus, focus.section == .itineraries else { return }
+        if trips.contains(where: { $0.clientUUID == focus.id }) {
+            withAnimation(.easeOut(duration: 0.2)) { selectedTripUUID = focus.id }
+        }
+        router.focus = nil
     }
 
     // MARK: - Back-swipe wiring (mirrors ListsView.syncBackHandler)


### PR DESCRIPTION
## Summary

Surfaces itinerary items and expenses in the Activity feed alongside the existing todos / notes / lists / folders, keeping Activity's on-device "derive, don't store" projection (no new `@Model`; the only schema change is one additive field with a default).

- **Itinerary items**: one row each, trip name as the parent chip, deep-links into the owning trip (`ItinerariesView.consumeFocus()`).
- **Individual (non-PDF) expenses**: one row each (merchant + SGD amount + category).
- **Statement imports**: collapse into a **single** row per statement, titled by the imported PDF **file name**. The filename is now captured at import and stored on each row (`LocalExpense.statementFileName`, additive), threaded from the picker through `StatementImporter`. Grouping falls back to the parsed attribution label, then the import day, so a statement never explodes into per-line rows even when its header can't be parsed.
- **New filter chips**: Trips, Finance.
- **Bug fix (latent)**: the feed sorted by `sortDate` but grouped days by `createdAt`. When those differ (itinerary/expense rows triggered it), grouping produced non-contiguous day sections sharing a key, so `ForEach(id: \.key)` duplicated and dropped rows. Grouping and the row timestamp now key off `sortDate`, guaranteeing contiguous, uniquely-keyed day groups.

## Test plan

- [x] Static build: `xcodegen generate` + `xcodebuild ... archive` → **ARCHIVE / EXPORT SUCCEEDED**.
- [x] Device QA on iPhone 16 Pro Max (installed via OTA + `devicectl`):
  - [x] Itinerary items appear as their own rows under the correct trip.
  - [x] Individual expenses appear as their own rows.
  - [x] A statement collapses into a single Activity row (not one row per line).
  - [x] Existing todo/note/list/folder rows + new Trips/Finance chips behave; day grouping no longer duplicates rows.

Closes #198