### PR TITLE
fix(ios): chunk statement import so large statements import completely

### DIFF
--- a/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
+++ b/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
@@ -201,27 +201,84 @@ enum StatementExtractionError: LocalizedError {
 }
 
 extension AnthropicClient {
-    /// Larger token budget for statement extraction. Output scales with the
-    /// transaction count (~30-50 tokens per line), so the 1024-token default
-    /// used elsewhere would truncate any real statement. 8192 comfortably
-    /// covers ~150 lines; beyond that the model may still hit the ceiling and
-    /// we surface a `possiblyTruncated` flag on the result so the caller can
-    /// warn the user (see `StatementImporter`).
-    static let statementMaxTokens = 8192
+    /// Per-chunk token budget for statement extraction. Output scales with the
+    /// transaction count (~30-70 tokens per line). The primary guard against a
+    /// dropped tail is now page chunking (see `extractStatement` / `PDFChunker`),
+    /// which keeps each request to ~80 lines; this raised ceiling is the
+    /// secondary guard so an individual chunk essentially never truncates.
+    /// Sonnet 4.5 supports far more than the old 8192, so 16384 leaves generous
+    /// headroom. A chunk that somehow still hits the ceiling sets
+    /// `possiblyTruncated`, which propagates to a prominent warning in the
+    /// import summary (see `StatementImporter`).
+    static let statementMaxTokens = 16384
 
-    /// Send a whole credit-card statement PDF to Claude and ask for every
-    /// transaction line as a JSON array (#184). Uses a native `document` block
-    /// (behind the `pdfs-2024-09-25` beta header) so Claude reads the full
-    /// statement directly — this sidesteps the 6000-char text cap in
-    /// `EmailAttachmentProcessor.pdfText`, which a multi-page statement would
-    /// blow past.
+    /// Extract every transaction line from a credit-card statement PDF (#184),
+    /// splitting large statements into page-range chunks so nothing is lost to
+    /// the output-token ceiling (#202).
+    ///
+    /// Small statements (≤ one chunk's worth of pages) take the single-call
+    /// path unchanged. Larger statements are split by `PDFChunker` and each
+    /// chunk is extracted SEQUENTIALLY (not in parallel — the on-device tool
+    /// loop and API rate limits favour serial calls, and it avoids hammering
+    /// the key). The per-chunk line arrays are concatenated into one list; the
+    /// header/meta is taken from the first chunk that yields it (statements
+    /// print it on page 1). `possiblyTruncated` is the OR across chunks, so the
+    /// truncation warning still fires if any single chunk ran out of budget.
+    ///
+    /// Page-boundary duplicates (a rare row read on both sides of a split) are
+    /// harmless: the merged list flows through the EXISTING `ExpenseDedupe` in
+    /// `StatementImporter.insert`, which collapses structural duplicates.
+    func extractStatement(pdfData: Data) async throws -> (lines: [ExtractedStatementLine], meta: ExtractedStatementMeta, possiblyTruncated: Bool) {
+        let chunks = PDFChunker.split(pdfData)
+
+        // Single chunk (small or unsplittable statement): identical behaviour
+        // to the pre-#202 path — one call, same request bytes.
+        if chunks.count <= 1 {
+            return try await extractStatementChunk(pdfData: chunks.first ?? pdfData)
+        }
+
+        var mergedLines: [ExtractedStatementLine] = []
+        var mergedMeta: ExtractedStatementMeta?
+        var anyTruncated = false
+
+        for chunk in chunks {
+            let (lines, meta, truncated) = try await extractStatementChunk(pdfData: chunk)
+            mergedLines.append(contentsOf: lines)
+            anyTruncated = anyTruncated || truncated
+            // Take the header from the FIRST chunk that carries any readable
+            // field (the statement header lives on page 1). Once found, keep it
+            // — a later page must never overwrite it with an invented header.
+            if mergedMeta == nil, Self.metaHasContent(meta) {
+                mergedMeta = meta
+            }
+        }
+
+        let finalMeta = mergedMeta ?? ExtractedStatementMeta(
+            issuer: nil, last4: nil, statementMonth: nil, statementYear: nil
+        )
+        return (mergedLines, finalMeta, anyTruncated)
+    }
+
+    /// True when a parsed header carries at least one readable field, so the
+    /// chunk-merge only adopts a header that actually came off the statement
+    /// rather than an all-nil placeholder.
+    private static func metaHasContent(_ meta: ExtractedStatementMeta) -> Bool {
+        meta.issuer != nil || meta.last4 != nil
+            || meta.statementMonth != nil || meta.statementYear != nil
+    }
+
+    /// Send ONE statement PDF (a whole small statement, or a single page-range
+    /// chunk of a large one) to Claude and ask for every transaction line as a
+    /// JSON array (#184). Uses a native `document` block (behind the
+    /// `pdfs-2024-09-25` beta header) so Claude reads the PDF directly — this
+    /// sidesteps the 6000-char text cap in `EmailAttachmentProcessor.pdfText`,
+    /// which a multi-page statement would blow past.
     ///
     /// Returns the parsed lines, the statement header metadata (#189), plus
     /// whether the model likely ran out of output tokens (stop_reason ==
-    /// "max_tokens"), which for a very large statement means the tail was cut
-    /// off. The header sits at the FRONT of the emitted object, so it survives
-    /// even when the trailing `lines` array is truncated.
-    func extractStatement(pdfData: Data) async throws -> (lines: [ExtractedStatementLine], meta: ExtractedStatementMeta, possiblyTruncated: Bool) {
+    /// "max_tokens"). The header sits at the FRONT of the emitted object, so it
+    /// survives even when the trailing `lines` array is truncated.
+    func extractStatementChunk(pdfData: Data) async throws -> (lines: [ExtractedStatementLine], meta: ExtractedStatementMeta, possiblyTruncated: Bool) {
         let base64 = pdfData.base64EncodedString()
         let content: [AnthropicJSONValue] = [
             .object([

--- a/mobile/PersonalDashboard/AI/PDFChunker.swift
+++ b/mobile/PersonalDashboard/AI/PDFChunker.swift
@@ -1,0 +1,65 @@
+import Foundation
+import PDFKit
+
+/// Splits a statement PDF into page-range chunks so each extraction call stays
+/// well under the model's output-token ceiling (#202).
+///
+/// A long statement sent as ONE request truncates: the model runs out of
+/// output budget partway through the transaction list and the tail rows are
+/// silently dropped (a real 9-page Amex imported 111 of ~187 lines). Chunking
+/// the input by page range and extracting each chunk sequentially makes import
+/// length-independent — each chunk carries few enough lines that it never hits
+/// the ceiling, and the merged results flow through the existing dedup so any
+/// page-boundary overlap collapses cleanly.
+enum PDFChunker {
+    /// Default pages per chunk. A typical credit-card statement carries roughly
+    /// 25-30 transaction lines per page, so 3 pages ≈ 80 lines ≈ 5-6k output
+    /// tokens — comfortably under the 16k ceiling with headroom for the JSON
+    /// envelope and header object.
+    static let defaultPagesPerChunk = 3
+
+    /// Split `pdfData` into chunks of at most `pagesPerChunk` pages each, every
+    /// chunk returned as a standalone single-document PDF's `Data` ready to feed
+    /// the native `document` extraction block.
+    ///
+    /// Returns `[pdfData]` unchanged when the PDF can't be parsed, has no pages,
+    /// or already fits within a single chunk — so a small statement sends the
+    /// exact same request bytes as before (zero behaviour change on the common
+    /// path). Never returns an empty array.
+    static func split(_ pdfData: Data, pagesPerChunk: Int = defaultPagesPerChunk) -> [Data] {
+        guard pagesPerChunk > 0,
+              let doc = PDFDocument(data: pdfData) else {
+            return [pdfData]
+        }
+        let pageCount = doc.pageCount
+        guard pageCount > pagesPerChunk else {
+            // Small statement (or single chunk's worth): send as-is, untouched.
+            return [pdfData]
+        }
+
+        var chunks: [Data] = []
+        var start = 0
+        while start < pageCount {
+            let end = min(start + pagesPerChunk, pageCount)
+            let chunkDoc = PDFDocument()
+            var insertIndex = 0
+            for pageIndex in start..<end {
+                // A PDFPage belongs to exactly one document, so copy it before
+                // inserting into the chunk document rather than moving it out of
+                // the source (which would corrupt later chunks).
+                guard let page = doc.page(at: pageIndex),
+                      let copy = page.copy() as? PDFPage else { continue }
+                chunkDoc.insert(copy, at: insertIndex)
+                insertIndex += 1
+            }
+            if insertIndex > 0, let data = chunkDoc.dataRepresentation() {
+                chunks.append(data)
+            }
+            start = end
+        }
+
+        // Defensive: if page copying somehow produced nothing, fall back to the
+        // original bytes as a single chunk rather than importing zero rows.
+        return chunks.isEmpty ? [pdfData] : chunks
+    }
+}

--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -48,11 +48,21 @@ struct StatementImportResult: Sendable {
         if failed > 0 {
             parts.append("\(failed) couldn't be added")
         }
-        var line = parts.joined(separator: " · ")
-        if possiblyTruncated {
-            line += "\n\nThis statement was large, so some later transactions may not have been read. Re-import or add the rest manually if a few are missing."
-        }
-        return line
+        let counts = parts.joined(separator: " · ")
+        guard possiblyTruncated else { return counts }
+
+        // Chunking makes this essentially unreachable, but if a single chunk
+        // still ran out of output budget the import is genuinely incomplete —
+        // make that unmissable (leading warning, not a trailing footnote) with
+        // the count that DID land, so the user knows to re-import.
+        return """
+        ⚠️ Incomplete import — some transactions may be missing
+
+        \(counts)
+
+        Part of this statement was too long to read in one pass. Re-import the \
+        statement to try again, or add any missing transactions manually.
+        """
     }
 }
 


### PR DESCRIPTION
## Summary

- Splits the statement PDF into 3-page chunks and runs sequential extraction calls, merging the results, so import capacity is no longer bounded by a single response's token budget.
- Reuses the existing `ExpenseDedupe` structural key to make chunk seams and re-imports idempotent — no reimplementation of dedup, no duplicate rows across chunk boundaries.
- Raises the per-call output ceiling 8192 → 16384 as a secondary guard so an individual chunk essentially never truncates.
- Promotes the incomplete-read note from a soft footnote to a prominent ⚠️ warning with the imported count.

Root cause: the importer made one Anthropic call capped at 8192 output tokens; a long statement exhausted the budget partway through and the tail was silently trimmed by the recovery parser. A 9-page/~187-line Amex statement imported only 111 lines before this fix.

### Files
- `mobile/PersonalDashboard/AI/PDFChunker.swift` (new) — PDFKit page-range splitter returning per-chunk PDF `Data`; returns the input unchanged when it fits in one chunk.
- `mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift` — `extractStatement` now orchestrates split → sequential per-chunk extraction → merged lines + first-chunk header; single-chunk path is byte-for-byte the old call. Ceiling raised to 16384.
- `mobile/PersonalDashboard/AI/StatementImporter.swift` — prominent truncation warning in `summaryLine`.

## Test plan

- [x] Clean static build (`xcodegen generate` + `xcodebuild ... -destination 'generic/platform=iOS' build`) → BUILD SUCCEEDED
- [x] Device QA on iPhone 16 Pro Max: re-imported the reproduction statement, full ~187 lines now import with no silent gap. Evidence in the ticket comment.
- [x] Small-statement path unchanged (≤3 pages takes the identical single-call path; only the higher ceiling differs, which can only help)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)