### PR TITLE
feat(ios): clear expenses in finance via chat, text, and voice

### DIFF
--- a/mobile/PersonalDashboard/AI/ChatActionResult.swift
+++ b/mobile/PersonalDashboard/AI/ChatActionResult.swift
@@ -44,7 +44,8 @@ struct ChatActionResult: Identifiable, Hashable, Sendable {
         switch outcome.action {
         case ActionString.created:
             return .created
-        case ActionString.deleted:
+        case ActionString.deleted, ActionString.cleared:
+            // A bulk clear reads as a removal in the card vocabulary.
             return .deleted
         default:
             // completed / reopened / updated / items_added / item_updated /

--- a/mobile/PersonalDashboard/AI/ChatDraft.swift
+++ b/mobile/PersonalDashboard/AI/ChatDraft.swift
@@ -163,9 +163,48 @@ extension ChatDraft {
         case .addExpense:
             return Self.addExpenseSummary(dict: dict)
 
+        case .clearExpenses:
+            return Self.clearExpensesSummary(dict: dict)
+
         case .unknown:
             return "Unknown action"
         }
+    }
+
+    /// Preview for `clear_expenses`. The card is rendered before the executor
+    /// runs, so the exact count isn't known here — describe the SCOPE instead
+    /// ("Clear Groceries expenses after 1 Jun 2026"). An unfiltered clear reads
+    /// "Clear ALL expenses"; without confirm_all it flags that confirmation is
+    /// still required, mirroring the executor's guard.
+    private static func clearExpensesSummary(dict: [String: AnthropicJSONValue]) -> String {
+        let after = (dict["after_date"]?.stringValue).flatMap(parseAnyDate)
+        let before = (dict["before_date"]?.stringValue).flatMap(parseAnyDate)
+        let categoryRaw = (dict["category"]?.stringValue ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let category = categoryRaw.isEmpty ? nil : ExpenseCategory(rawValue: categoryRaw)
+        let confirmAll = dict["confirm_all"]?.boolValue ?? false
+
+        let hasFilter = after != nil || before != nil || !categoryRaw.isEmpty
+        if !hasFilter {
+            return confirmAll ? "Clear ALL expenses" : "Clear ALL expenses — needs confirmation"
+        }
+
+        var parts: [String] = []
+        if let category {
+            parts.append(category.displayName)
+        } else if !categoryRaw.isEmpty {
+            parts.append(categoryRaw)
+        }
+        var scope = "Clear \(parts.isEmpty ? "" : parts.joined() + " ")expenses"
+        if let after, let before {
+            scope += " between \(shortDayMonth.string(from: after)) and \(shortDayMonth.string(from: before))"
+        } else if let after {
+            scope += " after \(shortDayMonth.string(from: after))"
+        } else if let before {
+            scope += " before \(shortDayMonth.string(from: before))"
+        }
+        return scope
     }
 
     /// Preview for `add_expense`. Format aims for the same scannable shape

--- a/mobile/PersonalDashboard/AI/ChatStream.swift
+++ b/mobile/PersonalDashboard/AI/ChatStream.swift
@@ -166,6 +166,7 @@ struct ChatStream {
         - remove_list_item: Remove a specific item from a list (requires list_id and item_index)
         - delete_trip: Delete an existing trip (cascades to all its itinerary items)
         - delete_itinerary_item: Delete a single itinerary item
+        - clear_expenses: Bulk-delete expenses matching an OPTIONAL filter (after_date, before_date, category). Filters are ANDed and apply immediately. FULL-WIPE SAFETY: a call with NO filter deletes EVERY expense — never issue an unfiltered clear on a first request. Instead reply asking the user to confirm they want to erase ALL their expenses (e.g. "yes, clear all"). Only after they explicitly confirm, call clear_expenses with confirm_all: true. A clear that carries any filter never needs confirm_all.
 
         CAPTURE DEFAULTS (for NEW items via draft_task / draft_note / draft_list / draft_trip):
         You MUST capture every new-item request into the best-fit type. Never refuse a capture with "I can't help with that". Pick the best fit from the user's intent and create the draft. The user can edit the captured item afterwards, so prefer capturing over asking.

--- a/mobile/PersonalDashboard/AI/ChatToDrafts.swift
+++ b/mobile/PersonalDashboard/AI/ChatToDrafts.swift
@@ -233,6 +233,7 @@ struct ChatToDrafts {
         - remove_list_item: Remove a specific item from a list (requires list_id and item_index)
         - delete_trip: Delete an existing trip (cascades to all its itinerary items)
         - delete_itinerary_item: Delete a single itinerary item
+        - clear_expenses: Bulk-delete expenses matching an OPTIONAL filter (after_date, before_date, category). Filters are ANDed and apply immediately. FULL-WIPE SAFETY: a call with NO filter deletes EVERY expense — never issue an unfiltered clear on a first request. Instead respond with assistant text warning the user this erases ALL their expenses and asking them to confirm (e.g. "yes, clear all"). Only after they explicitly confirm, call clear_expenses with confirm_all: true. A clear that carries any filter never needs confirm_all.
 
         CAPTURE DEFAULTS (for NEW items via draft_task / draft_note / draft_list / draft_trip):
         You MUST capture every new-item request into the best-fit type. Never refuse a capture with "I can't help with that". Pick the best fit from the user's intent and create the draft.

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -75,6 +75,7 @@ struct ExecuteDraftAction {
         case .updateItineraryItem: return try updateItineraryItem(input)
         case .deleteItineraryItem: return try deleteItineraryItem(input)
         case .addExpense: return try await addExpense(input)
+        case .clearExpenses: return try clearExpenses(input)
         case .unknown:
             throw DraftExecutionError.invalidArgument(field: "action", reason: "unknown action type")
         }
@@ -236,6 +237,121 @@ struct ExecuteDraftAction {
             addedNames: nil
         )
     }
+
+    /// `clear_expenses` tool handler (#204). Bulk-deletes finance entries
+    /// matching an optional after/before/category filter. Synchronous — unlike
+    /// `addExpense` there's no FX round-trip.
+    ///
+    /// Full-wipe safety guard: an UNFILTERED clear (no after_date, no
+    /// before_date, no category) deletes EVERY expense, so it only executes
+    /// when `confirm_all: true` is passed. Without it, nothing is deleted and
+    /// a `needs_confirmation` outcome is returned telling the user to confirm.
+    /// This guard lives here (not just in the system prompt) so the
+    /// auto-executing capture / voice path can't wipe everything on one
+    /// unconfirmed request. Filtered clears always execute directly, matching
+    /// every other delete on these surfaces.
+    private func clearExpenses(_ input: [String: AnthropicJSONValue]) throws -> DraftActionOutcome {
+        let cal = Calendar.current
+        // Normalise the bounds to start-of-day so day-granular "after 1 Jun"
+        // semantics line up with `LocalExpense.date` (also start-of-day).
+        let after = parseAnyISODate(input["after_date"]?.stringValue).map { cal.startOfDay(for: $0) }
+        let before = parseAnyISODate(input["before_date"]?.stringValue).map { cal.startOfDay(for: $0) }
+
+        let categoryRaw = (trimmedString(input["category"]) ?? "").lowercased()
+        let category = categoryRaw.isEmpty ? nil : ExpenseCategory(rawValue: categoryRaw)
+
+        // A filter is "present" whenever the model supplied any dimension —
+        // including a category string we don't recognise (handled just below),
+        // so an unknown category never silently degrades into a full wipe.
+        let hasFilter = (after != nil) || (before != nil) || !categoryRaw.isEmpty
+        let confirmAll = input["confirm_all"]?.boolValue ?? false
+
+        let service = ExpenseService(store: store)
+
+        // Full-wipe safety guard: unfiltered clear-all needs explicit confirm.
+        if !hasFilter && !confirmAll {
+            let count = (try? service.totalCount()) ?? 0
+            let message = count == 0
+                ? "There are no expenses to clear."
+                : "This clears all \(count) expense\(count == 1 ? "" : "s"). Say \"yes, clear all\" to confirm."
+            return DraftActionOutcome(
+                type: "expense",
+                action: ActionString.needsConfirmation,
+                id: "",
+                title: message,
+                dueDate: nil,
+                addedNames: nil
+            )
+        }
+
+        // Unknown-category guard: the model passed a category we can't map.
+        // Refuse rather than fall through to an unfiltered wipe.
+        if !categoryRaw.isEmpty && category == nil {
+            return DraftActionOutcome(
+                type: "expense",
+                action: ActionString.needsConfirmation,
+                id: "",
+                title: "I don't recognise the category \"\(categoryRaw)\", so nothing was cleared.",
+                dueDate: nil,
+                addedNames: nil
+            )
+        }
+
+        let deleted: Int
+        do {
+            deleted = try service.deleteExpenses(after: after, before: before, category: category)
+        } catch {
+            throw DraftExecutionError.persistence(error)
+        }
+
+        return DraftActionOutcome(
+            type: "expense",
+            action: ActionString.cleared,
+            id: "",
+            title: Self.clearedExpensesTitle(deleted: deleted, after: after, before: before, category: category),
+            dueDate: nil,
+            addedNames: nil
+        )
+    }
+
+    /// Scope-aware summary for a `clear_expenses` outcome, e.g.
+    /// "Cleared 12 expenses", "Cleared 3 expenses in Groceries after 1 Jun 2026",
+    /// or "No expenses matched before 1 May 2026." when nothing was deleted.
+    private static func clearedExpensesTitle(
+        deleted: Int,
+        after: Date?,
+        before: Date?,
+        category: ExpenseCategory?
+    ) -> String {
+        let scope = clearScopeSuffix(after: after, before: before, category: category)
+        guard deleted > 0 else {
+            return "No expenses matched\(scope)."
+        }
+        let noun = deleted == 1 ? "expense" : "expenses"
+        return "Cleared \(deleted) \(noun)\(scope)."
+    }
+
+    private static func clearScopeSuffix(after: Date?, before: Date?, category: ExpenseCategory?) -> String {
+        var parts: [String] = []
+        if let category {
+            parts.append("in \(category.displayName)")
+        }
+        if let after, let before {
+            parts.append("between \(clearDateFormatter.string(from: after)) and \(clearDateFormatter.string(from: before))")
+        } else if let after {
+            parts.append("after \(clearDateFormatter.string(from: after))")
+        } else if let before {
+            parts.append("before \(clearDateFormatter.string(from: before))")
+        }
+        return parts.isEmpty ? "" : " " + parts.joined(separator: " ")
+    }
+
+    private static let clearDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "d MMM yyyy"
+        return f
+    }()
 
     // MARK: - CREATE
 
@@ -1309,4 +1425,11 @@ enum ActionString {
     static let itemsAdded = "items_added"
     static let itemUpdated = "item_updated"
     static let itemRemoved = "item_removed"
+    /// Bulk clear of finance entries (#204). Distinct from `deleted` (single
+    /// row) so the dialog / cards can render a count-bearing summary.
+    static let cleared = "cleared"
+    /// A `clear_expenses` call that was refused because it would wipe ALL
+    /// expenses without confirmation (or named an unknown category). Nothing
+    /// was deleted; the outcome `title` carries the message to surface.
+    static let needsConfirmation = "needs_confirmation"
 }

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -428,6 +428,26 @@ enum ToolDefinitions {
         )
     )
 
+    /// Bulk-delete finance entries matching an optional filter (#204). All
+    /// filters are optional and ANDed. An unfiltered call is a full wipe of
+    /// EVERY expense — the model must not issue that until the user has
+    /// explicitly confirmed, and then it passes `confirm_all: true`. The
+    /// executor enforces the same guard so the auto-executing capture / voice
+    /// path can't wipe everything on a single unconfirmed request.
+    private static let clearExpenses = AnthropicTool(
+        name: "clear_expenses",
+        description: "Bulk-delete expenses (finance entries) matching an optional filter. Use for requests like \"clear my expenses\", \"delete all my food expenses\", \"remove expenses before May\". Apply whichever of after_date / before_date / category the user gives as an AND filter. SAFETY: if you provide NO filter (no after_date, no before_date, no category) this deletes EVERY expense. Do NOT call this unfiltered on a first request — instead reply in plain text telling the user this will erase ALL their expenses and ask them to confirm (e.g. \"yes, clear all\"). Only after they explicitly confirm, call clear_expenses again with confirm_all: true. Filtered clears (any of after_date / before_date / category present) apply immediately and do NOT need confirm_all.",
+        input_schema: object(
+            properties: [
+                "after_date": string("OPTIONAL ISO 8601 date (e.g. 2026-06-01). Delete only expenses dated STRICTLY AFTER this day. Omit or use empty string for no lower bound."),
+                "before_date": string("OPTIONAL ISO 8601 date. Delete only expenses dated STRICTLY BEFORE this day. Omit or use empty string for no upper bound."),
+                "category": string("OPTIONAL category to restrict the clear to. One of: food_and_dining, groceries, transport, shopping, entertainment, bills_and_utilities, health_and_wellness, travel, subscriptions, personal_care, gifts_and_donations, other. Omit or use empty string to clear across all categories."),
+                "confirm_all": bool("Set true ONLY to confirm an unfiltered clear of ALL expenses, and ONLY after the user has explicitly confirmed they want to erase everything. Ignored when any filter is present. Defaults to false.")
+            ],
+            required: []
+        )
+    )
+
     // MARK: - Public surface
 
     static let allTools: [AnthropicTool] = [
@@ -453,7 +473,8 @@ enum ToolDefinitions {
         deleteTrip,
         editItineraryItem,
         deleteItineraryItem,
-        addExpense
+        addExpense,
+        clearExpenses
     ]
 
     /// Subset of `allTools` excluded from the capture (Shortcut) auto-execute
@@ -496,6 +517,7 @@ enum ToolDefinitions {
         "delete_trip": .deleteTrip,
         "edit_itinerary_item": .updateItineraryItem,
         "delete_itinerary_item": .deleteItineraryItem,
-        "add_expense": .addExpense
+        "add_expense": .addExpense,
+        "clear_expenses": .clearExpenses
     ]
 }

--- a/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
+++ b/mobile/PersonalDashboard/Intents/CaptureToDashboardIntent.swift
@@ -236,6 +236,16 @@ struct CaptureToDashboardIntent: AppIntent {
         case (_, "deleted"):
             return "Deleted \(typeLabel)\(titleClause)."
 
+        // Bulk expense clear (#204): the title already carries the full
+        // count-bearing sentence ("Cleared 12 expenses…"), so surface it
+        // verbatim rather than wrapping it in the singular delete phrasing.
+        case ("expense", "cleared"):
+            return title.isEmpty ? "Cleared expenses." : title
+        // Full-wipe guard tripped — nothing was deleted; the title is the
+        // confirmation prompt to read back to the user.
+        case (_, "needs_confirmation"):
+            return title.isEmpty ? "That needs confirmation before I can clear it." : title
+
         default:
             return "Done."
         }

--- a/mobile/PersonalDashboard/Models/Draft.swift
+++ b/mobile/PersonalDashboard/Models/Draft.swift
@@ -24,5 +24,6 @@ enum DraftActionType: String, Codable, Hashable, Sendable {
     case updateItineraryItem = "UPDATE_ITINERARY_ITEM"
     case deleteItineraryItem = "DELETE_ITINERARY_ITEM"
     case addExpense = "ADD_EXPENSE"
+    case clearExpenses = "CLEAR_EXPENSES"
     case unknown = "UNKNOWN"
 }

--- a/mobile/PersonalDashboard/Services/ExpenseService.swift
+++ b/mobile/PersonalDashboard/Services/ExpenseService.swift
@@ -196,6 +196,48 @@ struct ExpenseService {
         try save()
     }
 
+    /// Bulk-delete expenses matching an optional filter (#204). The three
+    /// parameters are ANDed; a nil parameter means "no constraint on that
+    /// dimension". When ALL are nil this deletes EVERY expense, so any caller
+    /// that exposes this to the assistant MUST gate the unfiltered case behind
+    /// an explicit confirmation (see `ExecuteDraftAction.clearExpenses`).
+    /// Returns the number of rows deleted.
+    ///
+    /// Date bounds are STRICT (`> after`, `< before`). `category` matches on
+    /// `LocalExpense.category` (== `ExpenseCategory.rawValue`). Mirrors the
+    /// fetch-then-filter shape of `expenses(filter:)` above rather than a
+    /// `#Predicate`: `clientUUID` is a `String` (not `UUID`), the dataset is
+    /// personal-scale, and in-memory filtering sidesteps the optional-unwrap
+    /// fragility of building a predicate from three nullable bounds. Deletes
+    /// in a single `save()`, like the `deleteTrip` cascade.
+    @discardableResult
+    func deleteExpenses(
+        after: Date? = nil,
+        before: Date? = nil,
+        category: ExpenseCategory? = nil
+    ) throws -> Int {
+        let all = try store.context.fetch(FetchDescriptor<LocalExpense>())
+        let categoryRaw = category?.rawValue
+        let matches = all.filter { row in
+            if let after, !(row.date > after) { return false }
+            if let before, !(row.date < before) { return false }
+            if let categoryRaw, row.category != categoryRaw { return false }
+            return true
+        }
+        guard !matches.isEmpty else { return 0 }
+        for row in matches {
+            store.context.delete(row)
+        }
+        try save()
+        return matches.count
+    }
+
+    /// Total number of stored expenses. Backs the full-wipe confirmation
+    /// message ("This clears all N expenses…") without materialising rows.
+    func totalCount() throws -> Int {
+        try store.context.fetchCount(FetchDescriptor<LocalExpense>())
+    }
+
     // MARK: - Analytics
 
     /// Total SGD spent this calendar month (start-of-month → now).

--- a/mobile/PersonalDashboard/ViewModels/VoiceCaptureViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/VoiceCaptureViewModel.swift
@@ -460,6 +460,7 @@ final class VoiceCaptureViewModel {
         case .createTrip, .updateTrip, .deleteTrip, .addItineraryItems: return "trip"
         case .updateItineraryItem, .deleteItineraryItem:           return "item"
         case .addExpense:                                          return "expense"
+        case .clearExpenses:                                       return "expenses"
         case .unknown:                                             return "action"
         }
     }

--- a/mobile/PersonalDashboard/Views/Chat/ChatResultCard.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatResultCard.swift
@@ -124,6 +124,8 @@ struct ChatResultCard: View {
             return "item"
         case .addExpense:
             return "expense"
+        case .clearExpenses:
+            return "expenses"
         case .unknown:
             return "action"
         }


### PR DESCRIPTION
## Summary

- Adds a `clear_expenses` assistant tool that bulk-deletes finance entries (`LocalExpense`) by optional date and/or category filter, available on all three surfaces (chat, text capture, voice) from the shared tool list.
- Filtered clears execute directly, consistent with every other delete on these surfaces.
- Unfiltered full wipe is guarded in the executor: it deletes nothing unless `confirm_all: true` is passed, so the auto-executing voice/capture path cannot wipe everything on one unconfirmed command. A mistyped category refuses rather than degrading into a full wipe.
- After any clear, the assistant returns a count- and scope-aware summary.

## Test plan

- [x] Clean static build (`xcodegen generate` + `xcodebuild ... build`).
- [x] Installed to device and QA'd across chat, voice, and text capture: filtered clears remove only in-scope expenses; out-of-scope expenses survive; unfiltered clear-all is confirm-gated and only wipes after an explicit "yes, clear all".

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)