### PR TITLE
feat(ios): include refunds in statement import and net into finance totals

### DIFF
--- a/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
+++ b/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
@@ -30,12 +30,26 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
         case payment
         case refund
 
-        /// True when this line represents money spent (should become an
-        /// expense). Payments and refunds are excluded.
+        /// True when this line represents money spent (a debit). Payments and
+        /// refunds are NOT spend. Kept for callers that need the strict
+        /// spend/credit distinction; import routing uses `shouldImport`.
         var isSpend: Bool {
             switch self {
             case .purchase, .fee, .interest: return true
             case .payment, .refund:          return false
+            }
+        }
+
+        /// True when this line should be IMPORTED as a `LocalExpense` (#206).
+        /// Spend types import as expenses; a `refund` also imports, but as a
+        /// credit (`isRefund: true`) that nets against totals. A `payment` (a
+        /// transfer TO the card that reduces the balance) is NEVER imported —
+        /// it's counted and skipped, because it isn't spending and double-counts
+        /// against the purchases it paid off.
+        var shouldImport: Bool {
+            switch self {
+            case .purchase, .fee, .interest, .refund: return true
+            case .payment:                            return false
             }
         }
     }
@@ -477,8 +491,10 @@ extension AnthropicClient {
           GIRO). These are NOT spending — but still return them, tagged
           "payment", so they can be counted and skipped.
         - "refund": a credit / reversal / chargeback / cashback on a purchase
-          (money coming back). Return them tagged "refund" so they can be
-          counted and skipped.
+          (money coming back to you). Tag these "refund". They ARE imported —
+          they net against your spending — so give a refund the same accurate
+          merchant, date, amount, and category you'd give the purchase it
+          reverses.
     - "date" is the transaction date in ISO 8601 (YYYY-MM-DD). Statement lines
       often omit the year (e.g. "07 SEP", "12/09"). Infer the year from the
       statement period / billing cycle shown on the statement. If a line's
@@ -496,8 +512,10 @@ extension AnthropicClient {
       Pick the best fit from the merchant (a supermarket → groceries, a
       restaurant → food_and_dining, an airline/hotel → travel, Netflix/Spotify
       → subscriptions, a utility → bills_and_utilities). For fees and interest
-      use "bills_and_utilities". Use "other" only when nothing fits. For
-      payments and refunds, still pick a plausible category (it is ignored).
+      use "bills_and_utilities". Use "other" only when nothing fits. A refund
+      is imported, so give it the category of the purchase it reverses (a
+      grocery refund → groceries). For a payment, still pick a plausible
+      category (a payment is skipped, so its category is ignored).
     - Do NOT include summary rows, balances, "total", "opening/closing
       balance", minimum-payment lines, or reward-point lines — only real
       transaction lines.

--- a/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
+++ b/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
@@ -217,12 +217,14 @@ struct AssistantContextBuilder {
                 let monthComps = cal.dateComponents([.year, .month], from: now)
                 let monthStart = cal.date(from: monthComps) ?? now
                 let monthRows = recent.filter { $0.date >= monthStart }
-                let monthTotal = monthRows.reduce(0.0) { $0 + $1.sgdAmount }
+                // Net refunds against spend (#206) so the figure the assistant
+                // reports matches the Finance UI's netted totals.
+                let monthTotal = monthRows.reduce(0.0) { $0 + $1.signedSGD }
 
-                // Category totals this month, biggest first.
+                // Category totals this month, biggest first (refunds netted).
                 var byCategory: [String: Double] = [:]
                 for row in monthRows {
-                    byCategory[row.category, default: 0] += row.sgdAmount
+                    byCategory[row.category, default: 0] += row.signedSGD
                 }
                 let topCategories = byCategory
                     .sorted { $0.value > $1.value }
@@ -256,6 +258,9 @@ struct AssistantContextBuilder {
                         line += String(format: " (\(row.originalCurrency.uppercased()) %.2f)", row.originalAmount)
                     }
                     line += " · \(category)"
+                    // Flag refunds so the assistant reads them as money-in, not
+                    // spend — the amount above is a positive magnitude (#206).
+                    if row.isRefund { line += " · refund (credit)" }
                     out += line
                 }
             }

--- a/mobile/PersonalDashboard/AI/ExpenseDedupe.swift
+++ b/mobile/PersonalDashboard/AI/ExpenseDedupe.swift
@@ -28,6 +28,11 @@ enum ExpenseDedupe {
         let originalAmount: Double  // amount in the original currency
         let originalCurrency: String // ISO 4217, uppercased
         let sourceReference: String // order / booking reference, or "" if none
+        /// Direction (#206). A refund and a same-magnitude purchase are NOT
+        /// equivalent, so this is folded into the structural key. Defaulted to
+        /// false so every existing caller (email path) is unchanged and only
+        /// the statement importer, which can propose refunds, sets it.
+        var isRefund: Bool = false
     }
 
     /// Compute the equivalence signature for a proposed expense.
@@ -46,7 +51,11 @@ enum ExpenseDedupe {
         let day = dayKey(proposed.date)
         let amount = amountKey(proposed.originalAmount)
         let currency = proposed.originalCurrency.uppercased()
-        return "s:\(merchant)|\(day)|\(amount)|\(currency)"
+        // A refund gets its own namespace so it never collides with a
+        // same-magnitude purchase; an expense keeps the original format so
+        // existing stored `dedupeKey`s stay valid (#206).
+        let dir = proposed.isRefund ? "refund|" : ""
+        return "s:\(dir)\(merchant)|\(day)|\(amount)|\(currency)"
     }
 
     /// True when an equivalent expense already exists. Checks both the stored
@@ -94,7 +103,8 @@ enum ExpenseDedupe {
         let day = dayKey(proposed.date)
         let amount = amountKey(proposed.originalAmount)
         let currency = proposed.originalCurrency.uppercased()
-        return "\(merchant)|\(day)|\(amount)|\(currency)"
+        let dir = proposed.isRefund ? "refund|" : ""
+        return "\(dir)\(merchant)|\(day)|\(amount)|\(currency)"
     }
 
     /// The structural key for an existing stored row, computed the SAME way as
@@ -105,7 +115,8 @@ enum ExpenseDedupe {
         let day = dayKey(row.date)
         let amount = amountKey(row.originalAmount)
         let currency = row.originalCurrency.uppercased()
-        return "\(merchant)|\(day)|\(amount)|\(currency)"
+        let dir = row.isRefund ? "refund|" : ""
+        return "\(dir)\(merchant)|\(day)|\(amount)|\(currency)"
     }
 
     // MARK: - Normalisation

--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -5,13 +5,22 @@ import SwiftData
 /// pipeline (#184). Every parsed line lands in exactly one of these buckets, so
 /// `imported + skippedDuplicates + ignoredNonSpend + failed == total parsed`.
 struct StatementImportResult: Sendable {
-    /// Purchase/fee/interest lines that deduped clean and were inserted.
+    /// Lines that deduped clean and were inserted. Counts BOTH spend
+    /// (purchase/fee/interest) and refund rows — every row that produced a
+    /// `LocalExpense` this run. `refunds` (below) is the refund subset, so the
+    /// spend-only count is `imported - refunds`.
     let imported: Int
-    /// Spend lines that matched an existing expense via `ExpenseDedupe` and were
-    /// skipped.
+    /// Subset of `imported` that were refunds/credits, inserted with
+    /// `isRefund: true` so they net against spending totals (#206). Surfaced
+    /// separately in the summary ("including N refunds") so it's clear money
+    /// came back in, not just out.
+    let refunds: Int
+    /// Lines (spend or refund) that matched an existing expense via
+    /// `ExpenseDedupe` and were skipped.
     let skippedDuplicates: Int
-    /// Payment (card transfer) and refund/credit lines — counted, never
-    /// inserted (the positive-only `LocalExpense` model can't represent them).
+    /// Payment (card transfer) lines — counted, never inserted. A payment is a
+    /// transfer TO the card that pays down the balance; importing it would
+    /// double-count against the purchases it settled (#206).
     let ignoredNonSpend: Int
     /// Spend lines that failed to insert (bad amount, FX failure, persistence
     /// error). Non-fatal — the batch continues past each one.
@@ -31,19 +40,23 @@ struct StatementImportResult: Sendable {
 
     /// User-facing one-liner for the summary alert. Mentions only the buckets
     /// that have entries so a clean import reads simply. Examples:
-    ///   "Imported 42 · Skipped 8 duplicates · Ignored 5 payments/refunds"
+    ///   "Imported 42 (including 3 refunds) · Skipped 8 duplicates · Ignored 5 payments"
     ///   "Imported 12"
     ///   "Nothing to import — no transactions found."
     var summaryLine: String {
         guard totalParsed > 0 else {
             return "Nothing to import — no transactions found on this statement."
         }
-        var parts: [String] = ["Imported \(imported)"]
+        var head = "Imported \(imported)"
+        if refunds > 0 {
+            head += " (including \(refunds) refund\(refunds == 1 ? "" : "s"))"
+        }
+        var parts: [String] = [head]
         if skippedDuplicates > 0 {
             parts.append("Skipped \(skippedDuplicates) duplicate\(skippedDuplicates == 1 ? "" : "s")")
         }
         if ignoredNonSpend > 0 {
-            parts.append("Ignored \(ignoredNonSpend) payment\(ignoredNonSpend == 1 ? "" : "s")/refund\(ignoredNonSpend == 1 ? "" : "s")")
+            parts.append("Ignored \(ignoredNonSpend) payment\(ignoredNonSpend == 1 ? "" : "s")")
         }
         if failed > 0 {
             parts.append("\(failed) couldn't be added")
@@ -71,7 +84,10 @@ struct StatementImportResult: Sendable {
 /// Mirrors `EmailToItinerary`'s "parse → dedupe → insert → stamp keys → count
 /// skipped" shape, but for a whole statement rather than one receipt:
 ///   1. Ask Claude for the full transaction array (native PDF block).
-///   2. Drop payment/refund lines (tally as `ignoredNonSpend`).
+///   2. Drop card-payment lines (tally as `ignoredNonSpend`) — a payment settles
+///      the balance and would double-count against the purchases it paid off.
+///      Refunds are NOT dropped: they import as credits (`isRefund: true`) that
+///      net against spending totals (#206).
 ///   3. For each remaining line: build an `ExpenseDedupe.Proposed`, skip if it
 ///      already exists, else FX-convert and insert via `ExpenseService` with
 ///      `source: .pdf`, then stamp `dedupeKey` (structural — statements carry
@@ -120,6 +136,7 @@ struct StatementImporter {
         possiblyTruncated: Bool
     ) async -> StatementImportResult {
         var imported = 0
+        var refunds = 0
         var skippedDuplicates = 0
         var ignoredNonSpend = 0
         var failed = 0
@@ -141,10 +158,16 @@ struct StatementImporter {
             // (import it) — the model reliably tags payments/refunds, so an
             // untyped line is far more likely a normal purchase than a credit.
             let type = line.type ?? .purchase
-            guard type.isSpend else {
+            guard type.shouldImport else {
+                // Card payments only — they settle the balance and must never
+                // be imported (they'd double-count against the purchases they
+                // paid off). Refunds fall through and import as credits.
                 ignoredNonSpend += 1
                 continue
             }
+            // A refund imports as a credit: positive magnitude, `isRefund: true`
+            // so it nets against totals. Everything else is ordinary spend.
+            let isRefund = (type == .refund)
 
             // Amount must be positive to be a valid LocalExpense. A statement
             // line with no readable amount is dropped as a failure so the count
@@ -168,7 +191,11 @@ struct StatementImporter {
                 date: Calendar(identifier: .gregorian).startOfDay(for: date),
                 originalAmount: amount,
                 originalCurrency: currency,
-                sourceReference: ""
+                sourceReference: "",
+                // Direction is part of equivalence (#206): a £50 refund must not
+                // be swallowed as a "duplicate" of a same-day £50 purchase, and
+                // a re-imported refund still dedupes against the prior refund.
+                isRefund: isRefund
             )
             let signature = ExpenseDedupe.signature(for: proposed)
             if ExpenseDedupe.exists(signature: signature, proposed: proposed, context: store.context) {
@@ -199,7 +226,8 @@ struct StatementImporter {
                     sgdAmount: conversion.sgdAmount,
                     fxRate: conversion.rate,
                     paymentMethod: paymentMethod,
-                    source: .pdf
+                    source: .pdf,
+                    isRefund: isRefund
                 )
                 // Stamp the dedupe signature so a re-import of the same
                 // statement dedups against this row cheaply, mirroring the
@@ -217,6 +245,7 @@ struct StatementImporter {
                 try? store.context.save()
 
                 imported += 1
+                if isRefund { refunds += 1 }
                 if let uuid = UUID(uuidString: row.clientUUID) {
                     importedUUIDs.append(uuid)
                 }
@@ -228,6 +257,7 @@ struct StatementImporter {
 
         return StatementImportResult(
             imported: imported,
+            refunds: refunds,
             skippedDuplicates: skippedDuplicates,
             ignoredNonSpend: ignoredNonSpend,
             failed: failed,

--- a/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
@@ -126,6 +126,21 @@ final class LocalExpense {
     // existing call site behaves exactly as before (unsplit = 1 share).
     var numberOfShares: Int = 1
 
+    // MARK: - Refund direction (#206)
+    //
+    // True when this row is a credit-card REFUND / reversal / cashback rather
+    // than a spend, i.e. money coming IN. A refund NETS AGAINST spending
+    // totals (see `signedSGD`), but its `originalAmount` / `sgdAmount` stay
+    // POSITIVE (the magnitude) so the existing `> 0` insert guards and the
+    // per-category math still hold — the direction is carried solely by this
+    // flag. Populated ONLY by the statement-import path (`StatementImporter`)
+    // today; every other source (manual / chat / voice / receipt / email)
+    // leaves it false, i.e. a plain expense. Additive with a default so the
+    // SwiftData migration on existing installs stays lightweight
+    // (add-with-default, never remove) and every existing call site compiles
+    // and behaves unchanged (existing rows default to false = expense).
+    var isRefund: Bool = false
+
     // MARK: - Dead-field parity with other LocalModels
     //
     // These are intentionally unused on Phase A. Kept so that the SwiftData
@@ -158,6 +173,7 @@ final class LocalExpense {
         eventUUID: UUID? = nil,
         eventName: String? = nil,
         numberOfShares: Int = 1,
+        isRefund: Bool = false,
         needsSync: Bool = false,
         version: Int = 0
     ) {
@@ -184,6 +200,7 @@ final class LocalExpense {
         self.eventUUID = eventUUID
         self.eventName = eventName
         self.numberOfShares = numberOfShares
+        self.isRefund = isRefund
         self.needsSync = needsSync
         self.version = version
     }
@@ -196,6 +213,18 @@ final class LocalExpense {
 
     var sourceEnum: ExpenseSource {
         ExpenseSource(rawValue: source) ?? .manual
+    }
+
+    /// Signed home-currency contribution this row makes to any spending total
+    /// (#206). A normal expense contributes `+sgdAmount` (money out); a refund
+    /// contributes `-sgdAmount` (money in, netting the total down). Every
+    /// aggregation site — month total, previous-month, per-category, daily
+    /// sparkline, day-group headers — sums THIS value rather than the raw
+    /// `sgdAmount`, so refunds net cleanly without ever storing a negative
+    /// amount (the `> 0` insert guards stay valid). A net category or day can
+    /// legitimately reach zero or go slightly negative; that is correct.
+    var signedSGD: Double {
+        isRefund ? -sgdAmount : sgdAmount
     }
 
     /// Whether this expense was split among more than one person (#188).

--- a/mobile/PersonalDashboard/Services/DataArchive.swift
+++ b/mobile/PersonalDashboard/Services/DataArchive.swift
@@ -141,6 +141,10 @@ enum DataArchive {
         let receiptImagePath: String?
         let source: String
         let createdAt: Date
+        /// Refund direction (#206). Optional so archives written before this
+        /// field existed still decode (missing key -> nil -> false on import,
+        /// i.e. a plain expense).
+        let isRefund: Bool?
     }
 
     struct VocabDTO: Codable {

--- a/mobile/PersonalDashboard/Services/DataExportService.swift
+++ b/mobile/PersonalDashboard/Services/DataExportService.swift
@@ -217,7 +217,8 @@ final class DataExportService {
             paymentMethod: expense.paymentMethod,
             receiptImagePath: expense.receiptImagePath,
             source: expense.source,
-            createdAt: expense.createdAt
+            createdAt: expense.createdAt,
+            isRefund: expense.isRefund
         )
     }
 

--- a/mobile/PersonalDashboard/Services/DataImportService.swift
+++ b/mobile/PersonalDashboard/Services/DataImportService.swift
@@ -337,6 +337,7 @@ final class DataImportService {
                     receiptImagePath: restoredPath ?? dto.receiptImagePath,
                     source: dto.source,
                     createdAt: dto.createdAt,
+                    isRefund: dto.isRefund ?? false,
                     needsSync: false,
                     version: 0
                 ))

--- a/mobile/PersonalDashboard/Services/ExpenseService.swift
+++ b/mobile/PersonalDashboard/Services/ExpenseService.swift
@@ -94,8 +94,11 @@ struct ExpenseService {
         eventUUID: UUID? = nil,
         eventName: String? = nil,
         numberOfShares: Int = 1,
+        isRefund: Bool = false,
         clientUUID: String? = nil
     ) throws -> LocalExpense {
+        // Amount is always the positive magnitude, even for a refund — the
+        // direction is carried by `isRefund`, so this guard stays valid (#206).
         guard originalAmount > 0 else { throw ExpenseServiceError.invalidAmount }
 
         let row = LocalExpense(
@@ -116,7 +119,8 @@ struct ExpenseService {
             personName: personName?.trimmedNonEmpty,
             eventUUID: eventUUID,
             eventName: eventName?.trimmedNonEmpty,
-            numberOfShares: max(numberOfShares, 1)
+            numberOfShares: max(numberOfShares, 1),
+            isRefund: isRefund
         )
         store.context.insert(row)
         try save()
@@ -261,7 +265,8 @@ struct ExpenseService {
         let rows = try fetch(in: start...end)
         var sums: [String: Double] = [:]
         for row in rows {
-            sums[row.category, default: 0] += row.sgdAmount
+            // Net refunds against the category they reverse (#206).
+            sums[row.category, default: 0] += row.signedSGD
         }
         return sums
             .sorted { $0.value > $1.value }
@@ -282,7 +287,7 @@ struct ExpenseService {
         var byDay: [Date: Double] = [:]
         for row in rows {
             let day = cal.startOfDay(for: row.date)
-            byDay[day, default: 0] += row.sgdAmount
+            byDay[day, default: 0] += row.signedSGD
         }
         var out: [(date: Date, total: Double)] = []
         for offset in 0..<30 {
@@ -310,7 +315,10 @@ struct ExpenseService {
     // MARK: - Helpers
 
     private func sum(in range: ClosedRange<Date>) throws -> Double {
-        try fetch(in: range).reduce(0) { $0 + $1.sgdAmount }
+        // Net: refunds subtract from the total (#206). Backs monthTotal /
+        // previousMonthTotal, so both the running month figure and the
+        // delta chip reflect money returned.
+        try fetch(in: range).reduce(0) { $0 + $1.signedSGD }
     }
 
     private func fetch(in range: ClosedRange<Date>) throws -> [LocalExpense] {

--- a/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
+++ b/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
@@ -54,15 +54,18 @@ struct ExpenseRow: View {
             Spacer()
 
             VStack(alignment: .trailing, spacing: 2) {
-                Text(FinanceDashboardBand.formatSGD(expense.sgdAmount))
+                // Refunds are money coming IN: shown in the success (green)
+                // colour with a leading "+" so they read as a credit against
+                // spend, distinct from a normal debit (#206).
+                Text(sgdAmountLabel)
                     .font(.edBodyMedium)
                     .monospacedDigit()
-                    .foregroundStyle(Tokens.ink)
+                    .foregroundStyle(expense.isRefund ? Tokens.success : Tokens.ink)
                 if expense.originalCurrency.uppercased() != "SGD" {
                     Text(originalAmountLabel)
                         .font(.edCaption)
                         .monospacedDigit()
-                        .foregroundStyle(Tokens.mutedSoft)
+                        .foregroundStyle(expense.isRefund ? Tokens.success.opacity(0.8) : Tokens.mutedSoft)
                 }
             }
         }
@@ -183,17 +186,29 @@ struct ExpenseRow: View {
         return pieces.isEmpty ? nil : pieces.joined(separator: " · ")
     }
 
+    /// Primary SGD amount, with a leading "+" for refunds so a credit is
+    /// unmistakable at a glance (the colour alone isn't enough for the
+    /// colour-blind, and "+" carries the meaning in VoiceOver too) (#206).
+    private var sgdAmountLabel: String {
+        let base = FinanceDashboardBand.formatSGD(expense.sgdAmount)
+        return expense.isRefund ? "+\(base)" : base
+    }
+
     private var originalAmountLabel: String {
         let formatter = NumberFormatter()
         formatter.minimumFractionDigits = 2
         formatter.maximumFractionDigits = 2
         formatter.numberStyle = .decimal
         let amount = formatter.string(from: NSNumber(value: expense.originalAmount)) ?? "\(expense.originalAmount)"
-        return "\(expense.originalCurrency.uppercased()) \(amount)"
+        let base = "\(expense.originalCurrency.uppercased()) \(amount)"
+        return expense.isRefund ? "+\(base)" : base
     }
 
     private var accessibilityLabel: String {
-        var pieces: [String] = [primaryLine, FinanceDashboardBand.formatSGD(expense.sgdAmount), expense.categoryEnum.displayName]
+        let amountSpoken = expense.isRefund
+            ? "refund \(FinanceDashboardBand.formatSGD(expense.sgdAmount))"
+            : FinanceDashboardBand.formatSGD(expense.sgdAmount)
+        var pieces: [String] = [primaryLine, amountSpoken, expense.categoryEnum.displayName]
         if expense.originalCurrency.uppercased() != "SGD" {
             pieces.append("\(originalAmountLabel) original")
         }

--- a/mobile/PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
@@ -105,7 +105,10 @@ struct FinanceDashboardBand: View {
     }
 
     private func categoryBar(entry: (category: ExpenseCategory, total: Double), max: Double) -> some View {
-        let ratio = max > 0 ? entry.total / max : 0
+        // A net-negative category (refunds outweighed spend, #206) would give a
+        // negative ratio; clamp to 0 so the bar just empties rather than drawing
+        // a negative width. The trailing SGD label still shows the true net.
+        let ratio = max > 0 ? Swift.max(0, entry.total / max) : 0
         return HStack(spacing: Space.sm) {
             Image(systemName: entry.category.sfSymbol)
                 .font(.system(size: 12, weight: .regular))
@@ -169,7 +172,9 @@ struct FinanceDashboardBand: View {
             let step = size.width / CGFloat(count - 1)
             for (idx, value) in values.enumerated() {
                 let x = CGFloat(idx) * step
-                let normalised = maxValue > 0 ? CGFloat(value / maxValue) : 0
+                // Clamp to >= 0 so a net-negative (refund) day rests on the
+                // baseline instead of drawing below the frame (#206).
+                let normalised = maxValue > 0 ? Swift.max(0, CGFloat(value / maxValue)) : 0
                 let y = size.height - (normalised * (size.height - 2)) - 1
                 if idx == 0 {
                     path.move(to: CGPoint(x: x, y: y))
@@ -187,7 +192,7 @@ struct FinanceDashboardBand: View {
             path.move(to: CGPoint(x: 0, y: size.height))
             for (idx, value) in values.enumerated() {
                 let x = CGFloat(idx) * step
-                let normalised = maxValue > 0 ? CGFloat(value / maxValue) : 0
+                let normalised = maxValue > 0 ? Swift.max(0, CGFloat(value / maxValue)) : 0
                 let y = size.height - (normalised * (size.height - 2)) - 1
                 path.addLine(to: CGPoint(x: x, y: y))
             }

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -563,7 +563,8 @@ struct FinanceView: View {
         let dict = Dictionary(grouping: rows) { cal.startOfDay(for: $0.date) }
         return dict.keys.sorted(by: >).map { day in
             let dayRows = dict[day] ?? []
-            let total = dayRows.reduce(0) { $0 + $1.sgdAmount }
+            // Net refunds into the day-group header total (#206).
+            let total = dayRows.reduce(0) { $0 + $1.signedSGD }
             return DailyGroup(day: day, total: total, rows: dayRows)
         }
     }
@@ -690,7 +691,9 @@ struct FinanceView: View {
         let cal = Calendar.current
 
         let rangeRows = allExpenses.filter { range.contains($0.date) }
-        let rangeTotal = rangeRows.reduce(0) { $0 + $1.sgdAmount }
+        // All dashboard-band figures net refunds (#206): the headline total,
+        // the delta comparison, the category bars, and the sparkline.
+        let rangeTotal = rangeRows.reduce(0) { $0 + $1.signedSGD }
 
         // Preceding comparison window. Calendar-month presets compare against
         // the previous CALENDAR month (so month-length differences don't skew
@@ -710,11 +713,11 @@ struct FinanceView: View {
             prevRange = prevStart...prevEnd
         }
         let prevRows = allExpenses.filter { prevRange.contains($0.date) }
-        let prevTotal = prevRows.reduce(0) { $0 + $1.sgdAmount }
+        let prevTotal = prevRows.reduce(0) { $0 + $1.signedSGD }
 
         var byCategory: [ExpenseCategory: Double] = [:]
         for row in rangeRows {
-            byCategory[row.categoryEnum, default: 0] += row.sgdAmount
+            byCategory[row.categoryEnum, default: 0] += row.signedSGD
         }
         let topCategories = byCategory
             .sorted { $0.value > $1.value }
@@ -729,7 +732,7 @@ struct FinanceView: View {
         var dailyDict: [Date: Double] = [:]
         for row in rangeRows {
             let day = cal.startOfDay(for: row.date)
-            dailyDict[day, default: 0] += row.sgdAmount
+            dailyDict[day, default: 0] += row.signedSGD
         }
         var dailyTotals: [(date: Date, total: Double)] = []
         for offset in 0..<max(dayCount, 1) {


### PR DESCRIPTION
## Summary

Statement import previously dropped every refund, so finance totals overstated real spend by the full value of any credit or reversal. This includes refunds and nets them into all finance figures. Credit-card payments stay ignored, as before.

- Refund lines now import (positive amount plus an `isRefund` flag) instead of being bucketed into `ignoredNonSpend`.
- Card payments remain excluded; only `refund` lines are added.
- Month total, previous-month total, top categories, and the 30-day sparkline all net refunds via a new `signedSGD` property (a refund contributes `-sgdAmount`).
- Refund rows render green with a leading `+`; the import summary reports refunds as imported and payments as ignored.
- Dedupe folds direction into its keys so a refund never collapses against a same-amount purchase.
- Backup export/import round-trips the new flag.

## Data model

Additive migration only: `isRefund: Bool = false` on `LocalExpense`. Existing rows read as expenses, so installs upgrade safely. No fields removed. The `originalAmount > 0` guard is untouched (amounts stay positive; direction lives in the flag).

## Scope

Chat/voice/photo add-expense is unchanged (expense-only). This ticket covers statement import.

## Test plan

Shipped to device and QA'd on the Finance surfaces:
- [x] Import summary counts refunds as imported, payments as ignored
- [x] Refund rows show green with a leading `+`
- [x] Month total and previous-month total net the refund
- [x] 30-day sparkline and category bars net refunds without drawing below baseline
- [x] Re-import dedupes refunds, no double-count
- [x] Card payments still excluded

Closes #206
