### PR TITLE
fix(ios): count-reconcile statement dedup on verbatim descriptor

### DIFF
--- a/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
+++ b/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
@@ -20,6 +20,17 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
     let type: LineType?
     let category: String?      // ExpenseCategory.rawValue
 
+    /// The transaction description EXACTLY as printed on the statement,
+    /// verbatim (including any trailing location / country tokens and reference
+    /// codes), with NO cleanup or reformatting (#208). Used ONLY as the stable
+    /// dedup key: the numeric columns (amount / date / currency) are stable
+    /// across extraction runs, but the model paraphrases `merchant` differently
+    /// each run, which broke re-import idempotency. The verbatim descriptor is
+    /// copied off the page character-for-character, so it's identical across
+    /// runs. Optional so older / partial responses without it still decode; the
+    /// importer falls back to `merchant` for the key when it's nil/empty.
+    let descriptor: String?
+
     /// Statement line classification. Purchases, fees, and interest become
     /// expenses; payments (transfers to the card) and refunds/credits are
     /// tallied and skipped because `LocalExpense` stores only positive spend.
@@ -61,10 +72,13 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
         case currency
         case type
         case category
+        case descriptor
     }
 
     /// Lenient decode: an unrecognised `type` string decodes to nil rather than
     /// failing the whole array, so one odd row never sinks a 40-line statement.
+    /// `descriptor` is `decodeIfPresent`, so a response (or a JSON-recovery
+    /// prefix) that omits it decodes cleanly to nil.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         merchant = try c.decodeIfPresent(String.self, forKey: .merchant)
@@ -73,16 +87,19 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
         currency = try c.decodeIfPresent(String.self, forKey: .currency)
         type = (try? c.decodeIfPresent(LineType.self, forKey: .type)) ?? nil
         category = try c.decodeIfPresent(String.self, forKey: .category)
+        descriptor = try c.decodeIfPresent(String.self, forKey: .descriptor)
     }
 
-    /// Direct memberwise init for tests.
-    init(merchant: String?, date: String?, amount: Double?, currency: String?, type: LineType?, category: String?) {
+    /// Direct memberwise init for tests. `descriptor` defaults to nil so
+    /// existing call sites that don't exercise the dedup key stay unchanged.
+    init(merchant: String?, date: String?, amount: Double?, currency: String?, type: LineType?, category: String?, descriptor: String? = nil) {
         self.merchant = merchant
         self.date = date
         self.amount = amount
         self.currency = currency
         self.type = type
         self.category = category
+        self.descriptor = descriptor
     }
 }
 
@@ -449,6 +466,7 @@ extension AnthropicClient {
       "lines": [
         {
           "merchant": "Starbucks",
+          "descriptor": "STARBUCKS @ ION ORCHARD SINGAPORE SG",
           "date": "YYYY-MM-DD",
           "amount": 12.34,
           "currency": "SGD",
@@ -478,6 +496,18 @@ extension AnthropicClient {
     Transaction line rules ("lines" array):
     - Return one element per transaction line on the statement. Include ALL of
       them: purchases, fees, interest charges, card payments, and refunds.
+    - "merchant" is the clean, human-readable merchant / vendor name for display
+      (e.g. "Starbucks", "Shopee"). Tidy it up as you normally would.
+    - "descriptor" is the transaction description EXACTLY as printed on the
+      statement — verbatim, character-for-character. Copy the raw description
+      text as-is, INCLUDING any trailing location, city, or country tokens and
+      any reference / merchant codes (e.g. "STARBUCKS @ ION ORCHARD SINGAPORE
+      SG", "SHOPEE SINGAPORE Shopee SINGAPORE", "AMZN Mktp SG*A1B2C3"). Do NOT
+      clean it up, expand abbreviations, fix casing, remove codes, or reformat
+      it in any way — it must match the statement text so the same line reads
+      identically every time. Return the same descriptor value even for a
+      payment or refund. Only if a line genuinely has no printed description at
+      all, set it to the same value as "merchant".
     - "amount" is always a POSITIVE number (the magnitude of the line). Never
       emit a negative amount; the sign is conveyed by "type" instead.
     - "type" is EXACTLY one of: "purchase", "fee", "interest", "payment",

--- a/mobile/PersonalDashboard/AI/ExpenseDedupe.swift
+++ b/mobile/PersonalDashboard/AI/ExpenseDedupe.swift
@@ -97,6 +97,32 @@ enum ExpenseDedupe {
         return false
     }
 
+    /// How many stored `LocalExpense` rows already match the STRUCTURAL class of
+    /// `proposed` (#208). Used by the statement importer to reconcile *counts*
+    /// rather than mere existence: a boolean `exists` can only ever say "at least
+    /// one", so once the first of two identical Kult Yard coffees lands, every
+    /// further identical line looks like a duplicate and real spend is
+    /// under-counted. This returns the multiplicity so the importer can insert
+    /// `max(0, N - M)` rows for a class.
+    ///
+    /// Counts purely by structural key (`merchant|day|amount|currency` +
+    /// refund-direction namespace). Reference matching is deliberately ignored:
+    /// statements carry no order/booking reference, so structural multiplicity is
+    /// the only thing that matters here. Because legit duplicates now share the
+    /// same structural `dedupeKey`, we must NOT take the fast `dedupeKey`-count
+    /// path (it would conflate reference/structural keys and can't see rows from
+    /// other sources); instead we fetch and compare each row's structural key the
+    /// SAME way `exists` does, so an already-logged receipt / email row for the
+    /// same visit also counts (and is absorbed rather than double-imported).
+    @MainActor
+    static func existingCount(matching proposed: Proposed, context: ModelContext) -> Int {
+        let target = structuralKey(proposed)
+        let rows = (try? context.fetch(FetchDescriptor<LocalExpense>())) ?? []
+        return rows.reduce(0) { count, row in
+            rowStructuralKey(row) == target ? count + 1 : count
+        }
+    }
+
     /// The structural key (reference-free) for a proposed expense.
     private static func structuralKey(_ proposed: Proposed) -> String {
         let merchant = normalizeMerchant(proposed.merchant)

--- a/mobile/PersonalDashboard/AI/ExpenseDedupe.swift
+++ b/mobile/PersonalDashboard/AI/ExpenseDedupe.swift
@@ -123,6 +123,126 @@ enum ExpenseDedupe {
         }
     }
 
+    // MARK: - Statement bucket reconciliation (#208)
+
+    /// One incoming statement line reduced to the fields that decide dedup.
+    /// `descriptor` is the VERBATIM statement descriptor (the caller applies the
+    /// merchant fallback when the model returned none); it is normalised inside
+    /// the reconciler, so the caller may pass it raw or pre-normalised.
+    struct StatementIncoming {
+        let isRefund: Bool
+        let date: Date
+        let amount: Double
+        let currency: String
+        let descriptor: String
+    }
+
+    /// Decide, for a batch of incoming statement lines, which ones to INSERT vs
+    /// treat as duplicates of already-stored rows (#208). Returns a parallel
+    /// `[Bool]` (`true` = insert) aligned to `incoming`.
+    ///
+    /// Why not the paraphrased merchant: the merchant string the model emits
+    /// drifts between extraction runs (e.g. "SHOPEE SINGAPORE" vs "SHOPEE
+    /// SINGAPORE Shopee"), so a merchant-based key failed to dedup a re-import
+    /// and silently re-inserted rows. Amount, date, and currency come from the
+    /// statement's numeric columns and are stable; the verbatim `descriptor` is
+    /// copied off the page unchanged and is stable too. So we reconcile as a
+    /// MULTISET within each (direction, day, amount, currency) BUCKET, matching
+    /// on the descriptor, with a legacy fallback for rows that predate the
+    /// descriptor field.
+    ///
+    /// A stored row MATCHES an incoming line when it shares the bucket AND
+    /// ( the stored `dedupeDescriptor` is empty [legacy / non-statement row]
+    ///   OR its normalised descriptor equals the incoming one ).
+    ///
+    /// Greedy assignment per bucket, order-stable, each stored row consumed at
+    /// most once:
+    ///   1. Exact pass — each incoming line claims an unconsumed stored row with
+    ///      the SAME non-empty descriptor (exact matches are preferred so a
+    ///      legacy wildcard slot is left for a line that has no exact match).
+    ///   2. Legacy pass — each still-unmatched incoming line claims an unconsumed
+    ///      EMPTY-descriptor stored row (a pre-fix row, or a receipt/manual row).
+    ///   3. Anything still unmatched is INSERTED.
+    ///
+    /// Consequences: exact re-import -> 0 inserted (idempotent); the SHOPEE
+    /// paraphrase case -> descriptor identical -> deduped; genuine same-day
+    /// same-amount lines with different descriptors -> both kept; a legacy row
+    /// with no descriptor -> matched on amount+date+currency so a re-import does
+    /// NOT re-add it; three identical lines -> 3 match 3 -> 0 on re-import.
+    @MainActor
+    static func statementInsertDecisions(
+        incoming: [StatementIncoming],
+        context: ModelContext
+    ) -> [Bool] {
+        // Mutable stored-row slots, grouped by bucket. A single fetch; the email
+        // /receipt path never runs this.
+        struct Slot { let descKey: String; var consumed: Bool }
+        let rows = (try? context.fetch(FetchDescriptor<LocalExpense>())) ?? []
+        var buckets: [String: [Slot]] = [:]
+        for row in rows {
+            let bucket = bucketKey(
+                isRefund: row.isRefund,
+                date: row.date,
+                amount: row.originalAmount,
+                currency: row.originalCurrency
+            )
+            buckets[bucket, default: []].append(
+                Slot(descKey: normalizeMerchant(row.dedupeDescriptor), consumed: false)
+            )
+        }
+
+        // Group incoming line indices by bucket, preserving statement order so
+        // an earlier line wins a contested legacy slot.
+        var indicesByBucket: [String: [Int]] = [:]
+        var bucketOrder: [String] = []
+        for (i, line) in incoming.enumerated() {
+            let bucket = bucketKey(
+                isRefund: line.isRefund,
+                date: line.date,
+                amount: line.amount,
+                currency: line.currency
+            )
+            if indicesByBucket[bucket] == nil { bucketOrder.append(bucket) }
+            indicesByBucket[bucket, default: []].append(i)
+        }
+
+        var decisions = [Bool](repeating: false, count: incoming.count)
+        for bucket in bucketOrder {
+            let indices = indicesByBucket[bucket] ?? []
+            var slots = buckets[bucket] ?? []
+            var pending: [Int] = []
+
+            // Pass 1 — exact non-empty descriptor match.
+            for i in indices {
+                let descKey = normalizeMerchant(incoming[i].descriptor)
+                if !descKey.isEmpty,
+                   let slotIdx = slots.firstIndex(where: { !$0.consumed && $0.descKey == descKey }) {
+                    slots[slotIdx].consumed = true   // duplicate -> skip
+                } else {
+                    pending.append(i)
+                }
+            }
+            // Pass 2 — legacy empty-descriptor fallback, else insert.
+            for i in pending {
+                if let slotIdx = slots.firstIndex(where: { !$0.consumed && $0.descKey.isEmpty }) {
+                    slots[slotIdx].consumed = true   // matched a legacy row -> skip
+                } else {
+                    decisions[i] = true              // new spend -> insert
+                }
+            }
+            buckets[bucket] = slots
+        }
+        return decisions
+    }
+
+    /// The reference-free (direction, day, amount, currency) bucket key that
+    /// groups structurally-comparable statement rows. Descriptor is NOT part of
+    /// the bucket — matching within a bucket is what the descriptor decides.
+    private static func bucketKey(isRefund: Bool, date: Date, amount: Double, currency: String) -> String {
+        let dir = isRefund ? "refund|" : ""
+        return "\(dir)\(dayKey(date))|\(amountKey(amount))|\(currency.uppercased())"
+    }
+
     /// The structural key (reference-free) for a proposed expense.
     private static func structuralKey(_ proposed: Proposed) -> String {
         let merchant = normalizeMerchant(proposed.merchant)

--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -88,15 +88,24 @@ struct StatementImportResult: Sendable {
 ///      the balance and would double-count against the purchases it paid off.
 ///      Refunds are NOT dropped: they import as credits (`isRefund: true`) that
 ///      net against spending totals (#206).
-///   3. For each remaining line: build an `ExpenseDedupe.Proposed`, skip if it
-///      already exists, else FX-convert and insert via `ExpenseService` with
-///      `source: .pdf`, then stamp `dedupeKey` (structural — statements carry
-///      no order reference, so `sourceReference` stays empty like the email
-///      path leaves it for reference-less rows).
+///   3. Reconcile by structural class rather than boolean existence (#208).
+///      Group the remaining lines by their structural key
+///      (dir|merchant|day|amount|currency). For each class, let N = lines this
+///      statement asserts and M = matching rows already stored; insert
+///      `max(0, N - M)` of them (FX-convert + `ExpenseService` with `source:
+///      .pdf`, stamping the structural `dedupeKey`; statements carry no order
+///      reference, so `sourceReference` stays empty), and count the rest as
+///      skipped duplicates.
+///
+/// Why counts, not a boolean: statement rows have no per-line reference, so two
+/// genuine same-day/same-amount purchases (e.g. two coffees at one café) are
+/// structurally identical. A boolean `exists` skips every line after the first
+/// and under-counts real spend. Counting inserts the right multiplicity while
+/// staying idempotent on re-import (N == M → insert 0) and self-healing after a
+/// truncated import or a receipt already logged for one visit (N > M → top up).
 ///
 /// Auto-import: there is no per-row review. The importer inserts survivors
-/// directly and returns counts for the summary. Dedup makes a re-import of the
-/// same statement idempotent.
+/// directly and returns counts for the summary.
 @MainActor
 struct StatementImporter {
     let anthropic: AnthropicClient
@@ -153,15 +162,37 @@ struct StatementImporter {
         let cardLabel = meta.cardLabel
         let paymentMethod = cardLabel.isEmpty ? nil : cardLabel
 
+        // One statement line reduced to everything the insert step needs, plus
+        // its structural class key. Built in the classification pass below so the
+        // insert pass can reconcile by class (#208) instead of skipping every
+        // structurally-identical line after the first.
+        struct Candidate {
+            let amount: Double
+            let currency: String
+            let date: Date
+            let merchant: String?
+            let category: ExpenseCategory
+            let isRefund: Bool
+            let proposed: ExpenseDedupe.Proposed
+            /// Structural class key. For a statement (no order reference) this is
+            /// the structural signature, so two same-merchant/day/amount/currency
+            /// lines of the same direction share it and reconcile together.
+            let classKey: String
+        }
+
+        // Pass 1 — classify every line. Payments are counted and dropped;
+        // amount-less lines fail here (they can't form a valid class); everything
+        // else becomes an ordered candidate carrying its structural class key.
+        var candidates: [Candidate] = []
         for line in lines {
-            // Classification. A missing/unknown type defaults to `.purchase`
-            // (import it) — the model reliably tags payments/refunds, so an
-            // untyped line is far more likely a normal purchase than a credit.
+            // A missing/unknown type defaults to `.purchase` (import it) — the
+            // model reliably tags payments/refunds, so an untyped line is far
+            // more likely a normal purchase than a credit.
             let type = line.type ?? .purchase
             guard type.shouldImport else {
-                // Card payments only — they settle the balance and must never
-                // be imported (they'd double-count against the purchases they
-                // paid off). Refunds fall through and import as credits.
+                // Card payments only — they settle the balance and must never be
+                // imported (they'd double-count against the purchases they paid
+                // off). Refunds fall through and import as credits.
                 ignoredNonSpend += 1
                 continue
             }
@@ -182,58 +213,91 @@ struct StatementImporter {
             let merchant = line.merchant?.trimmingCharacters(in: .whitespacesAndNewlines)
             let category = ExpenseCategory(rawValue: (line.category ?? "").lowercased()) ?? .other
 
-            // Dedup against existing rows using the EXISTING helper, exactly as
-            // the email path does. Statements have no order reference, so the
-            // signature falls back to the structural key
-            // (merchant|date|amount|currency).
+            // Statements have no order reference, so the signature falls back to
+            // the structural key (dir|merchant|date|amount|currency). Direction is
+            // part of equivalence (#206): a £50 refund must not collapse into a
+            // same-day £50 purchase, and each direction reconciles on its own.
             let proposed = ExpenseDedupe.Proposed(
                 merchant: merchant ?? "",
                 date: Calendar(identifier: .gregorian).startOfDay(for: date),
                 originalAmount: amount,
                 originalCurrency: currency,
                 sourceReference: "",
-                // Direction is part of equivalence (#206): a £50 refund must not
-                // be swallowed as a "duplicate" of a same-day £50 purchase, and
-                // a re-imported refund still dedupes against the prior refund.
                 isRefund: isRefund
             )
-            let signature = ExpenseDedupe.signature(for: proposed)
-            if ExpenseDedupe.exists(signature: signature, proposed: proposed, context: store.context) {
+            candidates.append(Candidate(
+                amount: amount,
+                currency: currency,
+                date: date,
+                merchant: merchant,
+                category: category,
+                isRefund: isRefund,
+                proposed: proposed,
+                classKey: ExpenseDedupe.signature(for: proposed)
+            ))
+        }
+
+        // Count reconciliation (#208). For each structural class, let N be the
+        // number of lines THIS statement asserts and M the number of matching
+        // rows ALREADY stored (computed ONCE, before this batch inserts anything).
+        // We may insert at most `max(0, N - M)` rows for the class; the rest are
+        // duplicates. `budget[classKey]` is that deficit, decremented as we
+        // consume slots so a re-query can't inflate M with rows we just inserted.
+        //
+        // Behaviour: two identical coffees with none stored → N=2,M=0 → both
+        // import; a clean re-import → N=2,M=2 → both skip (idempotent); a
+        // truncated first import → N=2,M=1 → one imports (self-heals); a receipt
+        // already logged for one visit → N=2,M=1 → one imports (absorbs overlap).
+        var budget: [String: Int] = [:]
+        for candidate in candidates where budget[candidate.classKey] == nil {
+            let n = candidates.filter { $0.classKey == candidate.classKey }.count
+            let m = ExpenseDedupe.existingCount(matching: candidate.proposed, context: store.context)
+            budget[candidate.classKey] = max(0, n - m)
+        }
+
+        // Pass 2 — walk candidates in original statement order. A class with
+        // remaining budget attempts an insert (consuming a slot regardless of
+        // outcome, so a failed insert never promotes a later duplicate into its
+        // place); once the budget is spent, the rest of the class are skipped
+        // duplicates.
+        for candidate in candidates {
+            guard let remaining = budget[candidate.classKey], remaining > 0 else {
                 skippedDuplicates += 1
                 continue
             }
+            budget[candidate.classKey] = remaining - 1
 
             // FX. SGD passes straight through; other currencies hit FXService
             // (cached 1 day). A rate failure counts the line as failed rather
             // than inserting a silent zero.
             let conversion: (sgdAmount: Double, rate: Double)
             do {
-                conversion = try await fx.convert(amount, from: currency)
+                conversion = try await fx.convert(candidate.amount, from: candidate.currency)
             } catch {
-                NSLog("StatementImporter: FX convert failed for %@: %@", currency, error.localizedDescription)
+                NSLog("StatementImporter: FX convert failed for %@: %@", candidate.currency, error.localizedDescription)
                 failed += 1
                 continue
             }
 
             do {
                 let row = try service.addExpense(
-                    date: date,
-                    category: category,
-                    merchant: merchant,
+                    date: candidate.date,
+                    category: candidate.category,
+                    merchant: candidate.merchant,
                     expenseDescription: nil,
-                    originalAmount: amount,
-                    originalCurrency: currency,
+                    originalAmount: candidate.amount,
+                    originalCurrency: candidate.currency,
                     sgdAmount: conversion.sgdAmount,
                     fxRate: conversion.rate,
                     paymentMethod: paymentMethod,
                     source: .pdf,
-                    isRefund: isRefund
+                    isRefund: candidate.isRefund
                 )
-                // Stamp the dedupe signature so a re-import of the same
-                // statement dedups against this row cheaply, mirroring the
-                // email path. sourceReference stays empty (structural key) —
-                // the statement carries no order/booking reference.
-                row.dedupeKey = signature
+                // Stamp the structural dedupe signature. It's now EXPECTED that
+                // legit duplicates in the same class share this key — counting,
+                // not the key's uniqueness, is what keeps re-imports idempotent.
+                // sourceReference stays empty (the statement carries no reference).
+                row.dedupeKey = candidate.classKey
                 row.sourceReference = ""
                 // Statement attribution (#189): which statement this came off.
                 // Display-only — deliberately NOT part of the dedupe signature.
@@ -245,7 +309,7 @@ struct StatementImporter {
                 try? store.context.save()
 
                 imported += 1
-                if isRefund { refunds += 1 }
+                if candidate.isRefund { refunds += 1 }
                 if let uuid = UUID(uuidString: row.clientUUID) {
                     importedUUIDs.append(uuid)
                 }

--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -88,21 +88,25 @@ struct StatementImportResult: Sendable {
 ///      the balance and would double-count against the purchases it paid off.
 ///      Refunds are NOT dropped: they import as credits (`isRefund: true`) that
 ///      net against spending totals (#206).
-///   3. Reconcile by structural class rather than boolean existence (#208).
-///      Group the remaining lines by their structural key
-///      (dir|merchant|day|amount|currency). For each class, let N = lines this
-///      statement asserts and M = matching rows already stored; insert
-///      `max(0, N - M)` of them (FX-convert + `ExpenseService` with `source:
-///      .pdf`, stamping the structural `dedupeKey`; statements carry no order
-///      reference, so `sourceReference` stays empty), and count the rest as
-///      skipped duplicates.
+///   3. Reconcile by VERBATIM descriptor within a bucket, not by the paraphrased
+///      merchant (#208). `ExpenseDedupe.statementInsertDecisions` multiset-matches
+///      each incoming line against already-stored rows inside its
+///      (dir|day|amount|currency) bucket, on the statement descriptor (with a
+///      legacy fallback for rows that predate the descriptor field). Unmatched
+///      lines are inserted (FX-convert + `ExpenseService` with `source: .pdf`,
+///      stamping `dedupeDescriptor` = the normalised verbatim descriptor and the
+///      structural `dedupeKey`; `sourceReference` stays empty); matched lines are
+///      counted as skipped duplicates.
 ///
-/// Why counts, not a boolean: statement rows have no per-line reference, so two
-/// genuine same-day/same-amount purchases (e.g. two coffees at one café) are
-/// structurally identical. A boolean `exists` skips every line after the first
-/// and under-counts real spend. Counting inserts the right multiplicity while
-/// staying idempotent on re-import (N == M → insert 0) and self-healing after a
-/// truncated import or a receipt already logged for one visit (N > M → top up).
+/// Why the verbatim descriptor: statement rows have no per-line reference, and
+/// the model paraphrases the merchant differently across extraction runs (e.g.
+/// "SHOPEE SINGAPORE" one run, "SHOPEE SINGAPORE Shopee" the next), so a
+/// merchant-keyed re-import silently re-inserted rows. The amount, date, and
+/// currency come from the statement's stable numeric columns; the descriptor is
+/// copied off the page character-for-character and is stable too. Matching on it
+/// keeps re-imports idempotent while two genuine same-day/same-amount lines with
+/// DIFFERENT descriptors both import, and self-heals after a truncated import or
+/// a receipt/legacy row already logged for one visit (that row is absorbed).
 ///
 /// Auto-import: there is no per-row review. The importer inserts survivors
 /// directly and returns counts for the summary.
@@ -174,10 +178,15 @@ struct StatementImporter {
             let category: ExpenseCategory
             let isRefund: Bool
             let proposed: ExpenseDedupe.Proposed
-            /// Structural class key. For a statement (no order reference) this is
-            /// the structural signature, so two same-merchant/day/amount/currency
-            /// lines of the same direction share it and reconcile together.
+            /// Structural class key (dir|merchant|day|amount|currency). Stamped on
+            /// the inserted row's `dedupeKey` for continuity with the email path;
+            /// NOT what statement re-import dedup keys on (that's `descKey`).
             let classKey: String
+            /// Normalised VERBATIM statement descriptor — the stable re-import
+            /// dedup key (#208). Falls back to the merchant when the model
+            /// returned no descriptor. Stamped on the inserted row's
+            /// `dedupeDescriptor`.
+            let descKey: String
         }
 
         // Pass 1 — classify every line. Payments are counted and dropped;
@@ -225,6 +234,17 @@ struct StatementImporter {
                 sourceReference: "",
                 isRefund: isRefund
             )
+
+            // Verbatim descriptor is the stable re-import dedup key (#208). The
+            // model paraphrases `merchant` differently across runs, so keying on
+            // it re-inserted the same line on re-import. If the model returned no
+            // descriptor for this line, fall back to the merchant so behaviour
+            // degrades to the old merchant-based key rather than an empty key
+            // that would over-merge unrelated same-amount/day lines.
+            let rawDescriptor = line.descriptor?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let descriptorSource = rawDescriptor.isEmpty ? (merchant ?? "") : rawDescriptor
+            let descKey = ExpenseDedupe.normalizeMerchant(descriptorSource)
+
             candidates.append(Candidate(
                 amount: amount,
                 currency: currency,
@@ -233,39 +253,51 @@ struct StatementImporter {
                 category: category,
                 isRefund: isRefund,
                 proposed: proposed,
-                classKey: ExpenseDedupe.signature(for: proposed)
+                classKey: ExpenseDedupe.signature(for: proposed),
+                descKey: descKey
             ))
         }
 
-        // Count reconciliation (#208). For each structural class, let N be the
-        // number of lines THIS statement asserts and M the number of matching
-        // rows ALREADY stored (computed ONCE, before this batch inserts anything).
-        // We may insert at most `max(0, N - M)` rows for the class; the rest are
-        // duplicates. `budget[classKey]` is that deficit, decremented as we
-        // consume slots so a re-query can't inflate M with rows we just inserted.
+        // Descriptor-based bucket reconciliation (#208). Within each (direction,
+        // day, amount, currency) bucket we multiset-match incoming lines against
+        // already-stored rows on the VERBATIM descriptor (with a legacy fallback
+        // for rows that predate the descriptor field), computed ONCE before this
+        // batch inserts anything. `decisions[i]` is true when candidate i is new
+        // spend to insert; false when it duplicates a stored row.
         //
-        // Behaviour: two identical coffees with none stored → N=2,M=0 → both
-        // import; a clean re-import → N=2,M=2 → both skip (idempotent); a
-        // truncated first import → N=2,M=1 → one imports (self-heals); a receipt
-        // already logged for one visit → N=2,M=1 → one imports (absorbs overlap).
-        var budget: [String: Int] = [:]
-        for candidate in candidates where budget[candidate.classKey] == nil {
-            let n = candidates.filter { $0.classKey == candidate.classKey }.count
-            let m = ExpenseDedupe.existingCount(matching: candidate.proposed, context: store.context)
-            budget[candidate.classKey] = max(0, n - m)
-        }
+        // Why descriptor, not merchant: the model paraphrases the merchant
+        // differently across extraction runs, so a merchant-keyed re-import
+        // silently re-inserted rows. The descriptor is copied off the page
+        // verbatim and is stable across runs.
+        //
+        // Behaviour: two identical lines with none stored → both import; a clean
+        // re-import → both skip (idempotent); a truncated first import → the
+        // missing one imports (self-heals); a receipt/legacy row already logged
+        // for one visit → absorbed; the SHOPEE merchant-paraphrase case → same
+        // descriptor → deduped.
+        let decisions = ExpenseDedupe.statementInsertDecisions(
+            incoming: candidates.map {
+                ExpenseDedupe.StatementIncoming(
+                    isRefund: $0.isRefund,
+                    date: $0.date,
+                    amount: $0.amount,
+                    currency: $0.currency,
+                    descriptor: $0.descKey
+                )
+            },
+            context: store.context
+        )
 
-        // Pass 2 — walk candidates in original statement order. A class with
-        // remaining budget attempts an insert (consuming a slot regardless of
-        // outcome, so a failed insert never promotes a later duplicate into its
-        // place); once the budget is spent, the rest of the class are skipped
-        // duplicates.
-        for candidate in candidates {
-            guard let remaining = budget[candidate.classKey], remaining > 0 else {
+        // Pass 2 — walk candidates in original statement order. A candidate the
+        // reconciler marked for insertion attempts one (a failed insert is
+        // counted as failed, never promoting a duplicate into its place, because
+        // decisions were fixed up front against the pre-batch store); the rest
+        // are skipped duplicates.
+        for (i, candidate) in candidates.enumerated() {
+            guard decisions[i] else {
                 skippedDuplicates += 1
                 continue
             }
-            budget[candidate.classKey] = remaining - 1
 
             // FX. SGD passes straight through; other currencies hit FXService
             // (cached 1 day). A rate failure counts the line as failed rather
@@ -293,12 +325,16 @@ struct StatementImporter {
                     source: .pdf,
                     isRefund: candidate.isRefund
                 )
-                // Stamp the structural dedupe signature. It's now EXPECTED that
-                // legit duplicates in the same class share this key — counting,
-                // not the key's uniqueness, is what keeps re-imports idempotent.
-                // sourceReference stays empty (the statement carries no reference).
+                // Stamp the structural dedupe signature (kept for continuity with
+                // the email path's fast-path). sourceReference stays empty (the
+                // statement carries no reference).
                 row.dedupeKey = candidate.classKey
                 row.sourceReference = ""
+                // The stable re-import dedup key (#208): the normalised verbatim
+                // descriptor. A future re-import matches on THIS within the
+                // (dir|day|amount|currency) bucket, so the same statement dedups
+                // even when the model paraphrases the merchant differently.
+                row.dedupeDescriptor = candidate.descKey
                 // Statement attribution (#189): which statement this came off.
                 // Display-only — deliberately NOT part of the dedupe signature.
                 row.statementLabel = statementLabel

--- a/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
+++ b/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
@@ -128,6 +128,15 @@ final class SwiftDataStore {
         }
     }
 
+    /// Test/preview-only initializer backed by an explicit container (usually
+    /// `makeInMemory()`), so isolated tests exercise the real service + dedup
+    /// paths against an in-memory store instead of the on-disk singleton. Skips
+    /// the launch-time itinerary migration (irrelevant to a fresh store). Never
+    /// used by the app, which always goes through `.shared`.
+    init(container: ModelContainer) {
+        self.container = container
+    }
+
     /// Build an in-memory container for tests or previews.
     static func makeInMemory() -> ModelContainer {
         do {

--- a/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
@@ -141,6 +141,27 @@ final class LocalExpense {
     // and behaves unchanged (existing rows default to false = expense).
     var isRefund: Bool = false
 
+    // MARK: - Statement dedup descriptor (#208)
+    //
+    // The VERBATIM transaction descriptor as printed on the statement, lowercased
+    // and whitespace-collapsed (the same normalisation merchants get). Populated
+    // ONLY by the statement-import path (`StatementImporter`); every other source
+    // and every row created before this field existed leaves it empty ("").
+    //
+    // Why it exists: the dedup key used to include the PARAPHRASED `merchant`,
+    // which the LLM rewrites slightly differently across extraction runs (e.g.
+    // "SHOPEE SINGAPORE" one run, "SHOPEE SINGAPORE Shopee" the next). The amount,
+    // date, and currency come from the statement's numeric columns and are stable;
+    // the merchant is the only unstable field. Keying re-import dedup on this
+    // stable verbatim descriptor (via `ExpenseDedupe`) makes re-importing the same
+    // statement idempotent. `merchant` is unchanged and still drives display.
+    //
+    // Additive with a default so the SwiftData migration on existing installs
+    // stays lightweight (add-with-default, never remove); an empty value marks a
+    // legacy row, which the importer matches on amount + date + currency alone so
+    // pre-fix data is never re-duplicated on a future re-import.
+    var dedupeDescriptor: String = ""
+
     // MARK: - Dead-field parity with other LocalModels
     //
     // These are intentionally unused on Phase A. Kept so that the SwiftData
@@ -174,6 +195,7 @@ final class LocalExpense {
         eventName: String? = nil,
         numberOfShares: Int = 1,
         isRefund: Bool = false,
+        dedupeDescriptor: String = "",
         needsSync: Bool = false,
         version: Int = 0
     ) {
@@ -201,6 +223,7 @@ final class LocalExpense {
         self.eventName = eventName
         self.numberOfShares = numberOfShares
         self.isRefund = isRefund
+        self.dedupeDescriptor = dedupeDescriptor
         self.needsSync = needsSync
         self.version = version
     }

--- a/mobile/PersonalDashboard/Services/DataArchive.swift
+++ b/mobile/PersonalDashboard/Services/DataArchive.swift
@@ -145,6 +145,11 @@ enum DataArchive {
         /// field existed still decode (missing key -> nil -> false on import,
         /// i.e. a plain expense).
         let isRefund: Bool?
+        /// Verbatim statement descriptor used as the dedup key (#208). Optional
+        /// so archives written before this field existed still decode (missing
+        /// key -> nil -> "" on import, i.e. a legacy row matched on
+        /// amount+date+currency alone).
+        let dedupeDescriptor: String?
     }
 
     struct VocabDTO: Codable {

--- a/mobile/PersonalDashboard/Services/DataExportService.swift
+++ b/mobile/PersonalDashboard/Services/DataExportService.swift
@@ -218,7 +218,8 @@ final class DataExportService {
             receiptImagePath: expense.receiptImagePath,
             source: expense.source,
             createdAt: expense.createdAt,
-            isRefund: expense.isRefund
+            isRefund: expense.isRefund,
+            dedupeDescriptor: expense.dedupeDescriptor
         )
     }
 

--- a/mobile/PersonalDashboard/Services/DataImportService.swift
+++ b/mobile/PersonalDashboard/Services/DataImportService.swift
@@ -338,6 +338,7 @@ final class DataImportService {
                     source: dto.source,
                     createdAt: dto.createdAt,
                     isRefund: dto.isRefund ?? false,
+                    dedupeDescriptor: dto.dedupeDescriptor ?? "",
                     needsSync: false,
                     version: 0
                 ))

--- a/mobile/PersonalDashboardTests/StatementDedupeReconciliationTests.swift
+++ b/mobile/PersonalDashboardTests/StatementDedupeReconciliationTests.swift
@@ -39,7 +39,8 @@ final class StatementDedupeReconciliationTests: XCTestCase {
         _ amount: Double?,
         day: String = "2026-05-01",
         type: ExtractedStatementLine.LineType = .purchase,
-        currency: String = "SGD"
+        currency: String = "SGD",
+        descriptor: String? = nil
     ) -> ExtractedStatementLine {
         ExtractedStatementLine(
             merchant: merchant,
@@ -47,7 +48,8 @@ final class StatementDedupeReconciliationTests: XCTestCase {
             amount: amount,
             currency: currency,
             type: type,
-            category: "food_and_dining"
+            category: "food_and_dining",
+            descriptor: descriptor
         )
     }
 
@@ -185,6 +187,88 @@ final class StatementDedupeReconciliationTests: XCTestCase {
             result.totalParsed
         )
         XCTAssertEqual(result.totalParsed, 5)
+    }
+
+    // MARK: - (f) Merchant paraphrase across runs — same descriptor dedups (#208)
+
+    func test_merchantParaphrase_sameDescriptor_reimportInsertsZero() async throws {
+        // The exact bug: SHOPEE lines stored as merchant "SHOPEE SINGAPORE" on
+        // the first import and "SHOPEE SINGAPORE Shopee" on the re-import (the
+        // model paraphrases the merchant), but the VERBATIM descriptor off the
+        // statement text is identical across both runs.
+        let verbatim = "SHOPEE SINGAPORE Shopee SINGAPORE"
+
+        let first = await importer.insert(
+            lines: [line("SHOPEE SINGAPORE", 10.27, descriptor: verbatim)],
+            possiblyTruncated: false
+        )
+        XCTAssertEqual(first.imported, 1)
+
+        // Re-import: merchant paraphrased differently, SAME verbatim descriptor.
+        let second = await importer.insert(
+            lines: [line("SHOPEE SINGAPORE Shopee", 10.27, descriptor: verbatim)],
+            possiblyTruncated: false
+        )
+        XCTAssertEqual(second.imported, 0, "same verbatim descriptor must dedup despite paraphrased merchant")
+        XCTAssertEqual(second.skippedDuplicates, 1)
+        XCTAssertEqual(try storedCount(), 1, "no duplicate row on re-import")
+    }
+
+    // MARK: - (g) Legacy row (empty descriptor) is matched, not re-added
+
+    func test_legacyRowNoDescriptor_matchedByBucket_insertsZero() async throws {
+        // A pre-fix row (or a receipt / manual row) has an EMPTY dedupeDescriptor.
+        // A statement re-import that now carries a verbatim descriptor must still
+        // recognise it via the legacy bucket fallback (amount + date + currency)
+        // so existing data is never re-duplicated.
+        try seed(merchant: "SHOPEE SINGAPORE", amount: 5.97, source: .receipt)
+
+        let result = await importer.insert(
+            lines: [line("Shopee", 5.97, descriptor: "SHOPEE SINGAPORE Shopee SINGAPORE")],
+            possiblyTruncated: false
+        )
+        XCTAssertEqual(result.imported, 0, "legacy empty-descriptor row matched on amount+date+currency")
+        XCTAssertEqual(result.skippedDuplicates, 1)
+        XCTAssertEqual(try storedCount(), 1, "legacy row is not re-duplicated")
+    }
+
+    // MARK: - (h) Same amount + day, different descriptors — both import
+
+    func test_sameAmountDay_differentDescriptors_bothImport_thenReimportZero() async throws {
+        let lines = [
+            line("Cafe A", 8.0, descriptor: "CAFE ALPHA SINGAPORE SG"),
+            line("Cafe B", 8.0, descriptor: "BETA COFFEE ROASTERS SG")
+        ]
+
+        let first = await importer.insert(lines: lines, possiblyTruncated: false)
+        XCTAssertEqual(first.imported, 2, "distinct descriptors are distinct transactions")
+        XCTAssertEqual(first.skippedDuplicates, 0)
+        XCTAssertEqual(try storedCount(), 2)
+
+        let second = await importer.insert(lines: lines, possiblyTruncated: false)
+        XCTAssertEqual(second.imported, 0, "re-import is idempotent")
+        XCTAssertEqual(second.skippedDuplicates, 2)
+        XCTAssertEqual(try storedCount(), 2)
+    }
+
+    // MARK: - (i) Three identical descriptors — 3 then 0
+
+    func test_tripleIdenticalDescriptor_firstThreeThenZero() async throws {
+        let verbatim = "KULT YARD @ TIONG BAHRU SG"
+        let lines = [
+            line("Kult Yard", 16.5, descriptor: verbatim),
+            line("Kult Yard", 16.5, descriptor: verbatim),
+            line("Kult Yard", 16.5, descriptor: verbatim)
+        ]
+
+        let first = await importer.insert(lines: lines, possiblyTruncated: false)
+        XCTAssertEqual(first.imported, 3, "three identical lines all import on first pass")
+        XCTAssertEqual(try storedCount(), 3)
+
+        let second = await importer.insert(lines: lines, possiblyTruncated: false)
+        XCTAssertEqual(second.imported, 0, "3 match 3 → nothing re-adds")
+        XCTAssertEqual(second.skippedDuplicates, 3)
+        XCTAssertEqual(try storedCount(), 3)
     }
 
     // MARK: - existingCount helper counts multiplicity, not existence

--- a/mobile/PersonalDashboardTests/StatementDedupeReconciliationTests.swift
+++ b/mobile/PersonalDashboardTests/StatementDedupeReconciliationTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+import SwiftData
+@testable import PersonalDashboard
+
+/// Count-reconciliation dedup for statement import (#208).
+///
+/// Statement rows carry no per-line reference, so two genuine same-day /
+/// same-amount charges at one merchant (e.g. two coffees) are structurally
+/// identical. The old boolean `ExpenseDedupe.exists` skipped every line after
+/// the first and under-counted real spend. These tests pin the new behaviour:
+/// for each structural class the importer inserts `max(0, N - M)` rows, where N
+/// is what the statement asserts and M is what is already stored.
+///
+/// Runs fully offline: every line is SGD, which `FXService` short-circuits to a
+/// 1.0 rate with no network call. Each test uses an isolated in-memory store so
+/// nothing touches the on-disk singleton.
+@MainActor
+final class StatementDedupeReconciliationTests: XCTestCase {
+
+    private var store: SwiftDataStore!
+    private var importer: StatementImporter!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        store = SwiftDataStore(container: SwiftDataStore.makeInMemory())
+        importer = StatementImporter(anthropic: AnthropicClient(), store: store)
+    }
+
+    override func tearDown() async throws {
+        store = nil
+        importer = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func line(
+        _ merchant: String,
+        _ amount: Double?,
+        day: String = "2026-05-01",
+        type: ExtractedStatementLine.LineType = .purchase,
+        currency: String = "SGD"
+    ) -> ExtractedStatementLine {
+        ExtractedStatementLine(
+            merchant: merchant,
+            date: day,
+            amount: amount,
+            currency: currency,
+            type: type,
+            category: "food_and_dining"
+        )
+    }
+
+    private func storedCount() throws -> Int {
+        try store.context.fetchCount(FetchDescriptor<LocalExpense>())
+    }
+
+    /// Seed a stored expense directly (models a row created by another path —
+    /// receipt / email / manual). Uses the same date normalisation the importer
+    /// uses so the structural keys line up.
+    @discardableResult
+    private func seed(
+        merchant: String,
+        amount: Double,
+        day: String = "2026-05-01",
+        source: ExpenseSource,
+        isRefund: Bool = false
+    ) throws -> LocalExpense {
+        let date = StatementImporter.parseDate(day) ?? Date()
+        return try ExpenseService(store: store).addExpense(
+            date: date,
+            category: .other,
+            merchant: merchant,
+            expenseDescription: nil,
+            originalAmount: amount,
+            originalCurrency: "SGD",
+            sgdAmount: amount,
+            fxRate: 1.0,
+            paymentMethod: nil,
+            source: source,
+            isRefund: isRefund
+        )
+    }
+
+    // MARK: - (a) Two identical lines both import
+
+    func test_twoIdenticalLines_bothImport() async throws {
+        let result = await importer.insert(
+            lines: [line("Kult Yard", 6.5), line("Kult Yard", 6.5)],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.imported, 2, "both same-day coffees must import (N=2, M=0)")
+        XCTAssertEqual(result.skippedDuplicates, 0)
+        XCTAssertEqual(try storedCount(), 2)
+        XCTAssertEqual(result.totalParsed, 2)
+    }
+
+    // MARK: - (b) Re-import of the same statement inserts zero
+
+    func test_reimportSameStatement_insertsZero() async throws {
+        let lines = [line("Kult Yard", 6.5), line("Kult Yard", 6.5)]
+
+        let first = await importer.insert(lines: lines, possiblyTruncated: false)
+        XCTAssertEqual(first.imported, 2)
+
+        let second = await importer.insert(lines: lines, possiblyTruncated: false)
+        XCTAssertEqual(second.imported, 0, "clean re-import is idempotent (N=2, M=2)")
+        XCTAssertEqual(second.skippedDuplicates, 2)
+        XCTAssertEqual(try storedCount(), 2, "no new rows on re-import")
+    }
+
+    // MARK: - (c) Truncated first import self-heals
+
+    func test_truncatedFirstImport_thenFull_insertsDeficit() async throws {
+        // First import landed only 1 of 2 (truncation).
+        let partial = await importer.insert(lines: [line("Kult Yard", 6.5)], possiblyTruncated: false)
+        XCTAssertEqual(partial.imported, 1)
+
+        // Re-import the full statement (2 lines): exactly the missing one lands.
+        let full = await importer.insert(
+            lines: [line("Kult Yard", 6.5), line("Kult Yard", 6.5)],
+            possiblyTruncated: false
+        )
+        XCTAssertEqual(full.imported, 1, "self-heals the missing line (N=2, M=1)")
+        XCTAssertEqual(full.skippedDuplicates, 1)
+        XCTAssertEqual(try storedCount(), 2, "total reaches the true 2")
+    }
+
+    // MARK: - (d) Receipt already logged for one visit is absorbed
+
+    func test_receiptOverlap_absorbsOneAndImportsRest() async throws {
+        // A receipt for one of the two visits was already logged (non-pdf source).
+        try seed(merchant: "Kult Yard", amount: 6.5, source: .receipt)
+
+        let result = await importer.insert(
+            lines: [line("Kult Yard", 6.5), line("Kult Yard", 6.5)],
+            possiblyTruncated: false
+        )
+        XCTAssertEqual(result.imported, 1, "statement tops up to the true count (N=2, M=1)")
+        XCTAssertEqual(result.skippedDuplicates, 1)
+        XCTAssertEqual(try storedCount(), 2, "receipt + one statement row = the true 2")
+    }
+
+    // MARK: - (e) Refund reconciles in its own direction class
+
+    func test_sameDaySameAmount_purchaseAndRefund_bothImport() async throws {
+        let result = await importer.insert(
+            lines: [
+                line("Zara", 50, type: .purchase),
+                line("Zara", 50, type: .refund)
+            ],
+            possiblyTruncated: false
+        )
+        // Direction is part of the structural class, so purchase and refund are
+        // different classes: each has N=1, M=0 → both import.
+        XCTAssertEqual(result.imported, 2)
+        XCTAssertEqual(result.refunds, 1)
+        XCTAssertEqual(result.skippedDuplicates, 0)
+        XCTAssertEqual(try storedCount(), 2)
+    }
+
+    // MARK: - Bucket invariant with a mixed statement
+
+    func test_mixedStatement_bucketsReconcile() async throws {
+        let result = await importer.insert(
+            lines: [
+                line("Kult Yard", 6.5),                 // import
+                line("Kult Yard", 6.5),                 // import (same class, N=2 M=0)
+                line("Autopay", 200, type: .payment),   // ignored (never imported)
+                line("Zara", 50, type: .refund),        // import (refund class)
+                line("Broken", nil)                     // failed (no amount)
+            ],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.imported, 3)
+        XCTAssertEqual(result.refunds, 1)
+        XCTAssertEqual(result.ignoredNonSpend, 1)
+        XCTAssertEqual(result.failed, 1)
+        XCTAssertEqual(result.skippedDuplicates, 0)
+        // The core accounting invariant must always hold.
+        XCTAssertEqual(
+            result.imported + result.skippedDuplicates + result.ignoredNonSpend + result.failed,
+            result.totalParsed
+        )
+        XCTAssertEqual(result.totalParsed, 5)
+    }
+
+    // MARK: - existingCount helper counts multiplicity, not existence
+
+    func test_existingCount_reflectsMultiplicity() async throws {
+        try seed(merchant: "Kult Yard", amount: 6.5, source: .receipt)
+        try seed(merchant: "Kult Yard", amount: 6.5, source: .pdf)
+        try seed(merchant: "Kult Yard", amount: 6.5, day: "2026-05-02", source: .pdf) // different day
+
+        let proposed = ExpenseDedupe.Proposed(
+            merchant: "Kult Yard",
+            date: Calendar(identifier: .gregorian).startOfDay(for: StatementImporter.parseDate("2026-05-01")!),
+            originalAmount: 6.5,
+            originalCurrency: "SGD",
+            sourceReference: "",
+            isRefund: false
+        )
+        let count = ExpenseDedupe.existingCount(matching: proposed, context: store.context)
+        XCTAssertEqual(count, 2, "counts both same-day rows, ignores the different day")
+    }
+}

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -119,6 +119,28 @@ targets:
         CODE_SIGN_STYLE: Automatic
         SWIFT_VERSION: "5.0"
         TARGETED_DEVICE_FAMILY: "1"
+        GENERATE_INFOPLIST_FILE: YES
+
+  # Logic-level unit tests, hosted in the app so `@testable import
+  # PersonalDashboard` can reach the importer + dedup internals. Wired for the
+  # `test` action only (not `all`), so `ship-lan.sh`'s archive of the app target
+  # never builds it. Depending on the app target makes xcodegen set TEST_HOST /
+  # BUNDLE_LOADER automatically.
+  PersonalDashboardTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: PersonalDashboardTests
+    dependencies:
+      - target: PersonalDashboard
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.akshaysharma.personaldashboard.tests
+        DEVELOPMENT_TEAM: "PJFPUSSNUW"
+        CODE_SIGN_STYLE: Automatic
+        SWIFT_VERSION: "5.0"
+        TARGETED_DEVICE_FAMILY: "1"
+        GENERATE_INFOPLIST_FILE: YES
 
 schemes:
   PersonalDashboard:
@@ -126,7 +148,9 @@ schemes:
       targets:
         PersonalDashboard: all
         PersonalDashboardUITests: [test]
+        PersonalDashboardTests: [test]
     test:
       gatherCoverageData: false
       targets:
+        - PersonalDashboardTests
         - PersonalDashboardUITests


### PR DESCRIPTION
## Summary

Statement import dropped legitimate duplicate transactions: when the same merchant charged the same amount on the same day more than once (e.g. three identical Kult Yard coffees), only the first was kept. The rest were counted as duplicates and skipped, so spend was under-counted.

The dedup was a boolean "does an equivalent row exist?", which cannot represent multiplicity. This moves to count reconciliation, and keys the match on a verbatim statement descriptor so re-import stays idempotent.

## How it works

- **Count reconciliation.** For each transaction class the statement asserts N lines; if M matching rows already exist, insert max(0, N - M). Genuine duplicates both import; re-import adds zero; a truncated import self-heals on re-import.
- **Verbatim descriptor key.** The dedup key uses the raw statement descriptor (copied verbatim by the parser), not the paraphrased merchant. The LLM was rendering the merchant inconsistently across runs (e.g. `SHOPEE SINGAPORE` vs `SHOPEE SINGAPORE Shopee`), which broke re-import idempotency. Amount, date, and currency come from the statement's numeric columns and are stable. The clean merchant is still stored and shown in the finance list; only the hidden key uses the descriptor.
- **Migration-safe.** Rows imported before this change have no stored descriptor, so they match on amount+date+currency within their bucket. A future re-import consumes them and inserts nothing, so existing data is not re-duplicated.

## Data model

Two additive fields, no removals: `isRefund` already present from #206; this adds `dedupeDescriptor: String = ""` on LocalExpense (empty default = safe lightweight migration; legacy rows read as no-descriptor). Round-trips through backup export/import.

## Scope

Statement import only. The email/receipt dedup path (boolean exists + reference matching) is unchanged. Card payments still ignored; refunds still import and net in their own direction bucket.

## Test plan

Unit tests: 11/11 passing (`xcodebuild test`, iPhone 17 Pro sim). Covers:
- [x] Two identical lines both import; re-import inserts zero
- [x] Merchant paraphrased differently but same verbatim descriptor -> 0 on re-import (the SHOPEE bug)
- [x] Legacy row with no descriptor -> matched on amount+date+currency -> not re-duplicated
- [x] Different merchants, same amount+day -> both import
- [x] Kult Yard triple -> 3 on first import, 0 on re-import
- [x] Truncation heal, refund direction, bucket invariant

Device QA:
- [x] Re-import of a previously double-added statement adds zero rows
- [x] Fresh statement imports every line; finance list shows clean merchant names

Closes #208
