### PR TITLE
feat(ios): add new list items to the top of the list

### DIFF
--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -727,7 +727,7 @@ struct ExecuteDraftAction {
         }
 
         var items = row.items
-        items.append(contentsOf: newItems)
+        items.insert(contentsOf: newItems, at: 0)
         row.items = items
         row.updatedAt = Date()
         try save()

--- a/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
@@ -128,7 +128,7 @@ final class ListsViewModel {
         guard !text.isEmpty,
               let listIndex = lists.firstIndex(where: { $0.id == list.id }) else { return }
         var snapshot = lists[listIndex]
-        snapshot.items.append(ChecklistItem(text: text, checked: false))
+        snapshot.items.insert(ChecklistItem(text: text, checked: false), at: 0)
         lists[listIndex] = snapshot
         await update(snapshot)
     }


### PR DESCRIPTION
## Summary
- New list items are now prepended to the top instead of appended to the bottom.
- Manual add bar (`ListsViewModel.addItem`) inserts at index 0.
- AI add-to-list (`ExecuteDraftAction.addToList`) inserts new items as a block at index 0, preserving relative order.
- Existing checkbox behaviour unchanged: checked items still sink to the bottom.

Closes #214

## Test plan
- [x] Clean simulator build, installed to device.
- [ ] Manual add: typed item appears at the top.
- [ ] AI add: multiple items appear at the top in order.
- [ ] Toggle check/uncheck still sinks checked items to the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)