### PR TITLE
fix(ios): make receipts inbox backup toggle purple for consistency

### DIFF
--- a/mobile/PersonalDashboard/Views/Settings/BackupSettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/BackupSettingsView.swift
@@ -128,7 +128,7 @@ struct BackupSettingsView: View {
 
                 Toggle("", isOn: $enabled)
                     .labelsHidden()
-                    .tint(Tokens.accent(for: .settings))
+                    .tint(Tokens.accentItineraries)
             }
             .padding(.horizontal, Space.lg)
             .padding(.vertical, Space.md)


### PR DESCRIPTION
## Summary
- The auto-add-from-forwarded-email toggle already uses the purple `accentItineraries` tint; the backup toggle used the slate `accentSettings` tint.
- Aligns the backup toggle to the same purple token so both receipts inbox toggles read consistently in light and dark mode.

Closes #215

## Test plan
- [x] Clean simulator build, installed to device.
- [ ] Both toggles read as the same purple when on (light + dark mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)