### PR TITLE
fix(ios): keep Finance category amounts on one line

### DIFF
--- a/mobile/PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
@@ -132,8 +132,10 @@ struct FinanceDashboardBand: View {
             Text(Self.formatSGD(entry.total))
                 .font(.edFootnote)
                 .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
                 .foregroundStyle(Tokens.inkSoft)
-                .frame(width: 86, alignment: .trailing)
+                .frame(width: 108, alignment: .trailing)
         }
     }
 


### PR DESCRIPTION
## Summary
- Category amounts wrapped to two lines when wide (e.g. `SGD 2,051.93`) because the label sat in a fixed 86pt frame with no single-line constraint.
- Widen the amount column to 108pt and add `lineLimit(1)` + `minimumScaleFactor(0.75)` so amounts always render on one line, shrinking slightly for unusually large values instead of wrapping.

Closes #216

## Test plan
- [x] Clean simulator build, installed to device.
- [ ] Shopping's `SGD 2,051.93` renders on one line, aligned with other rows (light + dark mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)