### PR TITLE
feat(ios): live-refresh Notes/Lists/Tasks after voice or chat capture

### DIFF
--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -1275,6 +1275,10 @@ struct ExecuteDraftAction {
     private func save() throws {
         do {
             try store.context.save()
+            // Notify manual-fetch surfaces (Tasks / Notes / Lists) that the
+            // shared store changed so they can live-refresh. This is the single
+            // choke point for both the voice-capture and chat write paths.
+            NotificationCenter.default.post(name: .localStoreDidChange, object: nil)
         } catch {
             throw DraftExecutionError.persistence(error)
         }

--- a/mobile/PersonalDashboard/Cache/StoreChange.swift
+++ b/mobile/PersonalDashboard/Cache/StoreChange.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Notification.Name {
+    /// Broadcast after a successful write to the shared SwiftData store from
+    /// the AI capture (voice / Shortcut) or chat paths.
+    ///
+    /// Surfaces backed by manual-fetch view models (Tasks / Notes / Lists)
+    /// observe this and re-run their `load()`, since they don't use the
+    /// auto-updating `@Query` that keeps Activity / Finance / Itineraries live.
+    static let localStoreDidChange = Notification.Name("dev.dexter.localStoreDidChange")
+}

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 struct ListsView: View {
     @State private var viewModel = ListsViewModel()
@@ -54,6 +55,10 @@ struct ListsView: View {
             }
         }
         .activeSection(.lists)
+        // Live-refresh when the voice-capture or chat path writes a list / item.
+        .onReceive(NotificationCenter.default.publisher(for: .localStoreDidChange)) { _ in
+            Task { await viewModel.load() }
+        }
         .task { await viewModel.load() }
         .onAppear {
             // Activity timeline deep-link consumption. Same shape as TasksView:

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 struct NotesView: View {
     @State private var viewModel = NotesViewModel()
@@ -81,6 +82,10 @@ struct NotesView: View {
             }
         }
         .activeSection(.notes)
+        // Live-refresh when the voice-capture or chat path writes a note.
+        .onReceive(NotificationCenter.default.publisher(for: .localStoreDidChange)) { _ in
+            Task { await viewModel.load() }
+        }
         .task {
             await viewModel.load()
             if let id = pendingFolderLaunchId,

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 struct TasksView: View {
     @State private var viewModel = TodosViewModel()
@@ -77,6 +78,10 @@ struct TasksView: View {
             .animation(.easeOut(duration: 0.15), value: draftBucket)
         }
         .activeSection(.tasks)
+        // Live-refresh when the voice-capture or chat path writes a task.
+        .onReceive(NotificationCenter.default.publisher(for: .localStoreDidChange)) { _ in
+            Task { await viewModel.load() }
+        }
         .task { await viewModel.load() }
         .onAppear {
             // Activity timeline deep-link consumption. The Activity surface


### PR DESCRIPTION
## Summary
- Items added via voice capture (Action Button / Shortcut) or in-app chat now appear on the Notes, Lists, and Tasks surfaces live, without a manual pull-to-refresh or app relaunch.
- Root cause: those three surfaces use `@Observable` view models that fetch once (in `init` + a first-mount `.task`), with no `@Query` and no store-change observer, unlike the `@Query`-backed Activity/Finance/Itineraries views which were already live.
- Fix: broadcast a lightweight `.localStoreDidChange` notification at the single `save()` choke point in `ExecuteDraftAction` (covers both the capture and chat write paths, all entity types); `TasksView`/`NotesView`/`ListsView` observe it and re-run their existing `load()`. No view-model rewrite, no schema change.

## Changes
- New `Cache/StoreChange.swift` defining `Notification.Name.localStoreDidChange`.
- `AI/ExecuteDraftAction.swift`: post the notification after a successful `context.save()`.
- `Views/Tasks/TasksView.swift`, `Views/Notes/NotesView.swift`, `Views/Lists/ListsView.swift`: `.onReceive` listener that reloads.

Closes #228

## Test plan
- [x] `xcodegen generate` + `xcodebuild -scheme PersonalDashboard build` → BUILD SUCCEEDED
- [x] Installed to device via `devicectl`
- [ ] Device QA (waived by request): voice/chat-created todo, note, and list item appear live on the open surface; existing add/toggle/delete still animate; Activity feed unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)