### PR TITLE
feat(ios): capture and show flight arrival time on itinerary

### DIFF
--- a/mobile/PersonalDashboard/AI/EmailToItinerary.swift
+++ b/mobile/PersonalDashboard/AI/EmailToItinerary.swift
@@ -661,7 +661,7 @@ struct EmailToItinerary {
         // backfill the ticket text fields onto an item created before Phase 2.
         // Barcode / attachment stamping is NOT done here — that lives in the
         // decode enrichment step, which handles the file bytes directly.
-        for key in ["start_time", "end_time", "end_date", "notes", "address", "google_maps_link", "seat", "gate", "venue"] {
+        for key in ["start_time", "arrival_time", "end_time", "end_date", "notes", "address", "google_maps_link", "seat", "gate", "venue"] {
             if let raw = dict[key]?.stringValue {
                 let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty else { continue }
@@ -683,7 +683,8 @@ struct EmailToItinerary {
             row.googleMapsLink,
             row.seat,
             row.gate,
-            row.venue
+            row.venue,
+            row.arrivalTime
         )
 
         do {
@@ -709,6 +710,7 @@ struct EmailToItinerary {
             || after.seat != before.6
             || after.gate != before.7
             || after.venue != before.8
+            || after.arrivalTime != before.9
         return changed ? itemUUID : nil
     }
 
@@ -1257,7 +1259,7 @@ struct EmailToItinerary {
 
         MAPPING RULES:
         - Hotel / accommodation / Airbnb confirmation -> kind "stay". Set day_date to the check-in date and end_date to the check-out date (stays require end_date). Include the hotel name in the title.
-        - Flight, train, bus, ferry, car transfer -> kind "activity" (there is no transport kind). Title like "Flight BA123 LHR->FCO" or "Train to Kyoto". Put the departure datetime in start_time when known. For a multi-leg flight or multi-segment journey (connections, layovers, return legs), create a SEPARATE activity item for EACH leg — each with its own departure date in day_date, its departure datetime in start_time, and the route/flight number in the title (e.g. "Flight SQ424 SIN->DXB", "Flight SQ494 DXB->LHR"). Never merge multiple legs into one item, even when they share one confirmation code.
+        - Flight, train, bus, ferry, car transfer -> kind "activity" (there is no transport kind). Title like "Flight BA123 LHR->FCO" or "Train to Kyoto". Put the departure datetime in start_time and, when the booking states it, the arrival (landing) datetime in arrival_time. For a multi-leg flight or multi-segment journey (connections, layovers, return legs), create a SEPARATE activity item for EACH leg — each with its own departure date in day_date, its departure datetime in start_time, its arrival datetime in arrival_time, and the route/flight number in the title (e.g. "Flight SQ424 SIN->DXB", "Flight SQ494 DXB->LHR"). Never merge multiple legs into one item, even when they share one confirmation code.
         - Tour, attraction ticket, event, show -> kind "activity".
         - Restaurant reservation -> kind "restaurant", with the reservation time in start_time.
         - Sightseeing place with no booking -> kind "place".
@@ -1267,6 +1269,7 @@ struct EmailToItinerary {
         - title: concise and specific (vendor / flight number / hotel name).
         - notes: confirmation/booking number, times, and any other useful detail from the email. Keep it factual. The physical address goes in the address field (below), not here, so don't duplicate it verbatim into notes.
         - start_time: full ISO 8601 datetime with timezone when the email gives a clear time; otherwise omit.
+        - arrival_time: for a flight/train/bus/ferry/transfer (kind "activity"), the arrival (landing) datetime as full ISO 8601 with timezone when the booking states it; otherwise omit. Not for stays, restaurants, or places.
         - For stays only: end_date (check-out) is required; end_time optional.
         - address: the venue's physical/postal address when the email or attachment contains one (hotel or Airbnb address for a stay, restaurant address, activity venue, the airport or terminal for a flight-as-activity). Applies to every kind, since they are all physical locations. Copy the address text as written; omit or use empty string when the source gives no address.
         - google_maps_link: if the email or attachment contains an explicit Google Maps URL for the location (maps.app.goo.gl, goo.gl/maps, google.com/maps, maps.google.com), copy it verbatim into this field. Do NOT invent, guess, or construct a link from an address. The device builds the map link from the address field automatically, so focus on getting the address text right and leave google_maps_link empty unless a real link is present in the source.

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -961,6 +961,13 @@ struct ExecuteDraftAction {
             // model can omit the field entirely; we don't require it.
             let startTime = parseWallClockTime(dict["start_time"]?.stringValue)
 
+            // Activity-only arrival/landing time (same wall-clock parse as
+            // start_time). Discarded for non-activity kinds even if the model
+            // accidentally provided it — arrival only renders on activity rows.
+            let arrivalTime = kind == .activity
+                ? parseWallClockTime(dict["arrival_time"]?.stringValue)
+                : nil
+
             // Stay-only check-out fields. For non-stay kinds, both are
             // discarded even if the model accidentally provided them.
             var endDateValue: Date? = nil
@@ -1019,6 +1026,7 @@ struct ExecuteDraftAction {
                 startTime: startTime,
                 endDate: endDateValue,
                 endTime: endTimeValue,
+                arrivalTime: arrivalTime,
                 sortOrder: maxForDay + 1,
                 address: address,
                 googleMapsLink: mapsLink,
@@ -1159,6 +1167,16 @@ struct ExecuteDraftAction {
                 row.startTime = parsed; changed = true
             }
         }
+        // arrival_time: same empty/"null"/value tri-state as start_time. The
+        // stale-shape guard below clears it when the kind isn't activity.
+        if let raw = input["arrival_time"]?.stringValue {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == "null" {
+                row.arrivalTime = nil; changed = true
+            } else if !trimmed.isEmpty, let parsed = parseWallClockTime(trimmed) {
+                row.arrivalTime = parsed; changed = true
+            }
+        }
         // end_date / end_time: same tri-state. Cleared automatically when
         // kind switches away from stay (handled below after `changed` check).
         if let raw = input["end_date"]?.stringValue {
@@ -1233,6 +1251,11 @@ struct ExecuteDraftAction {
         if row.kindEnum != .stay {
             if row.endDate != nil { row.endDate = nil; changed = true }
             if row.endTime != nil { row.endTime = nil; changed = true }
+        }
+        // arrivalTime is activity-only; clear it if the kind moved away from
+        // activity so a stale arrival can't leak onto a place/restaurant/stay.
+        if row.kindEnum != .activity, row.arrivalTime != nil {
+            row.arrivalTime = nil; changed = true
         }
 
         guard changed else {

--- a/mobile/PersonalDashboard/AI/TicketExtraction.swift
+++ b/mobile/PersonalDashboard/AI/TicketExtraction.swift
@@ -135,6 +135,7 @@ struct TicketExtraction {
             ?? cal.startOfDay(for: trip.startDate)
 
         let startTime = Self.parseWallClockTime(extracted?.startTime)
+        let arrivalTime = Self.parseWallClockTime(extracted?.arrivalTime)
 
         // Merge ticket meta: BCBP is authoritative for the machine-read codes;
         // the LLM fills the human-readable extras it can see on the pass.
@@ -196,6 +197,7 @@ struct TicketExtraction {
             startTime: startTime,
             endDate: nil,
             endTime: nil,
+            arrivalTime: arrivalTime,
             sortOrder: maxForDay + 1,
             address: address,
             googleMapsLink: mapsLink,
@@ -346,6 +348,7 @@ struct ExtractedTicket {
     var kind: String?
     var dayDate: String?
     var startTime: String?
+    var arrivalTime: String?
     var venue: String?
     var address: String?
     var seat: String?
@@ -373,6 +376,7 @@ struct ExtractedTicket {
         kind = s("kind")
         dayDate = s("day_date")
         startTime = s("start_time")
+        arrivalTime = s("arrival_time")
         venue = s("venue")
         address = s("address")
         seat = s("seat")
@@ -414,6 +418,7 @@ extension TicketExtraction {
                 ]),
                 "day_date": field("The date the ticket is valid / the flight departs / the event starts, ISO 8601 (yyyy-MM-dd). Read the printed date. If the year is missing, resolve it from the trip's date range provided below."),
                 "start_time": field("OPTIONAL departure / start / boarding time as a full ISO 8601 datetime with timezone if printed (e.g. 2026-06-14T19:00:00+02:00). The date portion must match day_date. Omit if no time is shown."),
+                "arrival_time": field("OPTIONAL arrival / landing / end time — the time the traveller arrives at the destination — as a full ISO 8601 datetime with timezone if printed (e.g. 2026-06-14T22:35:00+01:00), or the ticket's stated local time in HH:mm (24h). For a flight/train this is the landing / arrival time. Omit for events and when no arrival time is shown."),
                 "venue": field("OPTIONAL venue / location NAME for an event (e.g. \"The O2, London\", \"Wembley Stadium\"). Omit for flights."),
                 "address": field("OPTIONAL postal address of the venue / terminal / departure point, as printed. Omit if none."),
                 "seat": field("OPTIONAL seat as printed (e.g. \"12A\", \"Block A Row 14 Seat 7\"). Omit if none."),

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -294,6 +294,10 @@ enum ToolDefinitions {
                 "type": .string("string"),
                 "description": .string("OPTIONAL start time for this item as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T19:00:00-04:00 or 2026-06-14T11:00:00Z). The DATE portion MUST match day_date. Set this whenever the user mentions a time (e.g., 'dinner at 8', '11am check-in', 'tour at 14:00'); otherwise omit. Items without a start_time render as 'untimed' on the timeline.")
             ]),
+            "arrival_time": .object([
+                "type": .string("string"),
+                "description": .string("ACTIVITY ONLY, OPTIONAL: the arrival / landing / end time for a timed transport activity (a flight's landing, a train's arrival) as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T22:35:00+01:00). The DATE portion should match day_date. Set this together with start_time (departure) whenever the booking states an arrival time for a flight/train/bus/ferry/transfer; otherwise omit. Not for stays (use end_time), places, or restaurants.")
+            ]),
             "end_date": .object([
                 "type": .string("string"),
                 "description": .string("STAY ONLY: ISO 8601 date for the check-out day (e.g., 2026-06-17). REQUIRED when kind is 'stay' (use day_date + 1 if user didn't specify, since most stays are at least one night). Must be > day_date. Omit for non-stay kinds.")
@@ -387,6 +391,7 @@ enum ToolDefinitions {
                 "title": string("New title. Use empty string to keep unchanged."),
                 "notes": string("New notes. Use empty string to keep unchanged, or the literal \"null\" to clear."),
                 "start_time": string("New start time as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T19:00:00-04:00). The date portion should match day_date. Use empty string to keep unchanged, or the literal \"null\" to clear (make the item untimed)."),
+                "arrival_time": string("ACTIVITY ONLY: new arrival / landing / end time (for a flight or train) as a full ISO 8601 datetime with timezone (e.g., 2026-06-14T22:35:00+01:00). The date portion should match day_date. Set together with start_time. Use empty string to keep unchanged, or the literal \"null\" to clear. Ignored for non-activity kinds."),
                 "end_date": string("STAY ONLY: new check-out date in ISO 8601 (e.g., 2026-06-17). Must be > day_date. Use empty string to keep unchanged, or the literal \"null\" to clear."),
                 "end_time": string("STAY ONLY: new check-out time as a full ISO 8601 datetime with timezone (e.g., 2026-06-17T11:00:00-04:00). The date portion should match end_date. Use empty string to keep unchanged, or the literal \"null\" to clear."),
                 "address": string("New postal address / location text for the location (e.g. hotel or restaurant address). The device builds the map link from this automatically. Use empty string to keep unchanged, or the literal \"null\" to clear."),

--- a/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalItineraryItem.swift
@@ -77,6 +77,17 @@ final class LocalItineraryItem {
     /// `startTime`). Only used when `endDate` is set.
     var endTime: Date?
 
+    /// Optional arrival / end time for a timed `.activity` item (a flight's
+    /// landing time, a train's arrival). Stored as UTC wall-clock exactly like
+    /// `startTime` — the stored `Date`'s UTC hour:minute equals the booking's
+    /// stated local time, so the timeline shows "10:35 → 15:35" without drifting
+    /// when the device timezone changes. Only meaningful when `startTime` is
+    /// also set. `nil` for untimed items and for kinds other than `.activity`.
+    /// Distinct from `endTime`, which is the stay-only check-out time. Additive
+    /// with a `nil` default so adding it to an existing install is a safe
+    /// lightweight migration (no data loss); NEVER remove or rename it.
+    var arrivalTime: Date?
+
     /// Ordering within a single day. Lower numbers render first; ties are
     /// broken by `createdAt`. Skeleton uses append-on-create (max + 1); a
     /// drag-to-reorder UI is a follow-up.
@@ -165,6 +176,7 @@ final class LocalItineraryItem {
         startTime: Date? = nil,
         endDate: Date? = nil,
         endTime: Date? = nil,
+        arrivalTime: Date? = nil,
         sortOrder: Int = 0,
         address: String = "",
         googleMapsLink: String = "",
@@ -187,6 +199,7 @@ final class LocalItineraryItem {
         self.startTime = startTime
         self.endDate = endDate
         self.endTime = endTime
+        self.arrivalTime = arrivalTime
         self.sortOrder = sortOrder
         self.address = address
         self.googleMapsLink = googleMapsLink

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -529,7 +529,14 @@ enum TimelineEntry: Identifiable {
         let timeFormat: (Date) -> String = { TimelineEntry.itineraryTimeFormatter.string(from: $0) }
         switch self {
         case .single(let item):
-            if let t = item.startTime { return timeFormat(t) }
+            if let dep = item.startTime {
+                // "10:35 → 15:35" when an arrival is also set; departure alone
+                // otherwise. Both render through the UTC-pinned formatter.
+                if let arr = item.arrivalTime {
+                    return "\(timeFormat(dep)) → \(timeFormat(arr))"
+                }
+                return timeFormat(dep)
+            }
             return "Anytime"
         case .stayCheckIn(let item):
             if let t = item.startTime { return "Check-in · \(timeFormat(t))" }
@@ -868,6 +875,11 @@ struct ItineraryItemEditorSheet: View {
     /// the kind first switches to stay.
     @State private var endDate: Date = Calendar.current.startOfDay(for: Date())
     @State private var hasEndTime: Bool = false
+    /// Activity only: the arrival / landing time. Shares the item's day for its
+    /// date component (like `startTime`), so the picker surfaces just the time.
+    /// Only settable when a departure (`hasTime`) is present.
+    @State private var arrivalTime: Date = Calendar.current.startOfDay(for: Date())
+    @State private var hasArrival: Bool = false
     @State private var notes: String = ""
     @State private var address: String = ""
     @State private var googleMapsLink: String = ""
@@ -902,6 +914,11 @@ struct ItineraryItemEditorSheet: View {
                         primaryDateField
                         if kind == .stay {
                             endDateField
+                        }
+                        // Arrival is activity-only and only meaningful once a
+                        // departure time is set (no lone arrival with no start).
+                        if kind == .activity && hasTime {
+                            arrivalTimeField
                         }
                         notesField
                         addressField
@@ -994,6 +1011,16 @@ struct ItineraryItemEditorSheet: View {
             // Default check-out time: 11 AM (most hotels). Same midnight
             // guard as the check-in time toggle.
             endDate = seededTime(on: endDate, defaultHour: 11)
+        }
+        .onChange(of: hasArrival) { _, newValue in
+            // Toggling arrival on: seed the picker at the departure time so it
+            // doesn't open at 12:00 AM; the user then nudges it forward.
+            guard newValue else { return }
+            let cal = Calendar.current
+            let comps = cal.dateComponents([.hour, .minute], from: arrivalTime)
+            if (comps.hour ?? 0) == 0 && (comps.minute ?? 0) == 0 {
+                arrivalTime = dayDate
+            }
         }
     }
 
@@ -1098,6 +1125,44 @@ struct ItineraryItemEditorSheet: View {
                         .tint(Tokens.accent(for: .itineraries))
                 }
                 .padding(Space.md)
+            }
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+        }
+    }
+
+    /// Activity-only arrival-time field. Arrival shares the item's day, so the
+    /// picker shows only the time. A toggle mirrors the "Include time" pattern;
+    /// the picker appears only when arrival is on, so it never surfaces a stray
+    /// 12:00 AM. Gated to `.activity` with a departure present by the caller.
+    private var arrivalTimeField: some View {
+        VStack(alignment: .leading, spacing: Space.fieldLabelGap) {
+            Text("Arrival time").eyebrow()
+            VStack(spacing: 0) {
+                HStack {
+                    Text("Include arrival time").font(.edBody).foregroundStyle(Tokens.inkSoft)
+                    Spacer()
+                    Toggle("", isOn: $hasArrival)
+                        .labelsHidden()
+                        .tint(Tokens.accent(for: .itineraries))
+                }
+                .padding(Space.md)
+
+                if hasArrival {
+                    Divider().background(Tokens.divider)
+
+                    HStack {
+                        DatePicker(
+                            "",
+                            selection: $arrivalTime,
+                            displayedComponents: .hourAndMinute
+                        )
+                        .labelsHidden()
+                        .tint(Tokens.accent(for: .itineraries))
+                        Spacer(minLength: 0)
+                    }
+                    .padding(Space.md)
+                }
             }
             .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
             .paperBorder(Tokens.border, radius: Radius.md)
@@ -1431,6 +1496,12 @@ struct ItineraryItemEditorSheet: View {
                     hasTime = true
                     dayDate = deviceLocalPickerDate(onDay: existing.dayDate, utcWallClock: start)
                 }
+                if let arrival = existing.arrivalTime {
+                    // Stored UTC wall-clock; seed the device-local picker on the
+                    // item's day so it surfaces the stated arrival time.
+                    hasArrival = true
+                    arrivalTime = deviceLocalPickerDate(onDay: existing.dayDate, utcWallClock: arrival)
+                }
                 if let end = existing.endDate {
                     endDate = end
                     if let endT = existing.endTime {
@@ -1468,6 +1539,12 @@ struct ItineraryItemEditorSheet: View {
         // unambiguous.
         let startTimeValue: Date? = hasTime ? utcWallClock(onDay: dayDate, timeFrom: dayDate) : nil
 
+        // Activity-only arrival time, stored UTC wall-clock on the item's day.
+        // Only when the kind is activity, a departure is set, and arrival is on.
+        let arrivalTimeValue: Date? = (kind == .activity && hasTime && hasArrival)
+            ? utcWallClock(onDay: dayDate, timeFrom: arrivalTime)
+            : nil
+
         // Stay-only end fields. Other kinds clear both.
         let endDateValue: Date? = kind == .stay ? cal.startOfDay(for: endDate) : nil
         let endTimeValue: Date? = (kind == .stay && hasEndTime) ? utcWallClock(onDay: endDate, timeFrom: endDate) : nil
@@ -1484,6 +1561,7 @@ struct ItineraryItemEditorSheet: View {
                 startTime: startTimeValue,
                 endDate: endDateValue,
                 endTime: endTimeValue,
+                arrivalTime: arrivalTimeValue,
                 sortOrder: nextSort,
                 address: cleanAddress,
                 googleMapsLink: cleanMapsLink
@@ -1508,6 +1586,7 @@ struct ItineraryItemEditorSheet: View {
                 existing.startTime = startTimeValue
                 existing.endDate = endDateValue
                 existing.endTime = endTimeValue
+                existing.arrivalTime = arrivalTimeValue
                 existing.updatedAt = Date()
             }
         }


### PR DESCRIPTION
## Summary
- Itinerary flight/transport rows now render `departure → arrival` (e.g. `10:35 → 15:35`) instead of departure only. Departure-only items are unchanged; non-activity items unaffected.
- New additive `arrivalTime: Date?` field on `LocalItineraryItem` (migration-safe; `endTime` stays architecturally stay-only).
- **Auto-capture**: email extraction (`EmailToItinerary`) and ticket-photo extraction (`TicketExtraction`) now capture the arrival/landing time, per leg — the multi-leg "separate item per leg" rule is preserved, each leg carrying its own departure + arrival.
- Chat/capture `add_itinerary_item` + `editItineraryItem` tools wired through (`ToolDefinitions`, `ExecuteDraftAction`), gated to `.activity`.
- Manual editor: optional "Include arrival time" toggle + picker for `.activity` items (only when a departure time is set).
- All times use the UTC wall-clock convention (parse via `parseWallClockTime`, round-trip via `utcWallClock`/`deviceLocalPickerDate`, display via the UTC-pinned formatter) so nothing drifts with device timezone.

Closes #232

## Test plan
- Installed on device (iPhone 16 Pro Max). QA: manual editor arrival toggle renders `dep → arr`; departure-only rows unchanged; forwarded flight email auto-populates arrival per leg; non-activity kinds unaffected; no timezone drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)