### PR TITLE
feat(ios): dedicated Parsed Files & Imports history screen

### DIFF
--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -355,6 +355,29 @@ struct StatementImporter {
             }
         }
 
+        // Persist a permanent parse record for the Parsed Files & Imports
+        // history (#234). Written on the SAME context the expenses were inserted
+        // on, so it lands in the same store. Recorded only when the run actually
+        // imported rows — a clean re-import that skips everything doesn't create
+        // an empty history entry (and the existing rows already have a record).
+        // Additive model, so this never changes the returned result or the
+        // summary alert; it's purely a side record.
+        if imported > 0 {
+            let record = LocalStatementImport(
+                fileName: statementFileName,
+                statementLabel: statementLabel,
+                imported: imported,
+                skippedDuplicates: skippedDuplicates,
+                ignoredNonSpend: ignoredNonSpend,
+                failed: failed,
+                refunds: refunds,
+                possiblyTruncated: possiblyTruncated,
+                importedExpenseUUIDs: importedUUIDs
+            )
+            store.context.insert(record)
+            try? store.context.save()
+        }
+
         return StatementImportResult(
             imported: imported,
             refunds: refunds,

--- a/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
+++ b/mobile/PersonalDashboard/Cache/SwiftDataStore.swift
@@ -35,6 +35,7 @@ final class SwiftDataStore {
                 LocalFXRate.self,
                 LocalProcessedEmail.self,
                 LocalEmailIngestLog.self,
+                LocalStatementImport.self,
             ])
             // SwiftData defaults the store URL to Application Support, but
             // on a fresh simulator that directory doesn't exist yet and
@@ -154,6 +155,7 @@ final class SwiftDataStore {
                 LocalFXRate.self,
                 LocalProcessedEmail.self,
                 LocalEmailIngestLog.self,
+                LocalStatementImport.self,
             ])
             let configuration = ModelConfiguration(
                 schema: schema,

--- a/mobile/PersonalDashboard/Models/Local/LocalStatementImport.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalStatementImport.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SwiftData
+
+/// One permanent record of a credit-card / bank statement PDF that was run
+/// through `StatementImporter` (#234). Gives the "Parsed Files & Imports"
+/// history a durable row per import, mirroring how `LocalEmailIngestLog`
+/// records each forwarded email. Before this model, a statement import's
+/// counts were shown once in an alert and then discarded.
+///
+/// Additive-only model — new @Model class, no field ever removed, so it is
+/// safe to add to the schema on existing installs (lightweight migration).
+@Model
+final class LocalStatementImport {
+    @Attribute(.unique) var clientUUID: UUID
+
+    /// The imported PDF's file name, e.g. "Citi_May2026.pdf". May be empty when
+    /// the picker gave no name.
+    var fileName: String
+
+    /// Parsed statement attribution label, e.g. "May 2026 Citi - 1234". Empty
+    /// when the header couldn't be read.
+    var statementLabel: String
+
+    /// Count buckets, mirroring `StatementImportResult`. `imported` counts every
+    /// row that produced a `LocalExpense` this run (spend + refund);
+    /// `refunds` is the refund subset.
+    var imported: Int
+    var skippedDuplicates: Int
+    var ignoredNonSpend: Int
+    var failed: Int
+    var refunds: Int
+
+    /// True when the model likely ran out of output budget on a very large
+    /// statement, so some tail rows may be missing.
+    var possiblyTruncated: Bool
+
+    /// Comma-joined `LocalExpense.clientUUID` strings inserted by this import,
+    /// so the detail screen can resolve and show exactly those expenses. Mirrors
+    /// the `LocalEmailIngestLog.addedItemUUIDs` pattern. Additive field with a
+    /// default so the migration stays lightweight. Empty when nothing landed.
+    var importedExpenseUUIDs: String = ""
+
+    var createdAt: Date
+
+    init(
+        clientUUID: UUID = UUID(),
+        fileName: String,
+        statementLabel: String,
+        imported: Int,
+        skippedDuplicates: Int,
+        ignoredNonSpend: Int,
+        failed: Int,
+        refunds: Int,
+        possiblyTruncated: Bool,
+        importedExpenseUUIDs: [UUID] = [],
+        createdAt: Date = Date()
+    ) {
+        self.clientUUID = clientUUID
+        self.fileName = fileName
+        self.statementLabel = statementLabel
+        self.imported = imported
+        self.skippedDuplicates = skippedDuplicates
+        self.ignoredNonSpend = ignoredNonSpend
+        self.failed = failed
+        self.refunds = refunds
+        self.possiblyTruncated = possiblyTruncated
+        self.importedExpenseUUIDs = importedExpenseUUIDs
+            .map { $0.uuidString.lowercased() }
+            .joined(separator: ",")
+        self.createdAt = createdAt
+    }
+
+    /// Parsed list of imported-expense UUIDs (as lowercased strings, matching
+    /// `LocalExpense.clientUUID` which is stored as a String).
+    var importedExpenseUUIDStrings: [String] {
+        importedExpenseUUIDs
+            .split(separator: ",")
+            .map { String($0) }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/mobile/PersonalDashboard/Services/EmailIngestService.swift
+++ b/mobile/PersonalDashboard/Services/EmailIngestService.swift
@@ -318,14 +318,18 @@ struct EmailIngestService {
         try? store.context.save()
     }
 
-    /// Keep the ingest log to the most recent 100 entries.
+    /// Keep the ingest log bounded. Raised from 100 to 2000 (#234): the log is
+    /// now a user-facing permanent history in Parsed Files & Imports, not just a
+    /// recent-activity strip, so it should retain far more. Still capped so the
+    /// store can't grow without bound on a device.
     private func trimLog() {
+        let cap = 2000
         var descriptor = FetchDescriptor<LocalEmailIngestLog>(
             sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
         )
-        descriptor.fetchLimit = 1000
-        guard let all = try? store.context.fetch(descriptor), all.count > 100 else { return }
-        for stale in all[100...] {
+        descriptor.fetchLimit = cap + 500
+        guard let all = try? store.context.fetch(descriptor), all.count > cap else { return }
+        for stale in all[cap...] {
             store.context.delete(stale)
         }
         try? store.context.save()

--- a/mobile/PersonalDashboard/Views/Settings/EmailInboxView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/EmailInboxView.swift
@@ -22,11 +22,6 @@ struct EmailInboxView: View {
     @State private var isFetching = false
     @State private var fetchSummary: String?
     @State private var saveConfirmation = false
-    @State private var selectedEntry: LocalEmailIngestLog?
-
-    // Recent log, newest first.
-    @Query(sort: \LocalEmailIngestLog.createdAt, order: .reverse)
-    private var logEntries: [LocalEmailIngestLog]
 
     var body: some View {
         NavigationStack {
@@ -37,7 +32,7 @@ struct EmailInboxView: View {
                         intro
                         credentialsSection
                         actionsSection
-                        logSection
+                        historyHint
                     }
                     .padding(.horizontal, Space.lg)
                     .padding(.top, Space.lg)
@@ -54,9 +49,6 @@ struct EmailInboxView: View {
                     Button("Save") { save() }
                         .fontWeight(.semibold)
                 }
-            }
-            .sheet(item: $selectedEntry) { entry in
-                EmailIngestDetailView(entry: entry)
             }
         }
         .onAppear(perform: load)
@@ -194,59 +186,15 @@ struct EmailInboxView: View {
         }
     }
 
-    @ViewBuilder
-    private var logSection: some View {
-        Section(title: "Recent activity") {
-            if logEntries.isEmpty {
-                Text("No emails processed yet. Forward a hotel or flight confirmation to get started.")
-                    .font(.edCaption)
-                    .foregroundStyle(Tokens.muted)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(Space.lg)
-            } else {
-                VStack(spacing: 0) {
-                    ForEach(Array(logEntries.prefix(10).enumerated()), id: \.element.clientUUID) { index, entry in
-                        if index > 0 { divider }
-                        logRow(entry)
-                    }
-                }
-            }
-        }
-    }
-
-    private func logRow(_ entry: LocalEmailIngestLog) -> some View {
-        Button {
-            selectedEntry = entry
-        } label: {
-            HStack(alignment: .top, spacing: Space.md) {
-                Image(systemName: entry.outcomeEnum.icon)
-                    .font(.system(size: 15))
-                    .foregroundStyle(color(for: entry.outcomeEnum))
-                    .frame(width: 20)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(entry.subject.isEmpty ? "(no subject)" : entry.subject)
-                        .font(.edBodyMedium)
-                        .foregroundStyle(Tokens.ink)
-                        .lineLimit(1)
-                    Text(entry.summary)
-                        .font(.edCaption)
-                        .foregroundStyle(Tokens.muted)
-                        .lineLimit(2)
-                    Text(entry.createdAt, format: .dateTime.month().day().hour().minute())
-                        .font(.edCaption)
-                        .foregroundStyle(Tokens.mutedSoft)
-                }
-                Spacer(minLength: Space.sm)
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .regular))
-                    .foregroundStyle(Tokens.mutedSoft)
-                    .padding(.top, 2)
-            }
-            .padding(.horizontal, Space.lg)
-            .padding(.vertical, Space.md)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
+    /// The processed-email history moved to the dedicated Parsed Files & Imports
+    /// screen (#234), so there's a single home for parsing history. This just
+    /// points the user there.
+    private var historyHint: some View {
+        Text("Processed emails now live in Settings › Parsed files & imports, alongside your statement imports.")
+            .font(.edCaption)
+            .foregroundStyle(Tokens.muted)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Space.xs)
     }
 
     // MARK: - Building blocks
@@ -272,14 +220,6 @@ struct EmailInboxView: View {
             .fill(Tokens.divider)
             .frame(height: 0.5)
             .padding(.leading, Space.lg)
-    }
-
-    private func color(for outcome: EmailIngestOutcome) -> Color {
-        switch outcome {
-        case .added:   return Tokens.success
-        case .skipped: return Tokens.muted
-        case .failed:  return Tokens.danger
-        }
     }
 
     private var canFetch: Bool {
@@ -368,66 +308,6 @@ private struct Section<Content: View>: View {
             content
                 .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
                 .paperBorder()
-        }
-    }
-}
-
-/// Diagnostics detail for a single ingest-log entry (#143): the outcome, the
-/// parsed body text the model actually received, and the trip-matching context
-/// it was given. This is what lets us tell a parser miss ("just a signature")
-/// apart from a real no-match, without needing the device console.
-private struct EmailIngestDetailView: View {
-    let entry: LocalEmailIngestLog
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        NavigationStack {
-            ZStack {
-                Tokens.paper.ignoresSafeArea()
-                ScrollView {
-                    VStack(alignment: .leading, spacing: Space.lg) {
-                        field("Outcome", entry.outcomeEnum.displayName)
-                        field("Subject", entry.subject.isEmpty ? "(none)" : entry.subject)
-                        if !entry.sender.isEmpty { field("From", entry.sender) }
-                        field("Summary", entry.summary)
-                        monospaceBlock("Parsed body the model received",
-                                       entry.debugBody.isEmpty ? "(not recorded)" : entry.debugBody)
-                        monospaceBlock("Trips the model could match against",
-                                       entry.debugTripContext.isEmpty ? "(not recorded)" : entry.debugTripContext)
-                    }
-                    .padding(Space.lg)
-                }
-            }
-            .navigationTitle("Email detail")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done") { dismiss() }
-                }
-            }
-        }
-    }
-
-    private func field(_ label: String, _ value: String) -> some View {
-        VStack(alignment: .leading, spacing: Space.xs) {
-            Text(label).eyebrow()
-            Text(value)
-                .font(.edBody)
-                .foregroundStyle(Tokens.ink)
-                .textSelection(.enabled)
-        }
-    }
-
-    private func monospaceBlock(_ label: String, _ value: String) -> some View {
-        VStack(alignment: .leading, spacing: Space.xs) {
-            Text(label).eyebrow()
-            Text(value)
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundStyle(Tokens.inkSoft)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(Space.md)
-                .background(Tokens.paper2, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
-                .textSelection(.enabled)
         }
     }
 }

--- a/mobile/PersonalDashboard/Views/Settings/ParsedFilesView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/ParsedFilesView.swift
@@ -1,0 +1,657 @@
+import SwiftUI
+import SwiftData
+
+/// Unified, reverse-chronological history of everything Dexter has parsed from
+/// external documents (#234): credit-card / bank statement imports and
+/// forwarded booking / receipt emails, in one place.
+///
+/// Two live sources are merged in memory and sorted newest-first:
+///   • `LocalStatementImport` — one row per statement import (counts + file).
+///   • `LocalEmailIngestLog`  — one row per forwarded email (outcome + summary).
+///
+/// A third, reconstructed source covers statements imported BEFORE #234 (which
+/// left no `LocalStatementImport` record): existing `.pdf`-source expenses are
+/// grouped by file name, shown with an expense count and flagged "counts
+/// unavailable" so no numbers are fabricated. Files that already have a real
+/// record are skipped so nothing is double-counted (mirrors how ActivityView
+/// collapses `.pdf` expenses by `statementFileName`).
+struct ParsedFilesView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Query(sort: \LocalStatementImport.createdAt, order: .reverse)
+    private var statementImports: [LocalStatementImport]
+
+    @Query(sort: \LocalEmailIngestLog.createdAt, order: .reverse)
+    private var emailLogs: [LocalEmailIngestLog]
+
+    // Needed to reconstruct pre-#234 statement imports from their expenses.
+    @Query private var expenses: [LocalExpense]
+
+    @State private var filter: Filter = .all
+    @State private var searchText: String = ""
+    @State private var presented: PresentedSheet?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Space.lg) {
+                        intro
+                        searchField
+                        filterChips
+                        listCard
+                    }
+                    .padding(.horizontal, Space.lg)
+                    .padding(.top, Space.lg)
+                    .padding(.bottom, 64)
+                }
+                .scrollDismissesKeyboard(.interactively)
+            }
+            .navigationTitle("Parsed files")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .sheet(item: $presented) { sheet in
+                switch sheet {
+                case .statement(let record):
+                    StatementDetailView(
+                        title: record.fileName.isEmpty ? displayTitle(for: record) : record.fileName,
+                        subtitle: statementSubtitle(for: record),
+                        countsAvailable: true,
+                        truncated: record.possiblyTruncated,
+                        expenseUUIDs: record.importedExpenseUUIDStrings
+                    )
+                case .reconstructed(let recon):
+                    StatementDetailView(
+                        title: recon.title,
+                        subtitle: recon.countsLine,
+                        countsAvailable: false,
+                        truncated: false,
+                        expenseUUIDs: recon.expenseUUIDs
+                    )
+                case .email(let entry):
+                    ParsedEmailDetailView(entry: entry)
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var intro: some View {
+        Text("Everything Dexter has read from your statements and forwarded emails, newest first. Tap a row to see what it added.")
+            .font(.edSubheadline)
+            .foregroundStyle(Tokens.muted)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: Space.sm) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 13, weight: .regular))
+                .foregroundStyle(Tokens.muted)
+            TextField("Search file, subject, or sender", text: $searchText)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .autocorrectionDisabled(true)
+                .textInputAutocapitalization(.never)
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 14, weight: .regular))
+                        .foregroundStyle(Tokens.mutedSoft)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, Space.md)
+        .padding(.vertical, Space.sm)
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+        .paperBorder(Tokens.border, radius: Radius.md)
+    }
+
+    private var filterChips: some View {
+        HStack(spacing: Space.sm) {
+            ForEach(Filter.allCases) { option in
+                let isActive = option == filter
+                Button {
+                    guard option != filter else { return }
+                    withAnimation(.easeOut(duration: 0.15)) { filter = option }
+                } label: {
+                    Text(option.label)
+                        .font(.edSubheadline)
+                        .foregroundStyle(isActive ? Tokens.accentActivity : Tokens.inkSoft)
+                        .padding(.horizontal, Space.md)
+                        .frame(minHeight: 36)
+                        .background(
+                            Capsule().fill(isActive ? Tokens.accentActivity.opacity(0.12) : Tokens.paper2)
+                        )
+                        .overlay(
+                            Capsule().stroke(
+                                isActive ? Tokens.accentActivity.opacity(0.35) : Tokens.border,
+                                lineWidth: 0.5
+                            )
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(isActive ? [.isSelected, .isButton] : .isButton)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    @ViewBuilder
+    private var listCard: some View {
+        let rows = visibleRows
+        if rows.isEmpty {
+            Text(emptyMessage)
+                .font(.edCaption)
+                .foregroundStyle(Tokens.muted)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(Space.lg)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+                .paperBorder()
+        } else {
+            LazyVStack(spacing: 0) {
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+                    if index > 0 { divider }
+                    rowView(row)
+                }
+            }
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+            .paperBorder()
+        }
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(Tokens.divider)
+            .frame(height: 0.5)
+            .padding(.leading, Space.lg)
+    }
+
+    // MARK: - Row views
+
+    @ViewBuilder
+    private func rowView(_ row: ParsedRow) -> some View {
+        switch row {
+        case .statement(let record):
+            historyRow(
+                icon: "doc.text.fill",
+                tint: Tokens.accentFinance,
+                title: record.fileName.isEmpty ? displayTitle(for: record) : record.fileName,
+                subtitle: statementSubtitle(for: record),
+                date: record.createdAt
+            ) { presented = .statement(record) }
+        case .reconstructed(let recon):
+            historyRow(
+                icon: "doc.text",
+                tint: Tokens.mutedSoft,
+                title: recon.title,
+                subtitle: recon.countsLine,
+                date: recon.createdAt
+            ) { presented = .reconstructed(recon) }
+        case .email(let entry):
+            historyRow(
+                icon: entry.outcomeEnum.icon,
+                tint: color(for: entry.outcomeEnum),
+                title: entry.subject.isEmpty ? "(no subject)" : entry.subject,
+                subtitle: emailSubtitle(for: entry),
+                date: entry.createdAt
+            ) { presented = .email(entry) }
+        }
+    }
+
+    private func historyRow(
+        icon: String,
+        tint: Color,
+        title: String,
+        subtitle: String,
+        date: Date,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: Space.md) {
+                Image(systemName: icon)
+                    .font(.system(size: 15))
+                    .foregroundStyle(tint)
+                    .frame(width: 20)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.edBodyMedium)
+                        .foregroundStyle(Tokens.ink)
+                        .lineLimit(1)
+                    Text(subtitle)
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.muted)
+                        .lineLimit(2)
+                    Text(date, format: .dateTime.month().day().year().hour().minute())
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.mutedSoft)
+                }
+                Spacer(minLength: Space.sm)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundStyle(Tokens.mutedSoft)
+                    .padding(.top, 2)
+            }
+            .padding(.horizontal, Space.lg)
+            .padding(.vertical, Space.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Row model + merge
+
+    private enum Filter: CaseIterable, Identifiable {
+        case all, statements, emails
+        var id: String {
+            switch self {
+            case .all: return "all"
+            case .statements: return "statements"
+            case .emails: return "emails"
+            }
+        }
+        var label: String {
+            switch self {
+            case .all: return "All"
+            case .statements: return "Statements"
+            case .emails: return "Emails"
+            }
+        }
+        func includes(_ row: ParsedRow) -> Bool {
+            switch self {
+            case .all: return true
+            case .emails:
+                if case .email = row { return true }
+                return false
+            case .statements:
+                if case .email = row { return false }
+                return true
+            }
+        }
+    }
+
+    private enum ParsedRow: Identifiable {
+        case statement(LocalStatementImport)
+        case reconstructed(ReconstructedStatement)
+        case email(LocalEmailIngestLog)
+
+        var id: String {
+            switch self {
+            case .statement(let s): return "stmt:\(s.clientUUID.uuidString)"
+            case .reconstructed(let r): return r.id
+            case .email(let e): return "mail:\(e.clientUUID.uuidString)"
+            }
+        }
+
+        var sortDate: Date {
+            switch self {
+            case .statement(let s): return s.createdAt
+            case .reconstructed(let r): return r.createdAt
+            case .email(let e): return e.createdAt
+            }
+        }
+    }
+
+    private struct ReconstructedStatement: Identifiable {
+        let id: String
+        let title: String
+        let expenseCount: Int
+        let createdAt: Date
+        let expenseUUIDs: [String]
+
+        var countsLine: String {
+            let n = expenseCount
+            return "\(n) expense\(n == 1 ? "" : "s") · counts unavailable"
+        }
+    }
+
+    private enum PresentedSheet: Identifiable {
+        case statement(LocalStatementImport)
+        case reconstructed(ReconstructedStatement)
+        case email(LocalEmailIngestLog)
+
+        var id: String {
+            switch self {
+            case .statement(let s): return "stmt:\(s.clientUUID.uuidString)"
+            case .reconstructed(let r): return r.id
+            case .email(let e): return "mail:\(e.clientUUID.uuidString)"
+            }
+        }
+    }
+
+    /// The merged, filtered, sorted rows shown in the list.
+    private var visibleRows: [ParsedRow] {
+        var rows: [ParsedRow] = statementImports.map { .statement($0) }
+        rows.append(contentsOf: reconstructedStatements.map { .reconstructed($0) })
+        rows.append(contentsOf: emailLogs.map { .email($0) })
+
+        let q = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return rows
+            .filter { filter.includes($0) }
+            .filter { q.isEmpty || matches($0, q) }
+            .sorted { $0.sortDate > $1.sortDate }
+    }
+
+    /// File names that already have a real `LocalStatementImport` record — their
+    /// expenses must NOT be reconstructed, or the file would appear twice.
+    private var recordedFileNames: Set<String> {
+        Set(
+            statementImports
+                .map { $0.fileName.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        )
+    }
+
+    /// Group `.pdf`-source expenses that have no matching real record into
+    /// reconstructed statement rows. Mirrors ActivityView's grouping: prefer the
+    /// file name, then the parsed attribution label, then the import day.
+    private var reconstructedStatements: [ReconstructedStatement] {
+        let recorded = recordedFileNames
+        var groups: [String: (title: String, rows: [LocalExpense])] = [:]
+
+        for expense in expenses where expense.sourceEnum == .pdf {
+            let fileName = expense.statementFileName.trimmingCharacters(in: .whitespacesAndNewlines)
+            // A file already captured by a real record is fully represented by
+            // that record — skip its rows so it isn't reconstructed too.
+            if !fileName.isEmpty && recorded.contains(fileName) { continue }
+
+            let label = expense.statementLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+            let key: String
+            let title: String
+            if !fileName.isEmpty {
+                key = "file:\(fileName)"; title = fileName
+            } else if !label.isEmpty {
+                key = "label:\(label)"; title = label
+            } else {
+                let day = Calendar.current.startOfDay(for: expense.createdAt)
+                key = "day:\(day.timeIntervalSince1970)"; title = "Statement import"
+            }
+            groups[key, default: (title, [])].rows.append(expense)
+        }
+
+        return groups.map { key, group in
+            let maxCreated = group.rows.map(\.createdAt).max() ?? Date()
+            return ReconstructedStatement(
+                id: "recon:\(key)",
+                title: group.title,
+                expenseCount: group.rows.count,
+                createdAt: maxCreated,
+                expenseUUIDs: group.rows.map(\.clientUUID)
+            )
+        }
+    }
+
+    private func matches(_ row: ParsedRow, _ needle: String) -> Bool {
+        switch row {
+        case .statement(let s):
+            return s.fileName.lowercased().contains(needle)
+                || s.statementLabel.lowercased().contains(needle)
+        case .reconstructed(let r):
+            return r.title.lowercased().contains(needle)
+        case .email(let e):
+            return e.subject.lowercased().contains(needle)
+                || e.sender.lowercased().contains(needle)
+                || e.summary.lowercased().contains(needle)
+        }
+    }
+
+    // MARK: - Copy helpers
+
+    /// Compact count breakdown for a statement row, e.g.
+    /// "12 imported (2 refunds) · 8 skipped · 5 ignored". Zero buckets are
+    /// omitted so a clean import reads simply. No em dashes.
+    private func statementSubtitle(for record: LocalStatementImport) -> String {
+        var parts: [String] = []
+        if record.imported > 0 {
+            var head = "\(record.imported) imported"
+            if record.refunds > 0 {
+                head += " (\(record.refunds) refund\(record.refunds == 1 ? "" : "s"))"
+            }
+            parts.append(head)
+        }
+        if record.skippedDuplicates > 0 { parts.append("\(record.skippedDuplicates) skipped") }
+        if record.ignoredNonSpend > 0 { parts.append("\(record.ignoredNonSpend) ignored") }
+        if record.failed > 0 { parts.append("\(record.failed) failed") }
+        var line = parts.isEmpty ? "No transactions imported" : parts.joined(separator: " · ")
+        if record.possiblyTruncated {
+            line += " · may be incomplete"
+        }
+        return line
+    }
+
+    private func displayTitle(for record: LocalStatementImport) -> String {
+        let label = record.statementLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        return label.isEmpty ? "Statement import" : label
+    }
+
+    private func emailSubtitle(for entry: LocalEmailIngestLog) -> String {
+        var pieces: [String] = [entry.outcomeEnum.displayName]
+        let sender = entry.sender.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !sender.isEmpty { pieces.append(sender) }
+        let summary = entry.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !summary.isEmpty { pieces.append(summary) }
+        return pieces.joined(separator: " · ")
+    }
+
+    private func color(for outcome: EmailIngestOutcome) -> Color {
+        switch outcome {
+        case .added:   return Tokens.success
+        case .skipped: return Tokens.muted
+        case .failed:  return Tokens.danger
+        }
+    }
+
+    private var emptyMessage: String {
+        switch filter {
+        case .all:
+            return "Nothing parsed yet. Import a statement in Finance or forward a booking email to your receipts inbox to get started."
+        case .statements:
+            return "No statement imports yet. Import a statement PDF from the Finance screen."
+        case .emails:
+            return "No forwarded emails processed yet. Forward a hotel, flight, or receipt email to your inbox."
+        }
+    }
+}
+
+// MARK: - Statement detail
+
+/// Shows the expenses a single statement import produced. For a real record we
+/// resolve its stored expense UUIDs; for a reconstructed (pre-#234) import we
+/// pass the grouped expense UUIDs. Either way the rows are resolved live so a
+/// later deletion is reflected here.
+private struct StatementDetailView: View {
+    let title: String
+    let subtitle: String
+    let countsAvailable: Bool
+    let truncated: Bool
+    let expenseUUIDs: [String]
+
+    @Environment(\.dismiss) private var dismiss
+    @Query private var allExpenses: [LocalExpense]
+
+    private var expenses: [LocalExpense] {
+        let ids = Set(expenseUUIDs)
+        return allExpenses
+            .filter { ids.contains($0.clientUUID) }
+            .sorted { $0.date > $1.date }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Space.lg) {
+                        header
+                        if !countsAvailable {
+                            unavailableNote
+                        }
+                        if truncated {
+                            truncatedNote
+                        }
+                        expenseSection
+                    }
+                    .padding(Space.lg)
+                    .padding(.bottom, 32)
+                }
+            }
+            .navigationTitle("Statement import")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Space.xs) {
+            Text(title)
+                .font(.edHeading)
+                .foregroundStyle(Tokens.ink)
+            Text(subtitle)
+                .font(.edSubheadline)
+                .foregroundStyle(Tokens.muted)
+        }
+    }
+
+    private var unavailableNote: some View {
+        Text("This statement was imported before Dexter kept per-import counts, so only its expenses are shown.")
+            .font(.edCaption)
+            .foregroundStyle(Tokens.muted)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Space.md)
+            .background(Tokens.paper2, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+    }
+
+    private var truncatedNote: some View {
+        Text("Part of this statement was too long to read in one pass, so some transactions may be missing.")
+            .font(.edCaption)
+            .foregroundStyle(Tokens.danger)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Space.md)
+            .background(Tokens.danger.opacity(0.08), in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var expenseSection: some View {
+        Text("Expenses").eyebrow()
+        if expenses.isEmpty {
+            Text("No expenses from this import are in your data. They may have been deleted.")
+                .font(.edCaption)
+                .foregroundStyle(Tokens.muted)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            VStack(spacing: Space.sm) {
+                ForEach(expenses, id: \.clientUUID) { expense in
+                    ExpenseRow(expense: expense, onTap: {})
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Email detail
+
+/// Detail for a single email-ingest log entry: outcome, subject, sender,
+/// summary, and (for an "added" entry) an Undo action that deletes the exact
+/// items / expenses that ingest added, via `EmailIngestService.undo`. Mirrors
+/// the diagnostics block the previous receipts-inbox screen showed, now with
+/// undo surfaced in-app.
+private struct ParsedEmailDetailView: View {
+    let entry: LocalEmailIngestLog
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var undone = false
+
+    private var canUndo: Bool {
+        entry.outcomeEnum == .added
+            && (!entry.addedItemUUIDList.isEmpty || !entry.addedExpenseUUIDList.isEmpty)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Space.lg) {
+                        field("Outcome", entry.outcomeEnum.displayName)
+                        field("Subject", entry.subject.isEmpty ? "(none)" : entry.subject)
+                        if !entry.sender.isEmpty { field("From", entry.sender) }
+                        field("Summary", entry.summary)
+                        if canUndo && !undone {
+                            undoButton
+                        }
+                        monospaceBlock("Parsed body the model received",
+                                       entry.debugBody.isEmpty ? "(not recorded)" : entry.debugBody)
+                        monospaceBlock("Trips the model could match against",
+                                       entry.debugTripContext.isEmpty ? "(not recorded)" : entry.debugTripContext)
+                    }
+                    .padding(Space.lg)
+                }
+            }
+            .navigationTitle("Email detail")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var undoButton: some View {
+        Button(role: .destructive) {
+            _ = EmailIngestService().undo(logUUID: entry.clientUUID)
+            undone = true
+        } label: {
+            HStack(spacing: Space.sm) {
+                Image(systemName: "arrow.uturn.left.circle")
+                    .font(.system(size: 15))
+                Text("Undo this import")
+                    .font(.edBody)
+            }
+            .foregroundStyle(Tokens.danger)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Space.md)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+            .paperBorder(Tokens.border, radius: Radius.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func field(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: Space.xs) {
+            Text(label).eyebrow()
+            Text(value)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .textSelection(.enabled)
+        }
+    }
+
+    private func monospaceBlock(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: Space.xs) {
+            Text(label).eyebrow()
+            Text(value)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(Tokens.inkSoft)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(Space.md)
+                .background(Tokens.paper2, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
@@ -7,6 +7,7 @@ struct SettingsView: View {
     @State private var showingResetData: Bool = false
     @State private var showingDataTransfer: Bool = false
     @State private var showingEmailInbox: Bool = false
+    @State private var showingParsedFiles: Bool = false
     @State private var showingBackup: Bool = false
 
     /// Currency all finances are DISPLAYED in (#220). SGD stays the canonical
@@ -30,6 +31,9 @@ struct SettingsView: View {
         }
         .sheet(isPresented: $showingEmailInbox) {
             EmailInboxView()
+        }
+        .sheet(isPresented: $showingParsedFiles) {
+            ParsedFilesView()
         }
         .sheet(isPresented: $showingBackup) {
             BackupSettingsView()
@@ -111,29 +115,53 @@ struct SettingsView: View {
 
     private var automationSection: some View {
         SettingsSection(title: "Automation") {
-            Button {
-                showingEmailInbox = true
-            } label: {
-                HStack(alignment: .firstTextBaseline, spacing: Space.md) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Receipts inbox")
-                            .font(.edBody)
-                            .foregroundStyle(Tokens.ink)
-                        Text("Auto-add itinerary items from forwarded booking emails")
-                            .font(.edCaption)
-                            .foregroundStyle(Tokens.muted)
-                    }
-                    Spacer(minLength: Space.md)
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 13, weight: .regular))
-                        .foregroundStyle(Tokens.mutedSoft)
+            VStack(spacing: 0) {
+                Button {
+                    showingEmailInbox = true
+                } label: {
+                    automationRow(
+                        title: "Receipts inbox",
+                        subtitle: "Connect the inbox that auto-adds from forwarded booking emails"
+                    )
                 }
-                .padding(.horizontal, Space.lg)
-                .padding(.vertical, Space.md)
-                .contentShape(Rectangle())
+                .buttonStyle(.plain)
+
+                Rectangle()
+                    .fill(Tokens.divider)
+                    .frame(height: 0.5)
+                    .padding(.leading, Space.lg)
+
+                Button {
+                    showingParsedFiles = true
+                } label: {
+                    automationRow(
+                        title: "Parsed files & imports",
+                        subtitle: "History of everything read from statements and forwarded emails"
+                    )
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
         }
+    }
+
+    private func automationRow(title: String, subtitle: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Space.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.ink)
+                Text(subtitle)
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.muted)
+            }
+            Spacer(minLength: Space.md)
+            Image(systemName: "chevron.right")
+                .font(.system(size: 13, weight: .regular))
+                .foregroundStyle(Tokens.mutedSoft)
+        }
+        .padding(.horizontal, Space.lg)
+        .padding(.vertical, Space.md)
+        .contentShape(Rectangle())
     }
 
     private var dataSection: some View {


### PR DESCRIPTION
## Summary
- Adds a dedicated **Parsed Files & Imports** screen (Settings) unifying statement imports and forwarded-email ingests into one reverse-chronological history with filter chips (All / Statements / Emails) and search.
- New `LocalStatementImport` SwiftData model (additive, migration-safe) records file name, timestamp, and imported / skipped / ignored / failed / refund counts at import time. These were previously shown in a one-time alert and discarded.
- Legacy statement imports (pre-this-build) are reconstructed from expense file-name stamps and flagged "counts unavailable" so no numbers are fabricated.
- Email ingest log moved from its buried Settings spot into the new screen, with in-app Undo added. Row trim cap raised 100 to 2000 since this is now user-facing permanent history.

Closes #234

## Test plan
- [x] Clean static build (`xcodegen generate` + `xcodebuild ... build`, BUILD SUCCEEDED)
- [x] Shipped to device and installed
- [ ] Device QA (owner walks the AC on #234):
  - Import a statement, confirm history row with correct count breakdown; tap opens exactly those expenses
  - Re-import same file (skips all), confirm no phantom empty row
  - Legacy statement shows "counts unavailable", no duplicate with a new record
  - Email rows show subject/sender/outcome; Undo removes added items/expenses
  - Filter chips + search work across mixed rows
  - Receipts inbox still opens and holds IMAP credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)
