### PR TITLE
feat(ios): support bank account statements in Finance import

### DIFF
--- a/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
+++ b/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
@@ -554,29 +554,55 @@ extension AnthropicClient {
         - "fee": a bank fee (annual fee, late fee, foreign-transaction fee,
           cash-advance fee, account service fee). Money OUT.
         - "interest": an interest / finance CHARGE (money OUT). Note: interest
-          CREDITED into a bank account is money IN — tag that "deposit", not
-          "interest".
-        - "payment": a payment made TO a credit card (a credit that reduces the
-          card balance, e.g. "PAYMENT - THANK YOU", autopay, a GIRO card
-          payment). These are NOT spending — but still return them, tagged
-          "payment", so they can be counted and skipped. This is a CREDIT-CARD
-          concept; do not use it for bank-account deposits.
-        - "refund": a credit / reversal / chargeback / cashback on a prior
-          purchase (money coming back to you). Tag these "refund". They ARE
-          imported — they net against your spending — so give a refund the same
-          accurate merchant, date, amount, and category you'd give the purchase
-          it reverses.
+          CREDITED into a bank account is money IN, not a charge — tag that
+          "refund" (a "+" credit), not "interest".
+        - "payment": a payment that SETTLES A CREDIT CARD. This covers two
+          cases, and both must be tagged "payment" (they are NOT spending —
+          importing them would double-count against the card purchases they pay
+          off, so they are counted and skipped):
+            (1) On a CREDIT-CARD statement: a credit that reduces the card
+                balance, e.g. "PAYMENT - THANK YOU", autopay, a GIRO card
+                payment.
+            (2) On a BANK statement: a money-OUT line that pays a credit-card
+                bill. Recognise it when the description references a CARD: a
+                full 15-16 digit card number or masked PAN, "CARD PAYMENT",
+                "CREDIT CARD", "CCC", or a card-network name (Visa / Mastercard /
+                Amex). Example: "Advice Bill Payment / CCC - 5425503303732696 :
+                I-BANK" is a credit-card bill payment → "payment".
+          Do NOT over-apply case (2): a money-OUT bill payment that is NOT a
+          credit card stays ordinary spend ("purchase"). Utilities, telco,
+          insurance, and TAX (e.g. "GIRO ... IRAS") are real expenses, not
+          "payment". Only a line that clearly settles a CARD gets "payment".
+        - "refund": a "+" CREDIT that should be recorded as money coming back in
+          (it nets against your spending). It is imported with a positive
+          amount. Tag "refund" for BOTH of these:
+            (1) A reversal / chargeback / cashback / credit on a prior purchase
+                (money coming back to you). Give it the merchant, date, amount,
+                and category of the purchase it reverses.
+            (2) On a BANK statement: money RECEIVED from another PERSON or a
+                reimbursement — an incoming PayNow from a named person, a funds
+                transfer from a named person, or an expense reimbursement.
+                Examples: "Funds Transfer IB:KATYAL PARUL", "INCOMING PAYNOW ...
+                FROM: <person>", "SEND BACK FROM PAYLAH!", "EXPENSE REPORT".
+                Use the sender's name as the merchant and a sensible category.
+          A "refund"-type bank line is NOT limited to card reversals — it is any
+          incoming peer money that is not salary.
         - "deposit": money received INTO a bank / savings / current account that
-          is NOT a refund of a prior card purchase — e.g. salary, an incoming
-          transfer, a FAST / GIRO receipt, interest credited to the account.
-          Any bank-account line where money came IN (the deposit / credit column
-          or a balance INCREASE) is a "deposit". On a credit-card statement this
-          type essentially never appears — use "payment" or "refund" there
-          instead.
+          is SALARY or PAYROLL. This is the ONLY money-in that should be a
+          "deposit" (it is skipped and only reported, not imported, because it
+          would swamp the spend view). Example: "DEC PAY CWV1L". A credit that
+          is clearly payroll → "deposit". For ANY OTHER money-in on a bank
+          statement (an incoming transfer from a person, a reimbursement),
+          prefer "refund" (case 2 above) so it is recorded as a "+" credit. When
+          incoming money is ambiguous, default to "refund"; use "deposit" ONLY
+          when it is clearly salary / payroll. On a credit-card statement this
+          type essentially never appears.
         - Mapping summary: bank withdrawal / debit → "purchase" (or "fee" /
-          "interest" when it's plainly a bank fee or an interest charge); bank
-          money-in → "deposit"; credit-card lines keep the
-          purchase / fee / interest / payment / refund meanings above.
+          "interest" for a bank fee or interest charge, or "payment" when it
+          settles a credit-card bill); bank money-in → "refund" for a peer
+          transfer / reimbursement, or "deposit" only for salary / payroll;
+          credit-card lines keep the purchase / fee / interest / payment /
+          refund meanings above.
     - "date" is the transaction date in ISO 8601 (YYYY-MM-DD). Statement lines
       often omit the year (e.g. "07 SEP", "12/09"). Infer the year from the
       statement period / billing cycle shown on the statement. If a line's

--- a/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
+++ b/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
@@ -32,22 +32,32 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
     let descriptor: String?
 
     /// Statement line classification. Purchases, fees, and interest become
-    /// expenses; payments (transfers to the card) and refunds/credits are
-    /// tallied and skipped because `LocalExpense` stores only positive spend.
+    /// expenses; payments (transfers to the card), refunds/credits, and bank
+    /// deposits are tallied and skipped because `LocalExpense` stores only
+    /// positive spend.
+    ///
+    /// `deposit` is the bank-statement addition (#243): money received INTO a
+    /// bank / savings / current account (salary, an incoming transfer, an
+    /// interest credit) that is NOT a refund of a prior card purchase. It is
+    /// kept DISTINCT from `payment` so the importer can count and REPORT
+    /// deposits separately (with a total) rather than folding them into the card
+    /// "payment" bucket. On a credit-card statement this type essentially never
+    /// appears.
     enum LineType: String, Decodable, Sendable {
         case purchase
         case fee
         case interest
         case payment
         case refund
+        case deposit
 
-        /// True when this line represents money spent (a debit). Payments and
-        /// refunds are NOT spend. Kept for callers that need the strict
-        /// spend/credit distinction; import routing uses `shouldImport`.
+        /// True when this line represents money spent (a debit). Payments,
+        /// refunds, and deposits are NOT spend. Kept for callers that need the
+        /// strict spend/credit distinction; import routing uses `shouldImport`.
         var isSpend: Bool {
             switch self {
-            case .purchase, .fee, .interest: return true
-            case .payment, .refund:          return false
+            case .purchase, .fee, .interest:   return true
+            case .payment, .refund, .deposit:  return false
             }
         }
 
@@ -56,11 +66,13 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
         /// credit (`isRefund: true`) that nets against totals. A `payment` (a
         /// transfer TO the card that reduces the balance) is NEVER imported —
         /// it's counted and skipped, because it isn't spending and double-counts
-        /// against the purchases it paid off.
+        /// against the purchases it paid off. A `deposit` (money into a bank
+        /// account) is likewise never imported: income isn't tracked yet, so it
+        /// is counted and reported, never stored (#243).
         var shouldImport: Bool {
             switch self {
             case .purchase, .fee, .interest, .refund: return true
-            case .payment:                            return false
+            case .payment, .deposit:                  return false
             }
         }
     }
@@ -451,9 +463,12 @@ extension AnthropicClient {
     }
 
     static let statementPrompt: String = """
-    This is a credit-card statement PDF. Extract the statement HEADER plus EVERY
-    transaction line item. Return STRICT JSON inside a ```json fence and nothing
-    else — no prose before or after.
+    This is a financial statement PDF. It may be a CREDIT-CARD statement OR a
+    BANK / SAVINGS / CURRENT account statement (e.g. a DBS Multiplier account).
+    First determine which kind it is, because they encode the direction of money
+    differently (see the direction rules below). Then extract the statement
+    HEADER plus EVERY transaction line item. Return STRICT JSON inside a ```json
+    fence and nothing else — no prose before or after.
 
     Return a single JSON OBJECT with exactly two keys, in this order:
     {
@@ -495,7 +510,8 @@ extension AnthropicClient {
 
     Transaction line rules ("lines" array):
     - Return one element per transaction line on the statement. Include ALL of
-      them: purchases, fees, interest charges, card payments, and refunds.
+      them: purchases, fees, interest charges, card payments, refunds, and
+      (on a bank account) deposits.
     - "merchant" is the clean, human-readable merchant / vendor name for display
       (e.g. "Starbucks", "Shopee"). Tidy it up as you normally would.
     - "descriptor" is the transaction description EXACTLY as printed on the
@@ -510,21 +526,57 @@ extension AnthropicClient {
       all, set it to the same value as "merchant".
     - "amount" is always a POSITIVE number (the magnitude of the line). Never
       emit a negative amount; the sign is conveyed by "type" instead.
+
+    - DIRECTION — how to tell money OUT from money IN (read this before typing
+      any line):
+        - CREDIT-CARD statement: classify each line from its description /
+          section as usual (purchases and fees increase the balance owed;
+          payments and refunds decrease it).
+        - BANK / SAVINGS / CURRENT account statement: the direction is set by
+          the COLUMN the amount sits in, NOT by the description wording. A
+          "Withdrawal" / "Debit" / "Money Out" / "Paid Out" column = money OUT
+          (spend). A "Deposit" / "Credit" / "Money In" / "Paid In" column =
+          money IN. If the columns are ambiguous or merged, use the running
+          BALANCE delta: if the balance DECREASED on that line, money went OUT;
+          if it INCREASED, money came IN.
+        - Do NOT infer direction from words like "Collection", "Payment",
+          "Receipt", "Transfer", "FAST", or "GIRO" — on a bank statement these
+          appear on BOTH directions and are unreliable. For example a DBS
+          "Advice FAST Payment / Receipt" or a "FAST Collection" line can be
+          money OUT even though it reads like incoming money: trust the column /
+          balance drop, not the label. The TO: / FROM: text can help
+          disambiguate a genuine tie, but the column / balance is authoritative.
+
     - "type" is EXACTLY one of: "purchase", "fee", "interest", "payment",
-      "refund".
-        - "purchase": a normal card purchase / spend.
+      "refund", "deposit".
+        - "purchase": a normal card purchase / spend, OR any bank-account
+          WITHDRAWAL / debit (money OUT) that isn't plainly a fee or interest.
         - "fee": a bank fee (annual fee, late fee, foreign-transaction fee,
-          cash-advance fee).
-        - "interest": an interest / finance charge.
-        - "payment": a payment made TO the card (a credit that reduces the
-          balance, e.g. "PAYMENT - THANK YOU", a bank transfer, autopay,
-          GIRO). These are NOT spending — but still return them, tagged
-          "payment", so they can be counted and skipped.
-        - "refund": a credit / reversal / chargeback / cashback on a purchase
-          (money coming back to you). Tag these "refund". They ARE imported —
-          they net against your spending — so give a refund the same accurate
-          merchant, date, amount, and category you'd give the purchase it
-          reverses.
+          cash-advance fee, account service fee). Money OUT.
+        - "interest": an interest / finance CHARGE (money OUT). Note: interest
+          CREDITED into a bank account is money IN — tag that "deposit", not
+          "interest".
+        - "payment": a payment made TO a credit card (a credit that reduces the
+          card balance, e.g. "PAYMENT - THANK YOU", autopay, a GIRO card
+          payment). These are NOT spending — but still return them, tagged
+          "payment", so they can be counted and skipped. This is a CREDIT-CARD
+          concept; do not use it for bank-account deposits.
+        - "refund": a credit / reversal / chargeback / cashback on a prior
+          purchase (money coming back to you). Tag these "refund". They ARE
+          imported — they net against your spending — so give a refund the same
+          accurate merchant, date, amount, and category you'd give the purchase
+          it reverses.
+        - "deposit": money received INTO a bank / savings / current account that
+          is NOT a refund of a prior card purchase — e.g. salary, an incoming
+          transfer, a FAST / GIRO receipt, interest credited to the account.
+          Any bank-account line where money came IN (the deposit / credit column
+          or a balance INCREASE) is a "deposit". On a credit-card statement this
+          type essentially never appears — use "payment" or "refund" there
+          instead.
+        - Mapping summary: bank withdrawal / debit → "purchase" (or "fee" /
+          "interest" when it's plainly a bank fee or an interest charge); bank
+          money-in → "deposit"; credit-card lines keep the
+          purchase / fee / interest / payment / refund meanings above.
     - "date" is the transaction date in ISO 8601 (YYYY-MM-DD). Statement lines
       often omit the year (e.g. "07 SEP", "12/09"). Infer the year from the
       statement period / billing cycle shown on the statement. If a line's
@@ -545,8 +597,8 @@ extension AnthropicClient {
       payment → rent). For fees and interest use "bills_and_utilities". Use
       "other" only when nothing fits. A refund
       is imported, so give it the category of the purchase it reverses (a
-      grocery refund → groceries). For a payment, still pick a plausible
-      category (a payment is skipped, so its category is ignored).
+      grocery refund → groceries). For a payment or a deposit, still pick a
+      plausible category (both are skipped, so the category is ignored).
     - Do NOT include summary rows, balances, "total", "opening/closing
       balance", minimum-payment lines, or reward-point lines — only real
       transaction lines.

--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -11,10 +11,11 @@ struct StatementImportResult: Sendable {
     /// `LocalExpense` this run. `refunds` (below) is the refund subset, so the
     /// spend-only count is `imported - refunds`.
     let imported: Int
-    /// Subset of `imported` that were refunds/credits, inserted with
-    /// `isRefund: true` so they net against spending totals (#206). Surfaced
-    /// separately in the summary ("including N refunds") so it's clear money
-    /// came back in, not just out.
+    /// Subset of `imported` inserted as "+" credits (`isRefund: true`) so they
+    /// net against spending totals (#206). Covers card reversals/cashback AND
+    /// (on a bank statement) money received from a person or a reimbursement
+    /// (#243). Surfaced in the summary as "including N credits" so it's clear
+    /// money came back in, not just out.
     let refunds: Int
     /// Lines (spend or refund) that matched an existing expense via
     /// `ExpenseDedupe` and were skipped.
@@ -52,8 +53,8 @@ struct StatementImportResult: Sendable {
 
     /// User-facing one-liner for the summary alert. Mentions only the buckets
     /// that have entries so a clean import reads simply. Examples:
-    ///   "Imported 42 (including 3 refunds) · Skipped 8 duplicates · Ignored 5 payments"
-    ///   "Imported 19 · Skipped 9 deposits (SGD 16,559.11), income isn't tracked yet"
+    ///   "Imported 42 (including 3 credits) · Skipped 8 duplicates · Ignored 5 payments"
+    ///   "Imported 26 (including 8 credits) · Ignored 1 payment · Skipped 1 deposit (SGD 14,840.00), income isn't tracked yet"
     ///   "Imported 12"
     ///   "Nothing to import — no transactions found."
     var summaryLine: String {
@@ -62,7 +63,10 @@ struct StatementImportResult: Sendable {
         }
         var head = "Imported \(imported)"
         if refunds > 0 {
-            head += " (including \(refunds) refund\(refunds == 1 ? "" : "s"))"
+            // "credits" not "refunds": this bucket now covers card reversals AND
+            // money received from a person / a reimbursement, all imported as
+            // "+" credits (#243). "credit" reads accurately for both.
+            head += " (including \(refunds) credit\(refunds == 1 ? "" : "s"))"
         }
         var parts: [String] = [head]
         if skippedDuplicates > 0 {

--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -1,9 +1,10 @@
 import Foundation
 import SwiftData
 
-/// Result of running one credit-card statement PDF through the batch-import
-/// pipeline (#184). Every parsed line lands in exactly one of these buckets, so
-/// `imported + skippedDuplicates + ignoredNonSpend + failed == total parsed`.
+/// Result of running one credit-card or bank statement PDF through the
+/// batch-import pipeline (#184, bank support #243). Every parsed line lands in
+/// exactly one of these buckets, so
+/// `imported + skippedDuplicates + ignoredNonSpend + deposits + failed == total parsed`.
 struct StatementImportResult: Sendable {
     /// Lines that deduped clean and were inserted. Counts BOTH spend
     /// (purchase/fee/interest) and refund rows — every row that produced a
@@ -34,13 +35,25 @@ struct StatementImportResult: Sendable {
     /// the email path's `addedExpenseUUIDs`; the UI doesn't offer undo yet).
     let importedUUIDs: [UUID]
 
+    /// Bank-statement deposit lines (money received into the account) — counted,
+    /// never inserted, because income isn't tracked yet (#243). Kept distinct
+    /// from `ignoredNonSpend` (card payments) so the summary can report deposits
+    /// with their own total. Defaults to 0 so credit-card imports and older test
+    /// call sites are unaffected.
+    var deposits: Int = 0
+    /// SGD sum of the deposits this run could FX-convert. A deposit whose FX
+    /// lookup failed is still counted in `deposits` but omitted here, so this is
+    /// a lower bound on money received. Defaults to 0.
+    var depositsTotalSGD: Double = 0
+
     var totalParsed: Int {
-        imported + skippedDuplicates + ignoredNonSpend + failed
+        imported + skippedDuplicates + ignoredNonSpend + deposits + failed
     }
 
     /// User-facing one-liner for the summary alert. Mentions only the buckets
     /// that have entries so a clean import reads simply. Examples:
     ///   "Imported 42 (including 3 refunds) · Skipped 8 duplicates · Ignored 5 payments"
+    ///   "Imported 19 · Skipped 9 deposits (SGD 16,559.11), income isn't tracked yet"
     ///   "Imported 12"
     ///   "Nothing to import — no transactions found."
     var summaryLine: String {
@@ -57,6 +70,14 @@ struct StatementImportResult: Sendable {
         }
         if ignoredNonSpend > 0 {
             parts.append("Ignored \(ignoredNonSpend) payment\(ignoredNonSpend == 1 ? "" : "s")")
+        }
+        if deposits > 0 {
+            // Bank deposits are money received. We classify and report them but
+            // don't store them (no income model yet, #243). State the total so
+            // it's clear money came in that isn't in the expense figures. No
+            // em dash in this user-facing string (project no-em-dash rule).
+            let depositWord = deposits == 1 ? "deposit" : "deposits"
+            parts.append("Skipped \(deposits) \(depositWord) (SGD \(Self.formatSGD(depositsTotalSGD))), income isn't tracked yet")
         }
         if failed > 0 {
             parts.append("\(failed) couldn't be added")
@@ -77,6 +98,26 @@ struct StatementImportResult: Sendable {
         statement to try again, or add any missing transactions manually.
         """
     }
+
+    /// Format an SGD magnitude with grouping and two decimals ("16,559.11").
+    /// POSIX locale so grouping / decimal separators are stable regardless of
+    /// device locale, matching how the rest of Finance renders amounts.
+    static func formatSGD(_ amount: Double) -> String {
+        Self.sgdFormatter.string(from: NSNumber(value: amount))
+            ?? String(format: "%.2f", amount)
+    }
+
+    private static let sgdFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.numberStyle = .decimal
+        f.usesGroupingSeparator = true
+        f.groupingSeparator = ","
+        f.decimalSeparator = "."
+        f.minimumFractionDigits = 2
+        f.maximumFractionDigits = 2
+        return f
+    }()
 }
 
 /// Batch statement-import orchestrator (#184).
@@ -153,6 +194,11 @@ struct StatementImporter {
         var skippedDuplicates = 0
         var ignoredNonSpend = 0
         var failed = 0
+        // Bank-statement deposits (money received) — counted and reported, never
+        // stored, because income isn't tracked yet (#243). `deposits` is the
+        // count; `depositsTotalSGD` is the SGD sum of those we could FX-convert.
+        var deposits = 0
+        var depositsTotalSGD = 0.0
         var importedUUIDs: [UUID] = []
 
         let fx = FXService(store: store)
@@ -199,10 +245,32 @@ struct StatementImporter {
             // more likely a normal purchase than a credit.
             let type = line.type ?? .purchase
             guard type.shouldImport else {
-                // Card payments only — they settle the balance and must never be
-                // imported (they'd double-count against the purchases they paid
-                // off). Refunds fall through and import as credits.
-                ignoredNonSpend += 1
+                // Non-importable credits. Two distinct kinds, counted separately:
+                //   - `.deposit` (bank money-in): tallied and, where FX allows,
+                //     summed for the import summary. Income isn't tracked yet, so
+                //     it's never stored (#243).
+                //   - `.payment` (card transfer): settles the card balance and
+                //     must never be imported (it'd double-count against the
+                //     purchases it paid off).
+                // Refunds have `shouldImport == true` and fall through to import
+                // as credits.
+                if type == .deposit {
+                    deposits += 1
+                    // Sum the deposit in SGD (same conversion path as spend).
+                    // A deposit with no readable positive amount, or one whose FX
+                    // lookup fails, is still COUNTED but omitted from the total —
+                    // the count must never silently drop.
+                    if let amount = line.amount, amount > 0 {
+                        let currency = Self.normalizeCurrency(line.currency)
+                        if let conversion = try? await fx.convert(amount, from: currency) {
+                            depositsTotalSGD += conversion.sgdAmount
+                        } else {
+                            NSLog("StatementImporter: FX convert failed for deposit in %@ — counted, excluded from total", currency)
+                        }
+                    }
+                } else {
+                    ignoredNonSpend += 1
+                }
                 continue
             }
             // A refund imports as a credit: positive magnitude, `isRefund: true`
@@ -372,7 +440,8 @@ struct StatementImporter {
                 failed: failed,
                 refunds: refunds,
                 possiblyTruncated: possiblyTruncated,
-                importedExpenseUUIDs: importedUUIDs
+                importedExpenseUUIDs: importedUUIDs,
+                deposits: deposits
             )
             store.context.insert(record)
             try? store.context.save()
@@ -385,7 +454,9 @@ struct StatementImporter {
             ignoredNonSpend: ignoredNonSpend,
             failed: failed,
             possiblyTruncated: possiblyTruncated,
-            importedUUIDs: importedUUIDs
+            importedUUIDs: importedUUIDs,
+            deposits: deposits,
+            depositsTotalSGD: depositsTotalSGD
         )
     }
 

--- a/mobile/PersonalDashboard/Models/Local/LocalStatementImport.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalStatementImport.swift
@@ -30,6 +30,12 @@ final class LocalStatementImport {
     var failed: Int
     var refunds: Int
 
+    /// Bank-statement deposit lines (money received) counted this import but
+    /// never stored as expenses (income isn't tracked yet, #243). Additive
+    /// field with a default so the SwiftData migration stays lightweight on
+    /// existing installs (ADD only, never remove).
+    var deposits: Int = 0
+
     /// True when the model likely ran out of output budget on a very large
     /// statement, so some tail rows may be missing.
     var possiblyTruncated: Bool
@@ -53,6 +59,7 @@ final class LocalStatementImport {
         refunds: Int,
         possiblyTruncated: Bool,
         importedExpenseUUIDs: [UUID] = [],
+        deposits: Int = 0,
         createdAt: Date = Date()
     ) {
         self.clientUUID = clientUUID
@@ -63,6 +70,7 @@ final class LocalStatementImport {
         self.ignoredNonSpend = ignoredNonSpend
         self.failed = failed
         self.refunds = refunds
+        self.deposits = deposits
         self.possiblyTruncated = possiblyTruncated
         self.importedExpenseUUIDs = importedExpenseUUIDs
             .map { $0.uuidString.lowercased() }

--- a/mobile/PersonalDashboard/Views/Settings/ParsedFilesView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/ParsedFilesView.swift
@@ -421,6 +421,7 @@ struct ParsedFilesView: View {
         }
         if record.skippedDuplicates > 0 { parts.append("\(record.skippedDuplicates) skipped") }
         if record.ignoredNonSpend > 0 { parts.append("\(record.ignoredNonSpend) ignored") }
+        if record.deposits > 0 { parts.append("\(record.deposits) deposit\(record.deposits == 1 ? "" : "s") skipped") }
         if record.failed > 0 { parts.append("\(record.failed) failed") }
         var line = parts.isEmpty ? "No transactions imported" : parts.joined(separator: " · ")
         if record.possiblyTruncated {

--- a/mobile/PersonalDashboard/Views/Settings/ParsedFilesView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/ParsedFilesView.swift
@@ -408,14 +408,14 @@ struct ParsedFilesView: View {
     // MARK: - Copy helpers
 
     /// Compact count breakdown for a statement row, e.g.
-    /// "12 imported (2 refunds) · 8 skipped · 5 ignored". Zero buckets are
+    /// "12 imported (2 credits) · 8 skipped · 5 ignored". Zero buckets are
     /// omitted so a clean import reads simply. No em dashes.
     private func statementSubtitle(for record: LocalStatementImport) -> String {
         var parts: [String] = []
         if record.imported > 0 {
             var head = "\(record.imported) imported"
             if record.refunds > 0 {
-                head += " (\(record.refunds) refund\(record.refunds == 1 ? "" : "s"))"
+                head += " (\(record.refunds) credit\(record.refunds == 1 ? "" : "s"))"
             }
             parts.append(head)
         }

--- a/mobile/PersonalDashboardTests/StatementDedupeReconciliationTests.swift
+++ b/mobile/PersonalDashboardTests/StatementDedupeReconciliationTests.swift
@@ -354,6 +354,107 @@ final class StatementDedupeReconciliationTests: XCTestCase {
         XCTAssertEqual(result.totalParsed, 5)
     }
 
+    // MARK: - (n) CC bill payment on a bank statement is ignored, not spend (#243)
+
+    func test_bankCreditCardBillPayment_ignoredNotSpend() async throws {
+        // "Advice Bill Payment / CCC - 5425503303732696 : I-BANK" settles a
+        // credit card → tagged `payment` by the extractor → must be ignored, not
+        // imported as spend (it double-counts the card's own purchases).
+        let result = await importer.insert(
+            lines: [line("Credit card bill", 1548.46, type: .payment, descriptor: "ADVICE BILL PAYMENT / CCC - 5425503303732696 : I-BANK")],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.imported, 0, "a credit-card bill payment is never imported")
+        XCTAssertEqual(result.ignoredNonSpend, 1, "it is counted as an ignored payment")
+        XCTAssertEqual(result.refunds, 0)
+        XCTAssertEqual(try storedCount(), 0, "nothing stored for a card settlement")
+    }
+
+    // MARK: - (o) A normal (non-card) bill like tax still imports as spend
+
+    func test_bankTaxBill_importsAsSpend() async throws {
+        // "GIRO ... IRAS" is tax, a real expense — the extractor keeps it a
+        // `purchase`, so it must import as ordinary spend.
+        let result = await importer.insert(
+            lines: [line("IRAS", 871.89, type: .purchase, descriptor: "GIRO PAYMENT IRAS TAX")],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.imported, 1, "a tax bill is real spend and imports")
+        XCTAssertEqual(result.ignoredNonSpend, 0, "a tax bill is NOT a card settlement")
+        XCTAssertEqual(try storedCount(), 1)
+    }
+
+    // MARK: - (p) Incoming peer transfer imports as a "+" credit
+
+    func test_incomingPeerTransfer_importsAsCredit() async throws {
+        // "INCOMING PAYNOW ... FROM: <person>" is money received from a person —
+        // the extractor tags it `refund` so the importer stores it as a "+"
+        // credit (isRefund: true) that nets against spend.
+        let result = await importer.insert(
+            lines: [line("Parul Katyal", 1000.0, type: .refund, descriptor: "FUNDS TRANSFER IB:KATYAL PARUL")],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.imported, 1, "received peer money is recorded, not dropped")
+        XCTAssertEqual(result.refunds, 1, "it is imported as a + credit")
+        XCTAssertEqual(result.ignoredNonSpend, 0)
+        // Confirm the stored row is actually a refund/credit.
+        let stored = try store.context.fetch(FetchDescriptor<LocalExpense>())
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertTrue(stored[0].isRefund, "the received transfer is stored as a + credit")
+    }
+
+    // MARK: - (q) Salary stays a skipped deposit
+
+    func test_salary_staysSkippedDeposit() async throws {
+        // "DEC PAY CWV1L" is payroll — the extractor keeps it `deposit`, so it is
+        // counted and reported but never imported (it would swamp the spend view).
+        let result = await importer.insert(
+            lines: [line("Salary", 14840.0, type: .deposit, descriptor: "DEC PAY CWV1L")],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.imported, 0, "salary is never imported")
+        XCTAssertEqual(result.deposits, 1, "salary is counted as a deposit")
+        XCTAssertEqual(result.depositsTotalSGD, 14840.0, accuracy: 0.001)
+        XCTAssertEqual(result.refunds, 0, "salary is NOT a credit")
+        XCTAssertEqual(try storedCount(), 0)
+    }
+
+    // MARK: - (r) DBS-shaped mix: summary wording uses "credits", salary skipped, card bill ignored
+
+    func test_dbsMixedStatement_summaryWording() async throws {
+        var lines: [ExtractedStatementLine] = []
+        // 3 ordinary withdrawals (spend).
+        lines.append(line("Kopitiam", 4.5, type: .purchase, descriptor: "KOPITIAM 1"))
+        lines.append(line("Grab", 12.0, type: .purchase, descriptor: "GRAB RIDE 2"))
+        lines.append(line("IRAS", 871.89, type: .purchase, descriptor: "GIRO IRAS TAX"))
+        // 1 credit-card bill payment (ignored).
+        lines.append(line("CC bill", 1548.46, type: .payment, descriptor: "ADVICE BILL PAYMENT / CCC - 5425503303732696 : I-BANK"))
+        // 2 incoming peer transfers (+ credits).
+        lines.append(line("Parul", 1000.0, type: .refund, descriptor: "FUNDS TRANSFER IB:KATYAL PARUL"))
+        lines.append(line("Naomi", 5.0, type: .refund, descriptor: "INCOMING PAYNOW FROM: NAOMI"))
+        // 1 salary (skipped deposit).
+        lines.append(line("Salary", 14840.0, type: .deposit, descriptor: "DEC PAY CWV1L"))
+
+        let result = await importer.insert(lines: lines, possiblyTruncated: false)
+
+        XCTAssertEqual(result.imported, 5, "3 spend + 2 credits import")
+        XCTAssertEqual(result.refunds, 2, "the two peer transfers are credits")
+        XCTAssertEqual(result.ignoredNonSpend, 1, "the card bill is ignored")
+        XCTAssertEqual(result.deposits, 1, "salary is a skipped deposit")
+        XCTAssertEqual(result.depositsTotalSGD, 14840.0, accuracy: 0.001)
+
+        let summary = result.summaryLine
+        XCTAssertTrue(summary.contains("Imported 5 (including 2 credits)"), "summary must say credits, not refunds, got: \(summary)")
+        XCTAssertTrue(summary.contains("Ignored 1 payment"), "the card bill shows as an ignored payment, got: \(summary)")
+        XCTAssertTrue(summary.contains("Skipped 1 deposit (SGD 14,840.00), income isn't tracked yet"), "salary reported as a skipped deposit, got: \(summary)")
+        XCTAssertFalse(summary.contains("refund"), "no 'refund' wording, got: \(summary)")
+        XCTAssertFalse(summary.contains("—"), "no em dash allowed, got: \(summary)")
+    }
+
     // MARK: - existingCount helper counts multiplicity, not existence
 
     func test_existingCount_reflectsMultiplicity() async throws {

--- a/mobile/PersonalDashboardTests/StatementDedupeReconciliationTests.swift
+++ b/mobile/PersonalDashboardTests/StatementDedupeReconciliationTests.swift
@@ -271,6 +271,89 @@ final class StatementDedupeReconciliationTests: XCTestCase {
         XCTAssertEqual(try storedCount(), 3)
     }
 
+    // MARK: - (j) Bank deposit is counted + totalled, never imported (#243)
+
+    func test_bankDeposit_countedAndTotalled_notImported() async throws {
+        let result = await importer.insert(
+            lines: [
+                line("Salary", 5000, type: .deposit),
+                line("Kopitiam", 4.5, type: .purchase)
+            ],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.imported, 1, "only the withdrawal imports as spend")
+        XCTAssertEqual(result.deposits, 1, "the deposit is counted")
+        XCTAssertEqual(result.depositsTotalSGD, 5000, accuracy: 0.001, "the deposit is summed in SGD")
+        XCTAssertEqual(result.ignoredNonSpend, 0, "a deposit is NOT a card payment")
+        XCTAssertEqual(result.refunds, 0, "a deposit is NOT a refund")
+        // The deposit must never become a LocalExpense (not as spend, not as a credit).
+        XCTAssertEqual(try storedCount(), 1, "only the withdrawal is stored")
+    }
+
+    // MARK: - (k) A money-out "collection" (mislabel trap) imports as spend
+
+    func test_moneyOutCollection_importsAsSpend() async throws {
+        // A DBS "FAST Collection" whose balance dropped is money OUT. The
+        // extractor is instructed to classify it by column/balance as a
+        // `purchase`, so the importer must treat it as ordinary spend.
+        let result = await importer.insert(
+            lines: [line("FAST Collection", 120.0, type: .purchase, descriptor: "ADVICE FAST COLLECTION SG")],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.imported, 1, "a money-out collection imports as spend")
+        XCTAssertEqual(result.deposits, 0)
+        XCTAssertEqual(result.ignoredNonSpend, 0)
+        XCTAssertEqual(try storedCount(), 1)
+    }
+
+    // MARK: - (l) summaryLine reports skipped deposits with a total
+
+    func test_summaryLine_includesDepositClause() async throws {
+        let result = await importer.insert(
+            lines: [
+                line("Coffee", 3.5, type: .purchase),
+                line("Transfer in", 16559.11, type: .deposit)
+            ],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.deposits, 1)
+        let summary = result.summaryLine
+        XCTAssertTrue(summary.contains("Skipped 1 deposit (SGD 16,559.11)"), "summary must state the deposit count and SGD total, got: \(summary)")
+        XCTAssertTrue(summary.contains("income isn't tracked yet"), "summary must explain deposits aren't tracked, got: \(summary)")
+        XCTAssertFalse(summary.contains("—"), "no em dash allowed in user-facing summary, got: \(summary)")
+        XCTAssertTrue(summary.contains("Imported 1"))
+    }
+
+    // MARK: - (m) totalParsed invariant now includes deposits
+
+    func test_totalParsed_includesDeposits() async throws {
+        let result = await importer.insert(
+            lines: [
+                line("Kopitiam", 4.5, type: .purchase),   // imported
+                line("Salary", 5000, type: .deposit),      // deposit
+                line("Bonus", 1000, type: .deposit),       // deposit
+                line("Autopay", 200, type: .payment),      // ignoredNonSpend
+                line("Broken", nil)                        // failed (no amount)
+            ],
+            possiblyTruncated: false
+        )
+
+        XCTAssertEqual(result.imported, 1)
+        XCTAssertEqual(result.deposits, 2)
+        XCTAssertEqual(result.ignoredNonSpend, 1)
+        XCTAssertEqual(result.failed, 1)
+        XCTAssertEqual(result.skippedDuplicates, 0)
+        XCTAssertEqual(
+            result.imported + result.skippedDuplicates + result.ignoredNonSpend + result.deposits + result.failed,
+            result.totalParsed,
+            "the accounting invariant now includes deposits"
+        )
+        XCTAssertEqual(result.totalParsed, 5)
+    }
+
     // MARK: - existingCount helper counts multiplicity, not existence
 
     func test_existingCount_reflectsMultiplicity() async throws {


### PR DESCRIPTION
## Summary

Extends the Finance statement importer to handle bank / savings account statements, not just credit cards.

- Extraction prompt now detects credit-card vs bank statements and classifies each line's direction by the debit/credit column (or balance delta), instead of guessing from description wording. Fixes DBS "FAST Collection" lines (money out) being read as credits.
- Adds a `deposit` line type for salary/payroll credits: counted and reported in the import summary, never dropped silently. Income is deliberately not stored (chosen scope).
- Ignores credit-card bill payments on both statement types (a bank line settling a card is a transfer, not spend), so importing both a bank and a card statement no longer double-counts.
- Records incoming peer transfers and reimbursements as "+" credits via the existing refund mechanism, so money someone sends you nets against spend and shows green. Salary stays skipped.
- Summary wording relabelled from "refunds" to "credits" to cover both cases.

## Test plan

- 20 unit tests pass in `StatementDedupeReconciliationTests` (15 prior unchanged + 5 new covering deposit/credit/payment classification and summary wording).
- Device QA completed on build 1.2.67 by re-importing the DBS Multiplier statement. Evidence and ticked acceptance criteria are on the linked issue.

Closes #243