### PR TITLE
feat(ios): import multiple expenses from a single photo

### DIFF
--- a/mobile/PersonalDashboard/AI/AnthropicClient+ExtractExpense.swift
+++ b/mobile/PersonalDashboard/AI/AnthropicClient+ExtractExpense.swift
@@ -105,6 +105,37 @@ extension AnthropicClient {
         )
     }
 
+    /// Send a PHOTO to Claude and ask for EVERY distinct expense in it (#247).
+    ///
+    /// A photo can hold several receipts at once, or a printed / handwritten
+    /// list of transactions for different merchants. This returns one
+    /// `ExtractedStatementLine` per distinct expense (a single receipt yields
+    /// exactly one line). It reuses the statement extraction CORE
+    /// (`runStatementExtraction`) — object-wrapper parsing, bare-array fallback,
+    /// truncated-array recovery, lenient per-line decode — with a RECEIPT-specific
+    /// prompt (`expensesFromPhotoPrompt`) instead of the statement prompt. No PDF
+    /// beta header is needed for an image, so `extraHeaders` is empty. Only the
+    /// `.lines` element is returned; there is no statement header for a photo.
+    func extractExpenses(imageData: Data, mediaType: String) async throws -> [ExtractedStatementLine] {
+        let base64 = imageData.base64EncodedString()
+        let content: [AnthropicJSONValue] = [
+            .object([
+                "type": .string("image"),
+                "source": .object([
+                    "type": .string("base64"),
+                    "media_type": .string(mediaType),
+                    "data": .string(base64)
+                ])
+            ]),
+            .object([
+                "type": .string("text"),
+                "text": .string(Self.expensesFromPhotoPrompt)
+            ])
+        ]
+        let (lines, _, _) = try await runStatementExtraction(content: content, extraHeaders: [:])
+        return lines
+    }
+
     // MARK: - Core
 
     private func runExtraction(
@@ -227,6 +258,63 @@ extension AnthropicClient {
     - "items" is a short list of line-item names (at most 6). Skip if not
       visible.
     - Do not invent fields. Do not add commentary outside the JSON fence.
+    """
+
+    /// Prompt for the PHOTO multi-expense path (#247). Unlike `extractionPrompt`
+    /// (one receipt → one object) this asks for one object PER DISTINCT expense,
+    /// and unlike `statementPrompt` it has NO statement header and only the two
+    /// receipt-relevant line types. The output KEEPS the `"lines"` wrapper key so
+    /// the shared `linesArray(in:)` parser matches, but OMITS the `"statement"`
+    /// wrapper (there is no header). `category` uses the RAW enum values (matching
+    /// how `StatementImporter.insert` maps via `ExpenseCategory(rawValue:)`), NOT
+    /// the display name the single-receipt prompt uses.
+    static let expensesFromPhotoPrompt: String = """
+    This is a PHOTO that may contain ONE OR MORE receipts, or a printed /
+    handwritten list of transactions for different merchants. Return one JSON
+    object per DISTINCT expense — one per receipt, or one per transaction line in
+    a list. If the photo is a single receipt, return EXACTLY ONE object.
+
+    Return STRICT JSON inside a ```json fence and nothing else — no prose before
+    or after. Emit a single JSON OBJECT with exactly one key, "lines":
+    {
+      "lines": [
+        {
+          "merchant": "Starbucks",
+          "date": "YYYY-MM-DD",
+          "amount": 12.34,
+          "currency": "SGD",
+          "type": "purchase",
+          "category": "food_and_dining",
+          "description": "Latte, croissant"
+        }
+      ]
+    }
+
+    Rules for each line:
+    - "merchant": the merchant / vendor name for display (e.g. "Starbucks").
+    - "date": the transaction date in ISO 8601 (YYYY-MM-DD). If the receipt shows
+      no year, infer a sensible one; never emit year 0, 0001, or 1970.
+    - "amount": the TOTAL for that receipt / transaction, as a POSITIVE number.
+      Never emit a negative amount — the sign is conveyed by "type".
+    - "currency": an ISO 4217 code (e.g. "SGD", "USD", "GBP"). If you genuinely
+      cannot tell, default to "SGD".
+    - "type": EXACTLY one of "purchase" or "refund".
+        - "purchase": a normal receipt / spend (the common case).
+        - "refund": a credit note or refund (money coming back).
+      Do NOT use "payment", "deposit", "interest", or "fee" — those are
+      statement-only concepts and never apply to a receipt photo.
+    - "category" must be EXACTLY one of these raw values: \(categoryRawList).
+      Pick the best fit from the merchant (a supermarket → groceries, a
+      restaurant → food_and_dining, an airline/hotel → travel, Netflix/Spotify →
+      subscriptions, a utility → bills_and_utilities, a monthly rent/lease → rent).
+      Use "other" only when nothing fits.
+    - "description": a SHORT summary of the line items on that receipt (at most 6,
+      comma-separated), e.g. "Latte, croissant". Omit or set null if not visible.
+    - Do NOT include a "descriptor" field — receipts have no verbatim bank
+      descriptor.
+
+    Never invent lines that aren't in the photo. Do not invent fields or add
+    commentary outside the JSON fence. Return ONLY the fenced JSON.
     """
 
     /// Pull the first ```json``` fenced block out of `text` and return its

--- a/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
+++ b/mobile/PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
@@ -20,6 +20,15 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
     let type: LineType?
     let category: String?      // ExpenseCategory.rawValue
 
+    /// Optional itemized / free-text description for the line. The STATEMENT
+    /// prompt never emits it (statement rows have no per-line detail), so it
+    /// stays nil there and statements are unaffected. The PHOTO / receipt
+    /// prompt (#247) uses it to carry the same short line-item summary the
+    /// single-receipt path produces, so a receipt imported via the multi-expense
+    /// path keeps its description. `decodeIfPresent` + a nil default keeps every
+    /// existing decode and call site unchanged.
+    let description: String?
+
     /// The transaction description EXACTLY as printed on the statement,
     /// verbatim (including any trailing location / country tokens and reference
     /// codes), with NO cleanup or reformatting (#208). Used ONLY as the stable
@@ -85,6 +94,7 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
         case type
         case category
         case descriptor
+        case description
     }
 
     /// Lenient decode: an unrecognised `type` string decodes to nil rather than
@@ -100,11 +110,12 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
         type = (try? c.decodeIfPresent(LineType.self, forKey: .type)) ?? nil
         category = try c.decodeIfPresent(String.self, forKey: .category)
         descriptor = try c.decodeIfPresent(String.self, forKey: .descriptor)
+        description = try c.decodeIfPresent(String.self, forKey: .description)
     }
 
-    /// Direct memberwise init for tests. `descriptor` defaults to nil so
-    /// existing call sites that don't exercise the dedup key stay unchanged.
-    init(merchant: String?, date: String?, amount: Double?, currency: String?, type: LineType?, category: String?, descriptor: String? = nil) {
+    /// Direct memberwise init for tests. `descriptor` and `description` default
+    /// to nil so existing call sites that don't exercise them stay unchanged.
+    init(merchant: String?, date: String?, amount: Double?, currency: String?, type: LineType?, category: String?, descriptor: String? = nil, description: String? = nil) {
         self.merchant = merchant
         self.date = date
         self.amount = amount
@@ -112,6 +123,7 @@ struct ExtractedStatementLine: Decodable, Sendable, Equatable {
         self.type = type
         self.category = category
         self.descriptor = descriptor
+        self.description = description
     }
 }
 
@@ -345,7 +357,11 @@ extension AnthropicClient {
 
     // MARK: - Core
 
-    private func runStatementExtraction(
+    /// Internal (not `private`) so the image multi-expense extractor
+    /// (`extractExpenses(imageData:mediaType:)`, #247) can reuse the exact same
+    /// object-wrapper parsing, bare-array fallback, truncated-array recovery,
+    /// 120s timeout, and lenient per-line decode. Behaviour is unchanged.
+    func runStatementExtraction(
         content: [AnthropicJSONValue],
         extraHeaders: [String: String]
     ) async throws -> (lines: [ExtractedStatementLine], meta: ExtractedStatementMeta, possiblyTruncated: Bool) {
@@ -456,7 +472,10 @@ extension AnthropicClient {
     /// Enum raw values advertised to the model, so it returns categories that
     /// map straight onto `LocalExpense.category`. Kept in sync with
     /// `ExpenseCategory` the same way the `add_expense` tool schema is.
-    private static var categoryRawList: String {
+    /// Internal (not `private`) so the photo multi-expense prompt in
+    /// `AnthropicClient+ExtractExpense.swift` reuses the same raw-value list
+    /// rather than duplicating it (#247).
+    static var categoryRawList: String {
         ExpenseCategory.allCases
             .map { $0.rawValue }
             .joined(separator: ", ")

--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -187,10 +187,22 @@ struct StatementImporter {
     /// It defaults to an empty header so existing test call sites that only pass
     /// `lines` keep compiling and behave exactly as before (no label, no
     /// payment method).
+    ///
+    /// `source`, `receiptImagePath`, and `recordsImportHistory` (#247) let the
+    /// photo multi-expense path reuse this exact pipeline. They all default to
+    /// the statement behaviour so every existing caller and test compiles
+    /// unchanged: statements tag rows `.pdf`, carry no receipt image, and write
+    /// a `LocalStatementImport` history record. A photo import passes `source:
+    /// .photo` (or `.receipt`), the saved receipt's `receiptImagePath` (shared
+    /// across all rows the photo produced), and `recordsImportHistory: false` so
+    /// photos don't pollute the statement history.
     func insert(
         lines: [ExtractedStatementLine],
         meta: ExtractedStatementMeta = ExtractedStatementMeta(issuer: nil, last4: nil, statementMonth: nil, statementYear: nil),
         fileName: String? = nil,
+        source: ExpenseSource = .pdf,
+        receiptImagePath: String? = nil,
+        recordsImportHistory: Bool = true,
         possiblyTruncated: Bool
     ) async -> StatementImportResult {
         var imported = 0
@@ -227,6 +239,10 @@ struct StatementImporter {
             let merchant: String?
             let category: ExpenseCategory
             let isRefund: Bool
+            /// Optional per-line description. nil for statement lines (the
+            /// statement prompt emits none); carries the receipt's item summary
+            /// for photo imports (#247).
+            let description: String?
             let proposed: ExpenseDedupe.Proposed
             /// Structural class key (dir|merchant|day|amount|currency). Stamped on
             /// the inserted row's `dedupeKey` for continuity with the email path;
@@ -317,6 +333,11 @@ struct StatementImporter {
             let descriptorSource = rawDescriptor.isEmpty ? (merchant ?? "") : rawDescriptor
             let descKey = ExpenseDedupe.normalizeMerchant(descriptorSource)
 
+            // Per-line description: nil for statements (none emitted), the
+            // receipt item summary for photo imports (#247). Trimmed, empty → nil.
+            let trimmedDescription = line.description?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let lineDescription = (trimmedDescription?.isEmpty == false) ? trimmedDescription : nil
+
             candidates.append(Candidate(
                 amount: amount,
                 currency: currency,
@@ -324,6 +345,7 @@ struct StatementImporter {
                 merchant: merchant,
                 category: category,
                 isRefund: isRefund,
+                description: lineDescription,
                 proposed: proposed,
                 classKey: ExpenseDedupe.signature(for: proposed),
                 descKey: descKey
@@ -388,13 +410,13 @@ struct StatementImporter {
                     date: candidate.date,
                     category: candidate.category,
                     merchant: candidate.merchant,
-                    expenseDescription: nil,
+                    expenseDescription: candidate.description,
                     originalAmount: candidate.amount,
                     originalCurrency: candidate.currency,
                     sgdAmount: conversion.sgdAmount,
                     fxRate: conversion.rate,
                     paymentMethod: paymentMethod,
-                    source: .pdf,
+                    source: source,
                     isRefund: candidate.isRefund
                 )
                 // Stamp the structural dedupe signature (kept for continuity with
@@ -407,6 +429,11 @@ struct StatementImporter {
                 // (dir|day|amount|currency) bucket, so the same statement dedups
                 // even when the model paraphrases the merchant differently.
                 row.dedupeDescriptor = candidate.descKey
+                // Receipt image the row came from (#247). nil for statements;
+                // for a photo import every row shares the ONE saved receipt path,
+                // so the reference-aware delete keeps the file until the last of
+                // them is removed.
+                row.receiptImagePath = receiptImagePath
                 // Statement attribution (#189): which statement this came off.
                 // Display-only — deliberately NOT part of the dedupe signature.
                 row.statementLabel = statementLabel
@@ -434,7 +461,12 @@ struct StatementImporter {
         // an empty history entry (and the existing rows already have a record).
         // Additive model, so this never changes the returned result or the
         // summary alert; it's purely a side record.
-        if imported > 0 {
+        //
+        // Gated on `recordsImportHistory` (#247): a photo import passes false so
+        // it never appears in the statement Parsed Files & Imports history —
+        // that history is for statement PDFs, and a photo has no file name to
+        // group under. Statements keep the default (true).
+        if recordsImportHistory, imported > 0 {
             let record = LocalStatementImport(
                 fileName: statementFileName,
                 statementLabel: statementLabel,

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -122,7 +122,9 @@ struct FinanceView: View {
             handleStatementData(data, fileName: fileName)
         }
         .alert(
-            "Statement import",
+            // Source-agnostic: this summary now backs both statement imports
+            // and multi-expense photo imports (#247).
+            "Import complete",
             isPresented: statementSummaryBinding,
             presenting: statementImportSummary
         ) { _ in
@@ -293,27 +295,40 @@ struct FinanceView: View {
 
         // 3. Run Vision in the background; the processing row is already visible.
         do {
-            let extracted: ExtractedExpense
             switch captureSource {
             case .camera, .photoLibrary:
-                extracted = try await client.extractExpense(
+                // A photo can hold MULTIPLE expenses — several receipts in one
+                // shot, or a printed/handwritten list of transactions for
+                // different merchants (#247). Extract them ALL, then route on
+                // count: 0 → failure fallback, 1 → today's single-receipt
+                // behaviour, 2+ → batch auto-import (like a statement).
+                let lines = try await client.extractExpenses(
                     imageData: visionImageData ?? data,
                     mediaType: "image/jpeg"
                 )
+                await handleExtractedPhotoLines(
+                    lines,
+                    receiptImagePath: relativePath,
+                    source: expenseSource
+                )
             case .pdf:
-                extracted = try await client.extractExpense(pdfData: data)
+                // PDF stays on the single-expense path, unchanged.
+                let extracted = try await client.extractExpense(pdfData: data)
+                let prefill = PrefilledExpense.fromExtraction(
+                    extracted,
+                    receiptImagePath: relativePath,
+                    source: expenseSource
+                )
+                await autoAddThenEdit(prefill: prefill)
             }
-            let prefill = PrefilledExpense.fromExtraction(
-                extracted,
-                receiptImagePath: relativePath,
-                source: expenseSource
-            )
-            await autoAddThenEdit(prefill: prefill)
         } catch {
             // Save the receipt regardless; open the form with a banner. No row
             // was created, so `.prefilled` inserting on save is correct here.
             let message: String = {
                 if let typed = error as? ReceiptExtractionError {
+                    return typed.localizedDescription
+                }
+                if let typed = error as? StatementExtractionError {
                     return typed.localizedDescription
                 }
                 return "We saved your receipt but couldn't read it. Fill in the details below."
@@ -324,6 +339,54 @@ struct FinanceView: View {
                 message: message
             )
             editingTarget = .prefilled(prefill)
+        }
+    }
+
+    /// Route the expenses extracted from ONE photo (#247). Called only for the
+    /// image path (camera / library); PDFs never reach here.
+    ///   - 0 lines: extraction returned nothing usable. Receipt is already
+    ///     saved, so fall back to the review sheet with a banner (same as a
+    ///     thrown extraction error).
+    ///   - 1 line: today's behaviour. Prefill from the single line and
+    ///     auto-add + open the sheet to confirm — exactly one row inserted.
+    ///   - 2+ lines: auto-import all of them through the SAME batch pipeline the
+    ///     statement path uses (dedupe + FX + insert), sharing the one saved
+    ///     receipt image across every row, and surface the count summary. No
+    ///     per-row review sheet in this case.
+    private func handleExtractedPhotoLines(
+        _ lines: [ExtractedStatementLine],
+        receiptImagePath: String,
+        source: ExpenseSource
+    ) async {
+        switch lines.count {
+        case 0:
+            let prefill = PrefilledExpense.fromFailure(
+                receiptImagePath: receiptImagePath,
+                source: source,
+                message: "We saved your photo but couldn't read any expenses. Fill in the details below."
+            )
+            editingTarget = .prefilled(prefill)
+        case 1:
+            let prefill = PrefilledExpense.from(
+                line: lines[0],
+                receiptImagePath: receiptImagePath,
+                source: source
+            )
+            await autoAddThenEdit(prefill: prefill)
+        default:
+            // Reuse the statement batch importer. Empty meta + nil fileName so
+            // nothing masquerades as a statement (no attribution label, no
+            // payment method, no statement history entry). `possiblyTruncated`
+            // is false — a photo is a single non-chunked request.
+            let result = await StatementImporter.default().insert(
+                lines: lines,
+                fileName: nil,
+                source: source,
+                receiptImagePath: receiptImagePath,
+                recordsImportHistory: false,
+                possiblyTruncated: false
+            )
+            statementImportSummary = result.summaryLine
         }
     }
 
@@ -830,8 +893,18 @@ struct FinanceView: View {
         // if the file delete fails (read-only volume, etc.) we still
         // proceed with the SwiftData delete; the orphaned file is a
         // bytes-wasted nuisance, not a correctness bug.
+        //
+        // A multi-expense photo import (#247) feeds ONE receipt image to N
+        // rows, all sharing the same `receiptImagePath`. Only delete the file
+        // once NO OTHER expense still references it — otherwise deleting one of
+        // the sibling rows would orphan the receipt the others still show.
         if let path = expense.receiptImagePath {
-            try? ReceiptStorage.shared.delete(relativePath: path)
+            let stillReferenced = allExpenses.contains {
+                $0.clientUUID != expense.clientUUID && $0.receiptImagePath == path
+            }
+            if !stillReferenced {
+                try? ReceiptStorage.shared.delete(relativePath: path)
+            }
         }
         modelContext.delete(expense)
         try? modelContext.save()

--- a/mobile/PersonalDashboard/Views/Finance/PrefilledExpense.swift
+++ b/mobile/PersonalDashboard/Views/Finance/PrefilledExpense.swift
@@ -75,6 +75,54 @@ struct PrefilledExpense: Hashable {
         )
     }
 
+    /// Single-line photo import (#247) → seed the review sheet from one
+    /// `ExtractedStatementLine`. Used when a photo yielded EXACTLY ONE expense,
+    /// so the flow matches today's single-receipt behaviour (auto-add one row,
+    /// open the sheet to confirm). Mirrors the field set `fromExtraction`
+    /// produces so `autoAddThenEdit` works unchanged.
+    ///
+    /// `category` maps via `ExpenseCategory(rawValue:)` — the photo prompt emits
+    /// RAW enum values (e.g. "food_and_dining"), NOT the display name — so this
+    /// deliberately does NOT use `ExpenseCategory.matching(displayName:)`.
+    static func from(
+        line: ExtractedStatementLine,
+        receiptImagePath: String,
+        source: ExpenseSource
+    ) -> PrefilledExpense {
+        let parsedDate: Date? = {
+            guard let raw = line.date else { return nil }
+            let formatter = DateFormatter()
+            formatter.calendar = Calendar(identifier: .iso8601)
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = "yyyy-MM-dd"
+            return formatter.date(from: raw)
+        }()
+
+        let category = (line.category?.trimmingCharacters(in: .whitespacesAndNewlines))
+            .flatMap { ExpenseCategory(rawValue: $0.lowercased()) }
+
+        let descriptionText: String? = {
+            guard let d = line.description?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !d.isEmpty else { return nil }
+            return d
+        }()
+
+        return PrefilledExpense(
+            receiptImagePath: receiptImagePath,
+            source: source,
+            extractionSucceeded: true,
+            extractionError: nil,
+            confidence: nil,
+            amount: line.amount,
+            currency: line.currency,
+            category: category,
+            date: parsedDate,
+            merchant: line.merchant,
+            descriptionText: descriptionText
+        )
+    }
+
     /// Vision failed → carry only the receipt + the error message.
     static func fromFailure(
         receiptImagePath: String,


### PR DESCRIPTION
## Summary
- A photo scan now asks the AI for **every** expense in the image, not just one.
- One expense in the photo: unchanged (added, edit sheet opens for review).
- Two or more expenses: all are FX-converted, deduped, and saved automatically with a count summary, reusing the existing statement import pipeline (`StatementImporter.insert`).
- New receipt-specific extractor `extractExpenses(imageData:mediaType:)` + prompt; reuses the statement extraction/array-recovery core.
- Re-scanning the same photo is idempotent (dedup on merchant + amount + date + currency).
- Receipt-file deletion is now reference-aware: deleting one of several expenses sharing a photo keeps the image on the others.
- PDF scanning is unchanged.

Closes #247

## Test plan
- [x] Clean static build (`xcodebuild ... BUILD SUCCEEDED`, `CODE_SIGNING_ALLOWED=NO`)
- [x] Shipped to device (iPhone 16 Pro Max) and QA'd by the user
- [x] Single receipt: one expense added, edit sheet opens (unchanged)
- [x] Multiple receipts / transaction list: all saved automatically with count summary; amounts, merchants, dates, categories correct
- [x] Mixed currencies each convert to SGD
- [x] Re-scanning the same multi-expense photo adds no duplicates
- [x] Deleting one expense from a shared photo keeps the receipt image on the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)