### PR TITLE
feat(ios): make time more evident on itinerary tiles

### DIFF
--- a/mobile/PersonalDashboard/Design/Typography.swift
+++ b/mobile/PersonalDashboard/Design/Typography.swift
@@ -34,6 +34,7 @@ extension Font {
     static let edBodyMedium  = inter(16, weight: .medium, relativeTo: .body)
     static let edSubheadline = inter(15, relativeTo: .subheadline)
     static let edFootnote    = inter(13, weight: .medium, relativeTo: .footnote)
+    static let edFootnoteStrong = inter(13, weight: .semibold, relativeTo: .footnote) // bold footnote, e.g. the prominent time line on itinerary tiles
     static let edCaption     = inter(12, relativeTo: .caption)
     static let edEyebrow     = inter(11, weight: .semibold, relativeTo: .caption2) // pair with .textCase(.uppercase) and .tracking(1.4)
     static let edMono        = jbMono(13, relativeTo: .footnote)

--- a/mobile/PersonalDashboard/Views/Itineraries/TicketCardView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TicketCardView.swift
@@ -124,7 +124,7 @@ struct TicketCardView: View {
             routeEndpoint(
                 code: meta?.originCode,
                 city: meta?.originCity,
-                time: departureTime,
+                time: departureTimeText,
                 alignment: .leading
             )
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -135,7 +135,7 @@ struct TicketCardView: View {
             routeEndpoint(
                 code: meta?.destinationCode,
                 city: meta?.destinationCity,
-                time: nil,
+                time: arrivalTimeText,
                 alignment: .trailing
             )
             .frame(maxWidth: .infinity, alignment: .trailing)
@@ -180,19 +180,39 @@ struct TicketCardView: View {
                     .lineLimit(1)
             }
             if let time, !time.isEmpty {
+                // Time reads as a real detail on the pass, not a footnote:
+                // bumped to body-medium ink, still subordinate to the display
+                // airport code above it.
                 Text(time)
-                    .font(.edFootnote)
-                    .foregroundStyle(Tokens.inkSoft)
+                    .font(.edBodyMedium)
+                    .monospacedDigit()
+                    .foregroundStyle(Tokens.ink)
                     .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
         }
         .multilineTextAlignment(alignment == .leading ? .leading : .trailing)
     }
 
     /// The departure time from the timeline's own time treatment, unless untimed.
+    /// Used by the event layout (a single moment) where `timeText` is one time.
     private var departureTime: String? {
         guard let t = timeText, !t.isEmpty, t != "Anytime" else { return nil }
         return t
+    }
+
+    /// Departure / arrival times for the boarding-pass hero, derived straight
+    /// from the item so each endpoint shows its own clock (the combined
+    /// `timeText` pairs both with an arrow, which we don't want per-endpoint).
+    /// Both go through the shared UTC-pinned formatter.
+    private var departureTimeText: String? {
+        guard let t = item.startTime else { return nil }
+        return TimelineEntry.itineraryTimeFormatter.string(from: t)
+    }
+
+    private var arrivalTimeText: String? {
+        guard let t = item.arrivalTime else { return nil }
+        return TimelineEntry.itineraryTimeFormatter.string(from: t)
     }
 
     /// "IndiGo · 6E681" for the label bar, from whatever of the two is present.
@@ -227,6 +247,22 @@ struct TicketCardView: View {
                     Text(item.venue)
                         .font(.edCaption)
                         .foregroundStyle(Tokens.muted)
+                        .lineLimit(1)
+                }
+            }
+
+            // Time is the event's primary "when": promoted out of the equal-
+            // weight facts strip into a prominent accent-led line under the
+            // venue, so it reads first among the details.
+            if let time = departureTime {
+                HStack(spacing: 6) {
+                    Image(systemName: "clock")
+                        .font(.system(size: 13, weight: .regular))
+                        .foregroundStyle(Tokens.accent(for: .itineraries))
+                    Text(time)
+                        .font(.edBodyMedium)
+                        .monospacedDigit()
+                        .foregroundStyle(Tokens.ink)
                         .lineLimit(1)
                 }
             }
@@ -450,13 +486,13 @@ struct TicketCardView: View {
     }
 
     /// Event facts: only the slots that carry a real value, so a sparse ticket
-    /// doesn't show empty columns.
+    /// doesn't show empty columns. Time is deliberately excluded here: it's
+    /// promoted to its own prominent line above the facts strip (see `eventTop`).
     private var eventFacts: [TicketFact] {
         [
             TicketFact(label: "Section", value: meta?.section),
             TicketFact(label: "Row",     value: meta?.row),
-            TicketFact(label: "Seat",    value: item.seat.isEmpty ? nil : item.seat),
-            TicketFact(label: "Time",    value: departureTime)
+            TicketFact(label: "Seat",    value: item.seat.isEmpty ? nil : item.seat)
         ].filter { $0.value != nil }
     }
 

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -437,11 +437,6 @@ enum TimelineLayout {
     /// Equals `railLeading + markerRadius + gutter` (~11pt gutter past the
     /// marker outer edge).
     static let cardLeading: CGFloat = 32
-    /// Width of the leading agenda-style time column inside each card. Sized to
-    /// fit a 12-hour "12:00 AM" (Inter medium 13, tabular digits) without
-    /// clipping; 24-hour "10:35" sits comfortably. Tune on device if a locale's
-    /// AM/PM string runs wider.
-    static let timeColumnWidth: CGFloat = 56
     /// Diameter of each item's marker dot.
     static let markerDiameter: CGFloat = 10
     /// Diameter of the day eyebrow's leading dot.
@@ -551,45 +546,6 @@ enum TimelineEntry: Identifiable {
             return "Check-out"
         }
     }
-
-    /// The individual pieces the leading agenda-style time column renders,
-    /// kept separate (not the combined `dateTimeLine` string) so the column can
-    /// style the primary time, a secondary time, and a descriptor
-    /// independently. `primary == nil` marks an untimed entry (the column shows
-    /// a quiet "Anytime"). All times go through the shared UTC-pinned formatter.
-    struct TimeColumnParts {
-        var primary: String?
-        var secondary: String?
-        var descriptor: String?
-    }
-
-    var timeColumn: TimeColumnParts {
-        let fmt: (Date) -> String = { TimelineEntry.itineraryTimeFormatter.string(from: $0) }
-        switch self {
-        case .single(let item):
-            // Departure up top; arrival (when set) beneath it as a secondary
-            // line, mirroring the "10:35 → 15:35" pairing of `dateTimeLine`.
-            return TimeColumnParts(
-                primary: item.startTime.map(fmt),
-                secondary: item.arrivalTime.map(fmt),
-                descriptor: nil
-            )
-        case .stayCheckIn(let item):
-            // The clock now lives in the column; the "Check-in" descriptor
-            // moves onto the card body (see `TripTimelineRow.card`).
-            return TimeColumnParts(
-                primary: item.startTime.map(fmt),
-                secondary: nil,
-                descriptor: "Check-in"
-            )
-        case .stayCheckOut(let item):
-            return TimeColumnParts(
-                primary: item.endTime.map(fmt),
-                secondary: nil,
-                descriptor: "Check-out"
-            )
-        }
-    }
 }
 
 // MARK: - Editor target
@@ -660,44 +616,35 @@ private struct TripDayCluster: View {
         let tripEnd = cal.startOfDay(for: trip.endDate)
         let withinTrip = day >= tripStart && day <= tripEnd
         let dayNumber = cal.dateComponents([.day], from: tripStart, to: day).day.map { $0 + 1 } ?? 0
+        // The date is now the section header, so it drops the uppercase/tracked
+        // eyebrow treatment for a readable title case (e.g. "Wed, 14 May").
         let weekdayDate = day
             .formatted(.dateTime.weekday(.abbreviated).day().month(.abbreviated))
-            .uppercased()
 
-        return HStack(spacing: Space.sm) {
+        return HStack(alignment: .center, spacing: Space.sm) {
             Circle()
-                .fill(Tokens.accent(for: .itineraries))
+                .fill(withinTrip ? Tokens.accent(for: .itineraries) : Tokens.muted)
                 .frame(width: TimelineLayout.dayDotDiameter, height: TimelineLayout.dayDotDiameter)
                 .railNode()
-            HStack(spacing: 0) {
-                if withinTrip {
-                    Text("DAY \(dayNumber)")
-                        .font(.edEyebrow)
-                        .textCase(.uppercase)
-                        .tracking(1.4)
-                        .foregroundStyle(Tokens.accent(for: .itineraries))
-                } else {
-                    Text("OUTSIDE TRIP")
-                        .font(.edEyebrow)
-                        .textCase(.uppercase)
-                        .tracking(1.4)
-                        .foregroundStyle(Tokens.muted)
-                }
-                Text(" · ")
-                    .font(.edEyebrow)
-                    .foregroundStyle(Tokens.mutedSoft)
-                Text(weekdayDate)
+            // Eyebrow context ("DAY n") stacked over the prominent date header,
+            // so the date reads as the clear divider between days.
+            VStack(alignment: .leading, spacing: 1) {
+                Text(withinTrip ? "DAY \(dayNumber)" : "OUTSIDE TRIP")
                     .font(.edEyebrow)
                     .textCase(.uppercase)
                     .tracking(1.4)
-                    .foregroundStyle(Tokens.muted)
+                    .foregroundStyle(withinTrip ? Tokens.accent(for: .itineraries) : Tokens.muted)
+                Text(weekdayDate)
+                    .font(.edHeading)
+                    .foregroundStyle(Tokens.ink)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
             Spacer(minLength: 0)
         }
         // Indent so the dot's centerline sits at `railLeading`, lined up
         // with every item marker below it.
         .padding(.leading, TimelineLayout.railLeading - TimelineLayout.dayDotDiameter / 2)
-        .frame(height: 36)
     }
 
     // MARK: Items + rail
@@ -797,87 +744,48 @@ private struct TripTimelineRow: View {
     private var card: some View {
         let item = entry.item
         let kind = item.kindEnum
-        let time = entry.timeColumn
+        let isTimed = entry.effectiveTime != nil
 
-        // Leading time column | content column. `.firstTextBaseline` pins the
-        // primary time's baseline to the title's first line, so the clock reads
-        // as the row's anchor (echoing the marker's title-line alignment).
-        return HStack(alignment: .firstTextBaseline, spacing: Space.md) {
-            timeColumnView(time)
+        return VStack(alignment: .leading, spacing: Space.xs) {
+            // Time reads first: bold, accent-coloured, tabular-digit line at the
+            // very top of the tile. An untimed "Anytime" stays the same
+            // treatment but softens to muted so timed rows carry the emphasis.
+            Text(entry.dateTimeLine)
+                .font(.edFootnoteStrong)
+                .monospacedDigit()
+                .foregroundStyle(isTimed ? Tokens.accent(for: .itineraries) : Tokens.muted)
+                .lineLimit(1)
+                .truncationMode(.tail)
 
-            VStack(alignment: .leading, spacing: Space.xs) {
-                Text(item.title)
-                    .font(.edBodyMedium)
-                    .foregroundStyle(Tokens.ink)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+            Text(item.title)
+                .font(.edBodyMedium)
+                .foregroundStyle(Tokens.ink)
+                .lineLimit(1)
+                .truncationMode(.tail)
 
-                HStack(spacing: Space.sm) {
-                    TripKindChip(kind: kind, transportMode: item.transportModeEnum)
-                    mapsChip(for: item)
-                    Spacer(minLength: 0)
-                }
+            HStack(spacing: Space.sm) {
+                TripKindChip(kind: kind, transportMode: item.transportModeEnum)
+                mapsChip(for: item)
+                Spacer(minLength: 0)
+            }
 
-                // Stays surface their "Check-in" / "Check-out" descriptor here
-                // now that the clock itself lives in the leading column.
-                if let descriptor = time.descriptor {
-                    Text(descriptor)
+            if !item.address.isEmpty {
+                HStack(alignment: .top, spacing: 4) {
+                    Image(systemName: "mappin.and.ellipse")
+                        .font(.system(size: 11, weight: .regular))
+                        .foregroundStyle(Tokens.muted)
+                    Text(item.address)
                         .font(.edCaption)
                         .foregroundStyle(Tokens.muted)
-                        .lineLimit(1)
-                }
-
-                if !item.address.isEmpty {
-                    HStack(alignment: .top, spacing: 4) {
-                        Image(systemName: "mappin.and.ellipse")
-                            .font(.system(size: 11, weight: .regular))
-                            .foregroundStyle(Tokens.muted)
-                        Text(item.address)
-                            .font(.edCaption)
-                            .foregroundStyle(Tokens.muted)
-                            .lineLimit(2)
-                            .truncationMode(.tail)
-                    }
+                        .lineLimit(2)
+                        .truncationMode(.tail)
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(Space.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
         .paperBorder(Tokens.border, radius: Radius.md)
-    }
-
-    /// The leading agenda-style time column: prominent primary time in ink with
-    /// tabular digits so times align vertically down the timeline; a quieter
-    /// arrival time beneath it when present; a muted "Anytime" for untimed rows
-    /// so timed rows pop.
-    @ViewBuilder
-    private func timeColumnView(_ parts: TimelineEntry.TimeColumnParts) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            if let primary = parts.primary {
-                Text(primary)
-                    .font(.edFootnote)
-                    .monospacedDigit()
-                    .foregroundStyle(Tokens.ink)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-                if let secondary = parts.secondary {
-                    Text(secondary)
-                        .font(.edCaption)
-                        .monospacedDigit()
-                        .foregroundStyle(Tokens.muted)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.8)
-                }
-            } else {
-                Text("Anytime")
-                    .font(.edCaption)
-                    .foregroundStyle(Tokens.muted)
-                    .lineLimit(1)
-            }
-        }
-        .frame(width: TimelineLayout.timeColumnWidth, alignment: .leading)
     }
 
     /// Maps affordance on the card: a labeled "MAP" pill sitting right after

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -626,20 +626,13 @@ private struct TripDayCluster: View {
                 .fill(withinTrip ? Tokens.accent(for: .itineraries) : Tokens.muted)
                 .frame(width: TimelineLayout.dayDotDiameter, height: TimelineLayout.dayDotDiameter)
                 .railNode()
-            // Eyebrow context ("DAY n") stacked over the prominent date header,
-            // so the date reads as the clear divider between days.
-            VStack(alignment: .leading, spacing: 1) {
-                Text(withinTrip ? "DAY \(dayNumber)" : "OUTSIDE TRIP")
-                    .font(.edEyebrow)
-                    .textCase(.uppercase)
-                    .tracking(1.4)
-                    .foregroundStyle(withinTrip ? Tokens.accent(for: .itineraries) : Tokens.muted)
-                Text(weekdayDate)
-                    .font(.edHeading)
-                    .foregroundStyle(Tokens.ink)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-            }
+            // Single-line prominent date header: "Day 1: Wed, 14 May" in one
+            // consistent size, no eyebrow/date split, no line break.
+            Text(withinTrip ? "Day \(dayNumber): \(weekdayDate)" : weekdayDate)
+                .font(.edHeading)
+                .foregroundStyle(Tokens.ink)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
             Spacer(minLength: 0)
         }
         // Indent so the dot's centerline sits at `railLeading`, lined up

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -626,13 +626,23 @@ private struct TripDayCluster: View {
                 .fill(withinTrip ? Tokens.accent(for: .itineraries) : Tokens.muted)
                 .frame(width: TimelineLayout.dayDotDiameter, height: TimelineLayout.dayDotDiameter)
                 .railNode()
-            // Single-line prominent date header: "Day 1: Wed, 14 May" in one
-            // consistent size, no eyebrow/date split, no line break.
-            Text(withinTrip ? "Day \(dayNumber): \(weekdayDate)" : weekdayDate)
-                .font(.edHeading)
-                .foregroundStyle(Tokens.ink)
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
+            // Single-line prominent date header, one consistent size, no line
+            // break. The "Day n" prefix is highlighted in the accent colour to
+            // set it apart from the ink date (e.g. "Day 1: Wed, 14 May").
+            Group {
+                if withinTrip {
+                    Text("Day \(dayNumber)")
+                        .foregroundStyle(Tokens.accent(for: .itineraries))
+                    + Text(": \(weekdayDate)")
+                        .foregroundStyle(Tokens.ink)
+                } else {
+                    Text(weekdayDate)
+                        .foregroundStyle(Tokens.ink)
+                }
+            }
+            .font(.edHeading)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
             Spacer(minLength: 0)
         }
         // Indent so the dot's centerline sits at `railLeading`, lined up

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -437,6 +437,11 @@ enum TimelineLayout {
     /// Equals `railLeading + markerRadius + gutter` (~11pt gutter past the
     /// marker outer edge).
     static let cardLeading: CGFloat = 32
+    /// Width of the leading agenda-style time column inside each card. Sized to
+    /// fit a 12-hour "12:00 AM" (Inter medium 13, tabular digits) without
+    /// clipping; 24-hour "10:35" sits comfortably. Tune on device if a locale's
+    /// AM/PM string runs wider.
+    static let timeColumnWidth: CGFloat = 56
     /// Diameter of each item's marker dot.
     static let markerDiameter: CGFloat = 10
     /// Diameter of the day eyebrow's leading dot.
@@ -544,6 +549,45 @@ enum TimelineEntry: Identifiable {
         case .stayCheckOut(let item):
             if let t = item.endTime { return "Check-out · \(timeFormat(t))" }
             return "Check-out"
+        }
+    }
+
+    /// The individual pieces the leading agenda-style time column renders,
+    /// kept separate (not the combined `dateTimeLine` string) so the column can
+    /// style the primary time, a secondary time, and a descriptor
+    /// independently. `primary == nil` marks an untimed entry (the column shows
+    /// a quiet "Anytime"). All times go through the shared UTC-pinned formatter.
+    struct TimeColumnParts {
+        var primary: String?
+        var secondary: String?
+        var descriptor: String?
+    }
+
+    var timeColumn: TimeColumnParts {
+        let fmt: (Date) -> String = { TimelineEntry.itineraryTimeFormatter.string(from: $0) }
+        switch self {
+        case .single(let item):
+            // Departure up top; arrival (when set) beneath it as a secondary
+            // line, mirroring the "10:35 → 15:35" pairing of `dateTimeLine`.
+            return TimeColumnParts(
+                primary: item.startTime.map(fmt),
+                secondary: item.arrivalTime.map(fmt),
+                descriptor: nil
+            )
+        case .stayCheckIn(let item):
+            // The clock now lives in the column; the "Check-in" descriptor
+            // moves onto the card body (see `TripTimelineRow.card`).
+            return TimeColumnParts(
+                primary: item.startTime.map(fmt),
+                secondary: nil,
+                descriptor: "Check-in"
+            )
+        case .stayCheckOut(let item):
+            return TimeColumnParts(
+                primary: item.endTime.map(fmt),
+                secondary: nil,
+                descriptor: "Check-out"
+            )
         }
     }
 }
@@ -753,43 +797,87 @@ private struct TripTimelineRow: View {
     private var card: some View {
         let item = entry.item
         let kind = item.kindEnum
+        let time = entry.timeColumn
 
-        return VStack(alignment: .leading, spacing: Space.xs) {
-            Text(item.title)
-                .font(.edBodyMedium)
-                .foregroundStyle(Tokens.ink)
-                .lineLimit(1)
-                .truncationMode(.tail)
+        // Leading time column | content column. `.firstTextBaseline` pins the
+        // primary time's baseline to the title's first line, so the clock reads
+        // as the row's anchor (echoing the marker's title-line alignment).
+        return HStack(alignment: .firstTextBaseline, spacing: Space.md) {
+            timeColumnView(time)
 
-            HStack(spacing: Space.sm) {
-                TripKindChip(kind: kind, transportMode: item.transportModeEnum)
-                mapsChip(for: item)
-                Spacer(minLength: 0)
-            }
+            VStack(alignment: .leading, spacing: Space.xs) {
+                Text(item.title)
+                    .font(.edBodyMedium)
+                    .foregroundStyle(Tokens.ink)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
 
-            if !item.address.isEmpty {
-                HStack(alignment: .top, spacing: 4) {
-                    Image(systemName: "mappin.and.ellipse")
-                        .font(.system(size: 11, weight: .regular))
-                        .foregroundStyle(Tokens.muted)
-                    Text(item.address)
+                HStack(spacing: Space.sm) {
+                    TripKindChip(kind: kind, transportMode: item.transportModeEnum)
+                    mapsChip(for: item)
+                    Spacer(minLength: 0)
+                }
+
+                // Stays surface their "Check-in" / "Check-out" descriptor here
+                // now that the clock itself lives in the leading column.
+                if let descriptor = time.descriptor {
+                    Text(descriptor)
                         .font(.edCaption)
                         .foregroundStyle(Tokens.muted)
-                        .lineLimit(2)
-                        .truncationMode(.tail)
+                        .lineLimit(1)
+                }
+
+                if !item.address.isEmpty {
+                    HStack(alignment: .top, spacing: 4) {
+                        Image(systemName: "mappin.and.ellipse")
+                            .font(.system(size: 11, weight: .regular))
+                            .foregroundStyle(Tokens.muted)
+                        Text(item.address)
+                            .font(.edCaption)
+                            .foregroundStyle(Tokens.muted)
+                            .lineLimit(2)
+                            .truncationMode(.tail)
+                    }
                 }
             }
-
-            Text(entry.dateTimeLine)
-                .font(.edCaption)
-                .foregroundStyle(Tokens.muted)
-                .lineLimit(1)
-                .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(Space.md)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
         .paperBorder(Tokens.border, radius: Radius.md)
+    }
+
+    /// The leading agenda-style time column: prominent primary time in ink with
+    /// tabular digits so times align vertically down the timeline; a quieter
+    /// arrival time beneath it when present; a muted "Anytime" for untimed rows
+    /// so timed rows pop.
+    @ViewBuilder
+    private func timeColumnView(_ parts: TimelineEntry.TimeColumnParts) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if let primary = parts.primary {
+                Text(primary)
+                    .font(.edFootnote)
+                    .monospacedDigit()
+                    .foregroundStyle(Tokens.ink)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+                if let secondary = parts.secondary {
+                    Text(secondary)
+                        .font(.edCaption)
+                        .monospacedDigit()
+                        .foregroundStyle(Tokens.muted)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
+            } else {
+                Text("Anytime")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.muted)
+                    .lineLimit(1)
+            }
+        }
+        .frame(width: TimelineLayout.timeColumnWidth, alignment: .leading)
     }
 
     /// Maps affordance on the card: a labeled "MAP" pill sitting right after


### PR DESCRIPTION
## Summary
Makes time and date more prominent on the itinerary timeline (#249).

- **Time moved to the top of each plain tile**, bold in the itineraries accent colour with monospaced digits (was a small muted 12pt line at the bottom). Untimed items keep a quieter muted "Anytime".
- **Day header is one prominent line**: "Day n" highlighted in the accent colour, followed by the date in ink (e.g. "Day 1: Wed, 14 May"), single size, no line break.
- **Ticket cards**: boarding-pass now shows arrival time under the destination route code (not just departure); event card promotes its Time to a prominent line.
- Reuses the existing UTC-pinned `itineraryTimeFormatter`, so times stay correct across device timezones and respect the 12/24-hour setting.

Added one typography token (`edFootnoteStrong`, Inter 13 semibold) for the tile time.

## Test plan
- [x] Clean static build (`xcodebuild ... build`)
- [x] Device QA on iPhone (installed via devicectl): plain tiles show bold accent time at top; single-line "Day n: date" header with Day n highlighted; boarding-pass shows departure + arrival; untimed items read quietly; times correct and no clipping.

Closes #249