### PR TITLE
feat(ios): give Lists a visual identity (per-list icon and color)

### DIFF
--- a/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
+++ b/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
@@ -97,6 +97,10 @@ struct AssistantContextBuilder {
                 let id = Self.uuidString(list.clientUUID)
                 let items = list.items
                 var line = "- List ID:\(id) \"\(Self.safe(list.title, maxLen: 200))\" (\(items.count) items)"
+                // Current visual identity so edit_list recolor/re-icon requests
+                // ("make the groceries list green") have the existing values.
+                if let icon = list.iconName, !icon.isEmpty { line += " icon:\(icon)" }
+                if let color = list.colorHex, !color.isEmpty { line += " color:\(color)" }
                 if !items.isEmpty {
                     line += "\n  Items:"
                     for (idx, item) in items.enumerated() {

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -512,10 +512,21 @@ struct ExecuteDraftAction {
         }
         let items = parseChecklistItems(input["items"])
 
+        // Resolve icon + color from the tool input, validating against the
+        // curated set. When the model omits or supplies an unknown value, fall
+        // back to the local keyword mapper so the tile is never blank (#253).
+        let inferred = ListAppearance.infer(from: title)
+        let rawIcon = trimmedString(input["icon"])
+        let icon = ListAppearance.isValidSymbol(rawIcon) ? rawIcon! : inferred.icon
+        let colorHex = ListAppearance.matchedPaletteColor(trimmedString(input["color"]))?.id
+            ?? inferred.colorHex
+
         let now = Date()
         let row = LocalList(
             title: title,
             items: items,
+            iconName: icon,
+            colorHex: colorHex,
             createdAt: now,
             updatedAt: now,
             needsSync: false
@@ -808,6 +819,15 @@ struct ExecuteDraftAction {
         if let arr = input["items"]?.arrayValue, !arr.isEmpty {
             row.items = parseChecklistItems(input["items"])
             changed = true
+        }
+        // Icon / color: empty string keeps current; a valid value sets it. An
+        // unknown SF Symbol or color name is ignored (leaves the list as-is)
+        // rather than clearing to a blank tile.
+        if let rawIcon = trimmedString(input["icon"]), ListAppearance.isValidSymbol(rawIcon) {
+            row.iconName = rawIcon; changed = true
+        }
+        if let matched = ListAppearance.matchedPaletteColor(trimmedString(input["color"])) {
+            row.colorHex = matched.id; changed = true
         }
         guard changed else {
             throw DraftExecutionError.invalidArgument(field: "list", reason: "no changes provided")

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -98,15 +98,22 @@ enum ToolDefinitions {
         )
     )
 
+    /// Description of the curated icon + color choices, shared by draft_list and
+    /// edit_list so the model always picks from the same on-brand set.
+    private static let listIconGuidance = "An SF Symbol name giving the list a visual identity. ALWAYS set this — pick the symbol that best fits the list's topic. Good choices: checklist, list.bullet, cart, bag, gift, creditcard, airplane, suitcase, map, car, briefcase, calendar, chart.bar, folder, figure.run, dumbbell, heart, leaf, house, fork.knife, cup.and.saucer, book, graduationcap, lightbulb, gamecontroller, music.note, film, camera, star, flag. Use a valid SF Symbol name; if unsure, use \"checklist\"."
+    private static let listColorGuidance = "A color for the list. ALWAYS set this. Use one of these names (or its hex): Teal (0F766E), Indigo (4338CA), Purple (6D28D9), Red (B91C1C), Amber (B45309), Green (047857), Pink (7C3F58), Slate (475569). Pick a color that fits the topic (e.g. travel -> Indigo, groceries/money -> Green, fitness/health -> Red, work -> Slate)."
+
     private static let draftList = AnthropicTool(
         name: "draft_list",
-        description: "Create a NEW list with items. Use this when the user wants to create a new checklist, shopping list, or any new list of items.",
+        description: "Create a NEW list with items. Use this when the user wants to create a new checklist, shopping list, or any new list of items. ALWAYS set an appropriate icon and color so the list has a clear visual identity (e.g. a \"Japan trip\" list gets airplane + Indigo, a grocery list gets cart + Green).",
         input_schema: object(
             properties: [
                 "title": string("The title of the list"),
-                "items": arrayOf(listItemSchema, description: "Array of list items with text and checked status")
+                "items": arrayOf(listItemSchema, description: "Array of list items with text and checked status"),
+                "icon": string(listIconGuidance),
+                "color": string(listColorGuidance)
             ],
-            required: ["title", "items"]
+            required: ["title", "items", "icon", "color"]
         )
     )
 
@@ -155,12 +162,14 @@ enum ToolDefinitions {
 
     private static let editList = AnthropicTool(
         name: "edit_list",
-        description: "Edit an EXISTING list. Use when user wants to rename a list or replace all its items. Requires the list UUID. IMPORTANT: At least one of title or items must have a non-empty value. If user does not specify what to change, ask for clarification instead of calling this tool.",
+        description: "Edit an EXISTING list. Use when user wants to rename a list, replace all its items, or change its icon / color. Requires the list UUID. IMPORTANT: At least one of title, items, icon, or color must have a non-empty value. If user does not specify what to change, ask for clarification instead of calling this tool.",
         input_schema: object(
             properties: [
                 "id": string("The UUID of the existing list to edit (from EXISTING LISTS context)"),
-                "title": string("New title for the list. Use empty string ONLY to keep current title unchanged (items must have values then)."),
-                "items": arrayOf(listItemSchema, description: "Complete new items array (replaces existing items). Use empty array ONLY to keep unchanged (title must have value then).")
+                "title": string("New title for the list. Use empty string ONLY to keep current title unchanged (another field must have a value then)."),
+                "items": arrayOf(listItemSchema, description: "Complete new items array (replaces existing items). Use empty array to keep unchanged (another field must have a value then)."),
+                "icon": string("New SF Symbol icon for the list. Set when the user wants a different icon. Use empty string to keep unchanged. " + listIconGuidance),
+                "color": string("New color for the list. Set when the user wants to recolor it. Use empty string to keep unchanged. " + listColorGuidance)
             ],
             required: ["id", "title", "items"]
         )

--- a/mobile/PersonalDashboard/Design/ListAppearance.swift
+++ b/mobile/PersonalDashboard/Design/ListAppearance.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+import UIKit
+
+/// Single source of truth for a list's visual identity (#253): the curated SF
+/// Symbol set, the palette, the default fallback, and the local keyword→icon
+/// mapper. Every list's icon + color resolves through here, so a nil / unknown
+/// value always renders as a valid, on-brand tile instead of a blank chip.
+///
+/// Colors are sourced from the existing `Tokens` accent palette — the stored
+/// `colorHex` is the palette KEY (the light-mode hex, uppercased, no prefix),
+/// which resolves back to a light/dark `Color.paper(...)` pair so tiles stay
+/// correct in both themes. Storing a bare hex would lose the dark variant.
+enum ListAppearance {
+
+    // MARK: - Palette
+
+    struct PaletteColor: Identifiable, Hashable {
+        /// Stable key AND the canonical stored `colorHex` (light hex, uppercased).
+        let id: String
+        let name: String
+        let light: UInt32
+        let dark: UInt32
+        var color: Color { Color.paper(light, dark) }
+    }
+
+    /// Eight colors, all lifted from the existing `Tokens` section accents so
+    /// the feature introduces no new hardcoded colors outside this helper.
+    static let palette: [PaletteColor] = [
+        PaletteColor(id: "0F766E", name: "Teal",   light: 0x0F766E, dark: 0x2DD4BF), // accentLists
+        PaletteColor(id: "4338CA", name: "Indigo", light: 0x4338CA, dark: 0x818CF8), // accentTasks
+        PaletteColor(id: "6D28D9", name: "Purple", light: 0x6D28D9, dark: 0xA78BFA), // accentItineraries
+        PaletteColor(id: "B91C1C", name: "Red",    light: 0xB91C1C, dark: 0xF87171), // accentToday
+        PaletteColor(id: "B45309", name: "Amber",  light: 0xB45309, dark: 0xF59E0B), // accentNotes
+        PaletteColor(id: "047857", name: "Green",  light: 0x047857, dark: 0x10B981), // accentFinance
+        PaletteColor(id: "7C3F58", name: "Pink",   light: 0x7C3F58, dark: 0xE5A3BA), // accentActivity
+        PaletteColor(id: "475569", name: "Slate",  light: 0x475569, dark: 0x94A3B8)  // accentSettings
+    ]
+
+    /// Teal — matches the historical `Tokens.accentLists`, so every existing
+    /// (nil-color) list keeps the exact look it has today.
+    static let defaultColorHex = "0F766E"
+    /// `checklist` exists on iOS 16+ so it is safe on the iOS 17 baseline.
+    static let defaultIcon = "checklist"
+
+    static var defaultPaletteColor: PaletteColor {
+        palette.first { $0.id == defaultColorHex } ?? palette[0]
+    }
+
+    /// Strict match: returns the palette entry for a stored hex OR a color name
+    /// (case-insensitive), or nil when nothing matches. Callers that want a
+    /// guaranteed color use `color(forHex:)`; the AI executor uses this to
+    /// distinguish "model gave a valid color" from "fall back to keyword map".
+    static func matchedPaletteColor(_ raw: String?) -> PaletteColor? {
+        guard let raw else { return nil }
+        let norm = normalizeHex(raw)
+        if let byHex = palette.first(where: { $0.id == norm }) { return byHex }
+        let lower = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return palette.first { $0.name.lowercased() == lower }
+    }
+
+    /// Always returns a usable color: the matched palette color or the default.
+    static func color(forHex hex: String?) -> Color {
+        (matchedPaletteColor(hex) ?? defaultPaletteColor).color
+    }
+
+    private static func normalizeHex(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        if s.hasPrefix("#") { s.removeFirst() }
+        if s.hasPrefix("0X") { s.removeFirst(2) }
+        return s
+    }
+
+    // MARK: - Icons
+
+    struct IconGroup: Identifiable {
+        let id: String        // group / theme name
+        let symbols: [String]
+    }
+
+    /// ~38 curated SF Symbols grouped by theme. Every symbol is available on the
+    /// iOS 17 baseline. The properties-sheet grid renders these groups directly.
+    static let iconGroups: [IconGroup] = [
+        IconGroup(id: "General",  symbols: ["checklist", "list.bullet", "star", "flag", "bookmark", "pin"]),
+        IconGroup(id: "Shopping", symbols: ["cart", "bag", "gift", "creditcard"]),
+        IconGroup(id: "Travel",   symbols: ["airplane", "suitcase", "map", "beach.umbrella", "car", "tram"]),
+        IconGroup(id: "Work",     symbols: ["briefcase", "laptopcomputer", "calendar", "chart.bar", "folder"]),
+        IconGroup(id: "Health",   symbols: ["figure.run", "dumbbell", "heart", "leaf", "cross.case"]),
+        IconGroup(id: "Home",     symbols: ["house", "fork.knife", "cup.and.saucer", "wrench.and.screwdriver"]),
+        IconGroup(id: "Learning", symbols: ["book", "graduationcap", "lightbulb", "pencil"]),
+        IconGroup(id: "Fun",      symbols: ["gamecontroller", "music.note", "film", "camera"])
+    ]
+
+    /// Flat list of every curated symbol (used for validation / highlighting).
+    static let allIcons: [String] = iconGroups.flatMap { $0.symbols }
+
+    /// Returns a guaranteed-renderable symbol name: the stored value when it is
+    /// a real SF Symbol, otherwise the default. Guards against an AI-supplied
+    /// symbol name that doesn't exist on the device (blank-tile prevention).
+    static func resolvedIconName(_ stored: String?) -> String {
+        guard let stored, !stored.isEmpty,
+              UIImage(systemName: stored) != nil else { return defaultIcon }
+        return stored
+    }
+
+    /// Whether a symbol name renders on this device.
+    static func isValidSymbol(_ name: String?) -> Bool {
+        guard let name, !name.isEmpty else { return false }
+        return UIImage(systemName: name) != nil
+    }
+
+    // MARK: - Keyword → appearance mapper
+
+    private struct KeywordRule {
+        let keywords: [String]
+        let icon: String
+        let colorHex: String
+    }
+
+    /// Simple lowercased-substring rules, checked top to bottom. No API calls —
+    /// runs instantly on the device when the user creates a list without picking
+    /// an icon, or when the AI omits icon/color on `draft_list`.
+    private static let keywordRules: [KeywordRule] = [
+        .init(keywords: ["grocer", "supermarket", "fairprice", "pantry"], icon: "cart", colorHex: "047857"),
+        .init(keywords: ["shop", "buy", "purchase", "wishlist"], icon: "bag", colorHex: "047857"),
+        .init(keywords: ["gym", "workout", "exercise", "fitness", "run", "training", "lift"], icon: "figure.run", colorHex: "B91C1C"),
+        .init(keywords: ["trip", "travel", "flight", "vacation", "holiday", "itinerary"], icon: "airplane", colorHex: "4338CA"),
+        .init(keywords: ["pack", "packing", "luggage"], icon: "suitcase", colorHex: "4338CA"),
+        .init(keywords: ["read", "book", "reading", "novel"], icon: "book", colorHex: "B45309"),
+        .init(keywords: ["study", "learn", "course", "school", "class", "exam"], icon: "graduationcap", colorHex: "B45309"),
+        .init(keywords: ["work", "project", "office", "meeting", "deadline", "sprint"], icon: "briefcase", colorHex: "475569"),
+        .init(keywords: ["money", "budget", "finance", "bill", "expense", "savings"], icon: "creditcard", colorHex: "047857"),
+        .init(keywords: ["food", "recipe", "cook", "dinner", "meal", "restaurant", "menu"], icon: "fork.knife", colorHex: "B45309"),
+        .init(keywords: ["home", "house", "chore", "clean", "move", "moving", "apartment"], icon: "house", colorHex: "6D28D9"),
+        .init(keywords: ["gift", "present", "birthday", "christmas", "holiday gift"], icon: "gift", colorHex: "7C3F58"),
+        .init(keywords: ["health", "doctor", "medicine", "wellness", "medical"], icon: "heart", colorHex: "B91C1C"),
+        .init(keywords: ["music", "playlist", "song", "album"], icon: "music.note", colorHex: "6D28D9"),
+        .init(keywords: ["movie", "film", "watch", "show", "series"], icon: "film", colorHex: "4338CA"),
+        .init(keywords: ["game", "gaming", "play"], icon: "gamecontroller", colorHex: "6D28D9"),
+        .init(keywords: ["idea", "goal", "plan", "brainstorm"], icon: "lightbulb", colorHex: "B45309"),
+        .init(keywords: ["garden", "plant", "grow"], icon: "leaf", colorHex: "047857")
+    ]
+
+    /// Infer an icon + palette color from a list title. Falls back to the
+    /// default checklist + teal when no keyword matches.
+    static func infer(from title: String) -> (icon: String, colorHex: String) {
+        let t = title.lowercased()
+        for rule in keywordRules where rule.keywords.contains(where: { t.contains($0) }) {
+            return (rule.icon, rule.colorHex)
+        }
+        return (defaultIcon, defaultColorHex)
+    }
+}
+
+// MARK: - Checklist convenience accessors
+
+extension Checklist {
+    /// The guaranteed-renderable SF Symbol for this list.
+    var resolvedIcon: String { ListAppearance.resolvedIconName(iconName) }
+    /// The theme-adaptive color for this list (palette match or default teal).
+    var resolvedColor: Color { ListAppearance.color(forHex: colorHex) }
+}
+
+// MARK: - Reusable icon chip
+
+/// The rounded colored square that carries a list's icon. Solid fill + white
+/// glyph for maximum at-a-glance differentiation against the paper surface,
+/// matching Apple Reminders' density. Shared by the Lists tile and Today row.
+struct ListIconChip: View {
+    let icon: String
+    let color: Color
+    var size: CGFloat = 40
+    var corner: CGFloat = 10
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: corner, style: .continuous)
+            .fill(color)
+            .frame(width: size, height: size)
+            .overlay(
+                Image(systemName: icon)
+                    .font(.system(size: size * 0.44, weight: .semibold))
+                    .foregroundStyle(.white)
+            )
+            .accessibilityHidden(true)
+    }
+}

--- a/mobile/PersonalDashboard/Models/Checklist.swift
+++ b/mobile/PersonalDashboard/Models/Checklist.swift
@@ -73,6 +73,11 @@ struct Checklist: Codable, Identifiable, Hashable, Sendable {
     var title: String
     var items: [ChecklistItem]
     var position: Int?
+    /// Per-list visual identity (#253). `iconName` is an SF Symbol name,
+    /// `colorHex` a palette key. Both optional; nil falls back to the default
+    /// checklist symbol + teal via `ListAppearance`.
+    var iconName: String?
+    var colorHex: String?
     let version: Int64
     let createdAt: Date
     let updatedAt: Date
@@ -83,6 +88,8 @@ struct Checklist: Codable, Identifiable, Hashable, Sendable {
         case title
         case items
         case position
+        case iconName
+        case colorHex
         case version
         case createdAt
         case updatedAt
@@ -93,9 +100,13 @@ struct Checklist: Codable, Identifiable, Hashable, Sendable {
 struct ChecklistCreateRequest {
     let title: String
     let items: [ChecklistItem]
+    var iconName: String? = nil
+    var colorHex: String? = nil
 }
 
 struct ChecklistUpdateRequest {
     let title: String
     let items: [ChecklistItem]
+    var iconName: String? = nil
+    var colorHex: String? = nil
 }

--- a/mobile/PersonalDashboard/Models/Local/LocalList.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalList.swift
@@ -10,6 +10,14 @@ final class LocalList {
     /// `[ChecklistItem]` array is reconstructed on demand via toDTO().
     var itemsData: Data
     var position: Int?
+    /// Per-list visual identity (#253). Both OPTIONAL with no non-nil default so
+    /// the SwiftData lightweight migration on existing installs can't fail —
+    /// adding nullable fields is the safe path (project rule: only ADD fields).
+    /// `iconName` is an SF Symbol name, `colorHex` a palette key (the light-mode
+    /// hex). Nil on every pre-existing list → the row renders with the default
+    /// checklist symbol + teal via `ListAppearance` at read time.
+    var iconName: String?
+    var colorHex: String?
     var version: Int64
     var createdAt: Date
     var updatedAt: Date
@@ -21,6 +29,8 @@ final class LocalList {
         title: String,
         items: [ChecklistItem] = [],
         position: Int? = nil,
+        iconName: String? = nil,
+        colorHex: String? = nil,
         version: Int64 = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
@@ -31,6 +41,8 @@ final class LocalList {
         self.title = title
         self.itemsData = LocalList.encode(items)
         self.position = position
+        self.iconName = iconName
+        self.colorHex = colorHex
         self.version = version
         self.createdAt = createdAt
         self.updatedAt = updatedAt
@@ -52,6 +64,8 @@ final class LocalList {
             title: title,
             items: items,
             position: position,
+            iconName: iconName,
+            colorHex: colorHex,
             version: version,
             createdAt: createdAt,
             updatedAt: updatedAt,

--- a/mobile/PersonalDashboard/Services/ChecklistService.swift
+++ b/mobile/PersonalDashboard/Services/ChecklistService.swift
@@ -25,6 +25,8 @@ struct ChecklistService {
         let row = LocalList(
             title: request.title,
             items: request.items,
+            iconName: request.iconName,
+            colorHex: request.colorHex,
             createdAt: now,
             updatedAt: now
         )
@@ -37,6 +39,8 @@ struct ChecklistService {
         let row = try fetchLocal(uuid: list.id)
         row.title = request.title
         row.items = request.items
+        row.iconName = request.iconName
+        row.colorHex = request.colorHex
         row.updatedAt = Date()
         try store.context.save()
         return row.toDTO()

--- a/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
@@ -34,9 +34,23 @@ final class ListsViewModel {
         isLoading = false
     }
 
-    func create(title: String, items: [ChecklistItem] = []) async {
+    func create(
+        title: String,
+        items: [ChecklistItem] = [],
+        iconName: String? = nil,
+        colorHex: String? = nil
+    ) async {
         do {
-            let request = ChecklistCreateRequest(title: title, items: items)
+            // When the caller doesn't specify an appearance, derive one from the
+            // title via the local keyword mapper (no API call) so every new list
+            // gets an identity immediately (#253).
+            let inferred = ListAppearance.infer(from: title)
+            let request = ChecklistCreateRequest(
+                title: title,
+                items: items,
+                iconName: iconName ?? inferred.icon,
+                colorHex: colorHex ?? inferred.colorHex
+            )
             let new = try await service.create(request)
             lists.insert(new, at: 0)
         } catch {
@@ -46,7 +60,14 @@ final class ListsViewModel {
 
     func update(_ list: Checklist) async {
         do {
-            let request = ChecklistUpdateRequest(title: list.title, items: list.items)
+            // Carry the appearance fields through so item toggles / renames don't
+            // wipe the list's icon + color (the request is a full row overwrite).
+            let request = ChecklistUpdateRequest(
+                title: list.title,
+                items: list.items,
+                iconName: list.iconName,
+                colorHex: list.colorHex
+            )
             let updated = try await service.update(list, request)
             if let index = lists.firstIndex(where: { $0.id == list.id }) {
                 lists[index] = updated
@@ -63,6 +84,26 @@ final class ListsViewModel {
               lists[listIndex].title != trimmed else { return }
         var snapshot = lists[listIndex]
         snapshot.title = trimmed
+        lists[listIndex] = snapshot
+        await update(snapshot)
+    }
+
+    /// Apply a new icon/color (and optionally a new title) from the properties
+    /// sheet. Mutates the in-memory DTO first so the tile + Today row update
+    /// immediately, then persists the whole row.
+    func updateAppearance(
+        _ list: Checklist,
+        iconName: String?,
+        colorHex: String?,
+        title: String? = nil
+    ) async {
+        guard let listIndex = lists.firstIndex(where: { $0.id == list.id }) else { return }
+        var snapshot = lists[listIndex]
+        if let title = title?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
+            snapshot.title = title
+        }
+        snapshot.iconName = iconName
+        snapshot.colorHex = colorHex
         lists[listIndex] = snapshot
         await update(snapshot)
     }

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -4,6 +4,7 @@ import Combine
 struct ListsView: View {
     @State private var viewModel = ListsViewModel()
     @State private var showingNewList = false
+    @State private var showingProperties = false
     @State private var selectedListId: UUID? = {
         if let raw = ProcessInfo.processInfo.environment["LAUNCH_LIST_ID"], let id = UUID(uuidString: raw) { return id }
         return nil
@@ -30,9 +31,13 @@ struct ListsView: View {
                                 await viewModel.delete(list)
                                 selectedListId = nil
                             }
-                        }
+                        },
+                        onProperties: { showingProperties = true }
                     )
                     ListDetailContent(viewModel: viewModel, listId: id)
+                        .sheet(isPresented: $showingProperties) {
+                            ListPropertiesSheet(viewModel: viewModel, list: list)
+                        }
                 } else {
                     TopBar(
                         title: "Lists",
@@ -159,6 +164,9 @@ private struct ListDetailHeader: View {
     let onBack: () -> Void
     let onRename: (String) -> Void
     let onDelete: () -> Void
+    /// Opens the list properties sheet (name + icon + color). Tap-to-rename on
+    /// the title stays as-is; this is the entry point for icon/color editing.
+    let onProperties: () -> Void
 
     @State private var isEditing = false
     @State private var draft = ""
@@ -203,6 +211,12 @@ private struct ListDetailHeader: View {
                     .accessibilityLabel("List title, tap to rename")
             }
             Spacer()
+            Button(action: onProperties) {
+                Image(systemName: "slider.horizontal.3")
+                    .frame(width: 44, height: 44)
+                    .foregroundStyle(Tokens.muted)
+            }
+            .accessibilityLabel("List appearance")
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .frame(width: 44, height: 44)
@@ -234,36 +248,42 @@ private struct ListSummaryRow: View {
     var body: some View {
         let total = list.items.count
         let completed = list.items.filter(\.checked).count
-        VStack(alignment: .leading, spacing: Space.sm) {
-            HStack {
-                Text(list.title)
-                    .font(.edBodyMedium)
-                    .foregroundStyle(Tokens.ink)
-                Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .regular))
-                    .foregroundStyle(Tokens.mutedSoft)
-            }
-            if total > 0 {
-                HStack(spacing: Space.xs) {
-                    GeometryReader { geo in
-                        ZStack(alignment: .leading) {
-                            Capsule().fill(Tokens.paper2).frame(height: 4)
-                            Capsule()
-                                .fill(Tokens.accentLists)
-                                .frame(width: geo.size.width * (Double(completed) / Double(max(total, 1))), height: 4)
+        let accent = list.resolvedColor
+        HStack(spacing: Space.md) {
+            // Per-list identity chip: colored square + SF Symbol in the left slot.
+            ListIconChip(icon: list.resolvedIcon, color: accent, size: 40)
+
+            VStack(alignment: .leading, spacing: Space.sm) {
+                HStack {
+                    Text(list.title)
+                        .font(.edBodyMedium)
+                        .foregroundStyle(Tokens.ink)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .regular))
+                        .foregroundStyle(Tokens.mutedSoft)
+                }
+                if total > 0 {
+                    HStack(spacing: Space.xs) {
+                        GeometryReader { geo in
+                            ZStack(alignment: .leading) {
+                                Capsule().fill(Tokens.paper2).frame(height: 4)
+                                Capsule()
+                                    .fill(accent)
+                                    .frame(width: geo.size.width * (Double(completed) / Double(max(total, 1))), height: 4)
+                            }
                         }
+                        .frame(height: 4)
+                        Text("\(completed)/\(total)")
+                            .font(.edCaption)
+                            .foregroundStyle(Tokens.muted)
+                            .monospacedDigit()
                     }
-                    .frame(height: 4)
-                    Text("\(completed)/\(total)")
+                } else {
+                    Text("Empty")
                         .font(.edCaption)
                         .foregroundStyle(Tokens.muted)
-                        .monospacedDigit()
                 }
-            } else {
-                Text("Empty")
-                    .font(.edCaption)
-                    .foregroundStyle(Tokens.muted)
             }
         }
         .padding(.horizontal, Space.md)
@@ -916,22 +936,42 @@ private struct NewListSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var title: String = ""
 
+    /// Live inferred appearance from the title so the user sees the identity the
+    /// keyword mapper will assign. If they never open the picker, this is what
+    /// gets saved (create() defaults to the same inference).
+    private var inferred: (icon: String, colorHex: String) {
+        ListAppearance.infer(from: title.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
                 Tokens.paper.ignoresSafeArea()
                 VStack(alignment: .leading, spacing: Space.lg) {
-                    Text("Title").eyebrow()
-                    TextField("List title", text: $title)
-                        .font(.edBody)
-                        .foregroundStyle(Tokens.ink)
-                        .padding(Space.md)
-                        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
-                        .paperBorder(Tokens.border, radius: Radius.md)
+                    HStack(spacing: Space.md) {
+                        ListIconChip(
+                            icon: ListAppearance.resolvedIconName(inferred.icon),
+                            color: ListAppearance.color(forHex: inferred.colorHex),
+                            size: 44
+                        )
+                        VStack(alignment: .leading, spacing: Space.fieldLabelGap) {
+                            Text("Title").eyebrow()
+                            TextField("List title", text: $title)
+                                .font(.edBody)
+                                .foregroundStyle(Tokens.ink)
+                                .padding(Space.md)
+                                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                                .paperBorder(Tokens.border, radius: Radius.md)
+                        }
+                    }
+                    Text("An icon and color are picked automatically from the title. You can change them later from the list.")
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.muted)
                     Spacer()
                 }
                 .padding(Space.lg)
             }
+            .animation(.easeOut(duration: 0.2), value: inferred.colorHex)
             .navigationTitle("New list")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -950,5 +990,153 @@ private struct NewListSheet: View {
                 }
             }
         }
+    }
+}
+
+/// Edit a list's name, icon, and color. Reached from the header's appearance
+/// button. Applying routes through `updateAppearance`, so the tile + Today row
+/// reflect the change immediately.
+private struct ListPropertiesSheet: View {
+    let viewModel: ListsViewModel
+    let list: Checklist
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String = ""
+    @State private var selectedIcon: String = ListAppearance.defaultIcon
+    @State private var selectedColorHex: String = ListAppearance.defaultColorHex
+
+    private let iconColumns = Array(repeating: GridItem(.flexible(), spacing: Space.sm), count: 6)
+
+    private var accent: Color { ListAppearance.color(forHex: selectedColorHex) }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Space.lg) {
+                        // Live preview + name field.
+                        HStack(spacing: Space.md) {
+                            ListIconChip(icon: selectedIcon, color: accent, size: 48)
+                            VStack(alignment: .leading, spacing: Space.fieldLabelGap) {
+                                Text("Name").eyebrow()
+                                TextField("List name", text: $name)
+                                    .font(.edBody)
+                                    .foregroundStyle(Tokens.ink)
+                                    .padding(Space.md)
+                                    .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                                    .paperBorder(Tokens.border, radius: Radius.md)
+                            }
+                        }
+
+                        // Color swatches.
+                        VStack(alignment: .leading, spacing: Space.fieldLabelGap) {
+                            Text("Color").eyebrow()
+                            HStack(spacing: Space.sm) {
+                                ForEach(ListAppearance.palette) { swatch in
+                                    let isSelected = swatch.id == selectedColorHex
+                                    Circle()
+                                        .fill(swatch.color)
+                                        .frame(width: 34, height: 34)
+                                        .overlay(
+                                            Circle()
+                                                .stroke(Tokens.ink, lineWidth: isSelected ? 2 : 0)
+                                                .padding(-3)
+                                        )
+                                        .overlay {
+                                            if isSelected {
+                                                Image(systemName: "checkmark")
+                                                    .font(.system(size: 13, weight: .bold))
+                                                    .foregroundStyle(.white)
+                                            }
+                                        }
+                                        .contentShape(Circle())
+                                        .onTapGesture {
+                                            Haptics.tick()
+                                            withAnimation(.easeOut(duration: 0.15)) { selectedColorHex = swatch.id }
+                                        }
+                                        .accessibilityLabel(swatch.name)
+                                        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+                                }
+                                Spacer(minLength: 0)
+                            }
+                        }
+
+                        // Icon grid, grouped by theme.
+                        VStack(alignment: .leading, spacing: Space.md) {
+                            Text("Icon").eyebrow()
+                            ForEach(ListAppearance.iconGroups) { group in
+                                VStack(alignment: .leading, spacing: Space.sm) {
+                                    Text(group.id)
+                                        .font(.edCaption)
+                                        .foregroundStyle(Tokens.muted)
+                                    LazyVGrid(columns: iconColumns, spacing: Space.sm) {
+                                        ForEach(group.symbols, id: \.self) { symbol in
+                                            iconCell(symbol)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(Space.lg)
+                }
+                .scrollDismissesKeyboard(.interactively)
+            }
+            .navigationTitle("List appearance")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }.foregroundStyle(Tokens.muted)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+                        Task {
+                            await viewModel.updateAppearance(
+                                list,
+                                iconName: selectedIcon,
+                                colorHex: selectedColorHex,
+                                title: trimmed.isEmpty ? nil : trimmed
+                            )
+                        }
+                        dismiss()
+                    }
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .foregroundStyle(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? Tokens.muted : Tokens.ink)
+                }
+            }
+            .onAppear {
+                name = list.title
+                selectedIcon = list.resolvedIcon
+                // Resolve to a palette key so the matching swatch highlights even
+                // when the stored value is a name or unknown hex.
+                selectedColorHex = ListAppearance.matchedPaletteColor(list.colorHex)?.id
+                    ?? ListAppearance.defaultColorHex
+            }
+        }
+    }
+
+    private func iconCell(_ symbol: String) -> some View {
+        let isSelected = symbol == selectedIcon
+        return RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+            .fill(isSelected ? accent.opacity(0.16) : Tokens.surface)
+            .frame(height: 46)
+            .overlay(
+                Image(systemName: symbol)
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(isSelected ? accent : Tokens.inkSoft)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                    .stroke(isSelected ? accent : Tokens.border, lineWidth: isSelected ? 2 : 1)
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                Haptics.tick()
+                withAnimation(.easeOut(duration: 0.12)) { selectedIcon = symbol }
+            }
+            .accessibilityLabel(symbol)
+            .accessibilityAddTraits(isSelected ? [.isSelected] : [])
     }
 }

--- a/mobile/PersonalDashboard/Views/Today/TodayView.swift
+++ b/mobile/PersonalDashboard/Views/Today/TodayView.swift
@@ -372,7 +372,10 @@ private struct TodayListRow: View {
         let total = list.items.count
         let done = list.items.filter(\.checked).count
 
+        let accent = list.resolvedColor
         HStack(spacing: Space.md) {
+            ListIconChip(icon: list.resolvedIcon, color: accent, size: 30, corner: 8)
+
             VStack(alignment: .leading, spacing: 2) {
                 Text(list.title)
                     .font(.edBodyMedium)
@@ -385,7 +388,7 @@ private struct TodayListRow: View {
 
             Spacer()
 
-            ProgressBar(done: done, total: total)
+            ProgressBar(done: done, total: total, color: accent)
                 .frame(width: 80, height: 4)
         }
         .padding(.horizontal, Space.lg)
@@ -396,6 +399,7 @@ private struct TodayListRow: View {
 private struct ProgressBar: View {
     let done: Int
     let total: Int
+    var color: Color = Tokens.accentLists
 
     var body: some View {
         GeometryReader { geo in
@@ -403,7 +407,7 @@ private struct ProgressBar: View {
                 Capsule(style: .continuous)
                     .fill(Tokens.paper2)
                 Capsule(style: .continuous)
-                    .fill(Tokens.accentLists)
+                    .fill(color)
                     .frame(width: geo.size.width * progress)
             }
         }


### PR DESCRIPTION
## Summary

- Each list now carries an SF Symbol icon and a palette color, shown as a colored chip on the list tile, in its progress bar, and on the Today row.
- `LocalList` gains optional `iconName` / `colorHex` (additive SwiftData migration; existing lists fall back to the default checklist icon + teal, so nothing is lost on upgrade).
- New `ListAppearance` helper: curated set of ~38 grouped SF Symbols, an 8-color palette drawn from existing tokens, a keyword-to-icon mapper, validators, and a reusable `ListIconChip`.
- AI: `draft_list` now requires `icon`/`color`; `edit_list` accepts them. `ExecuteDraftAction` validates both and falls back gracefully on unknown values so a tile is never blank.
- Manual create infers appearance from the title; a properties sheet (opened from the list header) edits name, icon, and color, with the tile updating immediately.

Closes #253

## Test plan

- [x] Static build clean (`xcodebuild`, Debug, `CODE_SIGNING_ALLOWED=NO`)
- [x] Shipped to device (iPhone 16 Pro Max) and QA'd on-device by the author
- [x] Existing lists open with items intact after the migration (default icon + teal)
- [x] Tiles show the colored icon chip; progress bar and Today row take the list color
- [x] AI-created lists get a sensible icon/color; manual create infers from title
- [x] Properties sheet edits name/icon/color and the tile reflects it live
