### PR TITLE
feat(ios): show average monthly expense on finance dashboard card

### DIFF
--- a/mobile/PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
@@ -8,6 +8,9 @@ struct FinanceDashboardStats {
     let previousMonthTotal: Double
     let topCategories: [(category: ExpenseCategory, total: Double)]
     let dailyTotals: [(date: Date, total: Double)]
+    /// Period total normalised to a 30.44-day month (#255), so "This year"
+    /// or a custom range both read as a comparable monthly run-rate.
+    let averagePerMonth: Double
 
     var deltaPercent: Double? {
         guard previousMonthTotal > 0 else { return nil }
@@ -41,6 +44,11 @@ struct FinanceDashboardBand: View {
                 .font(.edDisplay)
                 .foregroundStyle(Tokens.ink)
                 .tracking(-0.6)
+
+            Text("\(Self.formatMoneyRounded(stats.averagePerMonth)) / month")
+                .font(.edFootnote)
+                .foregroundStyle(Tokens.muted)
+                .monospacedDigit()
 
             if !stats.topCategories.isEmpty {
                 categoryBars
@@ -234,6 +242,38 @@ struct FinanceDashboardBand: View {
         // matches the SGD styling (e.g. "USD 927.31", "EUR 812.40").
         formatter.currencySymbol = "\(code) "
         return formatter.string(from: NSNumber(value: displayValue)) ?? "\(code) 0.00"
+    }
+
+    /// Same conversion as `formatMoney` but with 0 fraction digits (e.g.
+    /// "SGD 5,293"), used for the secondary "average / month" line (#255)
+    /// where cents are noise.
+    static func formatMoneyRounded(_ sgdValue: Double) -> String {
+        let code = FinanceSettings.displayCurrencyCode.uppercased()
+        let factor = FinanceSettings.displayRateToSGD
+
+        guard code != "SGD", factor.isFinite, factor > 0 else {
+            return formatSGDRounded(sgdValue)
+        }
+
+        let displayValue = sgdValue / factor
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = code
+        formatter.maximumFractionDigits = 0
+        formatter.minimumFractionDigits = 0
+        formatter.currencySymbol = "\(code) "
+        return formatter.string(from: NSNumber(value: displayValue)) ?? "\(code) 0"
+    }
+
+    /// SGD-only, 0-fraction-digit variant of `formatSGD`.
+    private static func formatSGDRounded(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "SGD"
+        formatter.maximumFractionDigits = 0
+        formatter.minimumFractionDigits = 0
+        formatter.currencySymbol = "SGD "
+        return formatter.string(from: NSNumber(value: value)) ?? "SGD 0"
     }
 
     /// SGD-only formatter (the base-currency fast path used by `formatMoney`).

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -808,6 +808,15 @@ struct FinanceView: View {
         // the delta comparison, the category bars, and the sparkline.
         let rangeTotal = rangeRows.reduce(0) { $0 + $1.signedSGD }
 
+        // Average monthly spend: normalise the period total to a 30.44-day month,
+        // using elapsed time (range start -> earlier of range end and now) so
+        // ongoing periods like "This year" divide by months so far, not a full 12.
+        let now = Date()
+        let effectiveEnd = min(range.upperBound, now)
+        let elapsedDays = max(1.0, effectiveEnd.timeIntervalSince(range.lowerBound) / 86_400.0)
+        let monthsElapsed = max(1.0, elapsedDays / 30.437)   // avg Gregorian month length
+        let averagePerMonth = rangeTotal / monthsElapsed
+
         // Preceding comparison window. Calendar-month presets compare against
         // the previous CALENDAR month (so month-length differences don't skew
         // the delta and "This month" keeps its exact prior behaviour); rolling
@@ -866,7 +875,8 @@ struct FinanceView: View {
             monthTotal: rangeTotal,
             previousMonthTotal: prevTotal,
             topCategories: topCategories,
-            dailyTotals: dailyTotals
+            dailyTotals: dailyTotals,
+            averagePerMonth: averagePerMonth
         )
     }
 


### PR DESCRIPTION
## Summary
- Adds an average-monthly-expense label to the finance dashboard card, under the big total, reading like `SGD 5,293 / month` in the configured display currency.
- The average is the selected period's refund-netted total normalised to a 30.44-day month, using elapsed time (range start to the earlier of range end and today, floored at one month), so ongoing periods like "This year" divide by months so far rather than a flat 12.
- Recomputes live when the period chip or custom range changes. Single-month periods read equal to the total by design.

## Test plan
- [x] Clean `xcodebuild` (Release, generic iOS device): BUILD SUCCEEDED.
- [x] Installed to device (iPhone 16 Pro Max) via devicectl.
- [ ] Device QA per acceptance criteria on #255 (period switches, custom range, refund netting).

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)