### PR TITLE
chore(ota): silence codesign keychain password prompt on ship

### DIFF
--- a/mobile/ota/setup-signing-noprompt.sh
+++ b/mobile/ota/setup-signing-noprompt.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# One-time setup: silence the macOS keychain password prompt that appears while
+# shipping the iOS build (bash mobile/ota/ship-lan.sh).
+#
+# Why the prompt happens:
+#   xcodebuild's `codesign` step needs the "Apple Development" private key in the
+#   login keychain. If codesign isn't on that key's always-allow list, macOS
+#   prompts for the keychain (login) password on every archive. The free
+#   personal-team cert regenerates ~weekly, and each new key arrives with a fresh
+#   ACL — so a one-time manual "Always Allow" keeps coming back.
+#
+# The fix (see ship-lan.sh):
+#   Re-run `security set-key-partition-list` on every ship to authorize codesign
+#   for all current signing keys. That command needs the login password once.
+#   This script stores it in the keychain so ship-lan.sh can read it silently
+#   (only /usr/bin/security is granted access to the item), no plaintext on disk.
+#
+# Run this ONCE (re-run any time to update the stored password):
+#   bash mobile/ota/setup-signing-noprompt.sh
+
+set -euo pipefail
+
+ACCOUNT="${USER}"
+SERVICE="dexter-signing-login-pw"
+LOGIN_KC="${HOME}/Library/Keychains/login.keychain-db"
+
+echo "This stores your macOS *login* password in the login keychain as an item"
+echo "named '${SERVICE}', readable only by /usr/bin/security. ship-lan.sh uses it"
+echo "to authorize codesign silently so you stop getting the password prompt."
+echo ""
+
+# -w with no value prompts interactively (hidden) for the password to store, so
+# it never appears in argv / process list / this file. -U updates if it exists.
+# -T grants /usr/bin/security access to the item's ACL.
+security add-generic-password \
+    -U \
+    -a "${ACCOUNT}" \
+    -s "${SERVICE}" \
+    -T /usr/bin/security \
+    -w
+
+echo ""
+echo "-> stored. verifying silent read..."
+STORED_PW="$(security find-generic-password -a "${ACCOUNT}" -s "${SERVICE}" -w 2>/dev/null || true)"
+if [ -z "${STORED_PW}" ]; then
+    echo "!! could not read the item back. If macOS showed a prompt, click 'Always Allow'."
+    exit 1
+fi
+
+echo "-> verifying it unlocks codesign (set-key-partition-list)..."
+if security set-key-partition-list \
+        -S apple-tool:,apple:,codesign: \
+        -s -k "${STORED_PW}" \
+        "${LOGIN_KC}" >/dev/null 2>&1; then
+    echo "-> OK. codesign is authorized. Future ships should not prompt."
+else
+    echo "!! set-key-partition-list failed — the stored password may be wrong."
+    echo "   Re-run this script and re-enter your login password."
+    exit 1
+fi
+unset STORED_PW

--- a/mobile/ota/ship-lan.sh
+++ b/mobile/ota/ship-lan.sh
@@ -153,6 +153,28 @@ SHORT_VERSION="${MAJOR_MINOR}.${PATCH}"
 BUNDLE_VERSION="${BUILD_NUMBER}"
 echo "-> versioning: v${SHORT_VERSION} (${BUNDLE_VERSION})"
 
+# ---- Pre-authorize codesign (silence the keychain password prompt) ----
+# The free personal-team signing cert regenerates ~weekly; each new private key
+# lands in the login keychain with a fresh ACL, so codesign prompts for the
+# keychain (login) password on the next archive. Re-applying the partition list
+# on every ship authorizes codesign for ALL current signing keys, silently.
+#
+# The login password is read here only by /usr/bin/security, from the keychain
+# item created by `bash mobile/ota/setup-signing-noprompt.sh`. If that setup
+# hasn't been run, we skip quietly — the old GUI prompt just appears as before.
+LOGIN_KC="${HOME}/Library/Keychains/login.keychain-db"
+SIGNING_PW="$(security find-generic-password -a "${USER}" -s dexter-signing-login-pw -w 2>/dev/null || true)"
+if [ -n "${SIGNING_PW}" ]; then
+    if security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${SIGNING_PW}" "${LOGIN_KC}" >/dev/null 2>&1; then
+        echo "-> codesign authorized via keychain (no password prompt expected)"
+    else
+        echo "-> WARNING: could not pre-authorize codesign; a keychain prompt may appear"
+    fi
+    unset SIGNING_PW
+else
+    echo "-> tip: run 'bash mobile/ota/setup-signing-noprompt.sh' once to stop the keychain password prompt"
+fi
+
 # ---- Archive (Release, dev signing) ----
 ARCHIVE_PATH="${OTA_DIR}/PersonalDashboard.xcarchive"
 echo "-> archiving (1-2 min)"


### PR DESCRIPTION
## Summary
- `ship-lan.sh` now re-authorizes codesign for all current signing keys on every ship via `security set-key-partition-list`, so the macOS keychain password prompt no longer interrupts shipping to the phone.
- The login password is read only by `/usr/bin/security` from a keychain item created once by the new `setup-signing-noprompt.sh` helper: no plaintext on disk, no secret in the repo.
- Because it runs on every ship, the fix survives the ~weekly free personal-team cert regeneration (which otherwise reintroduces the prompt with each new key). If the one-time setup was never run, the step no-ops and prints a hint.

## Test plan
- [x] `bash -n` syntax check on both scripts.
- [x] Verified in practice: a full archive + sign + install ran unattended in the background with no password prompt blocking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)