### PR TITLE
feat(ios): trip expenses with participants, shares and settle-up

### DIFF
--- a/mobile/PersonalDashboard/Models/Local/ExpenseSplit.swift
+++ b/mobile/PersonalDashboard/Models/Local/ExpenseSplit.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// One participant's slice of a group-split expense (trip expenses, #258).
+///
+/// Stored as JSON inside `LocalExpense.splitsData`. A `nil` / absent
+/// `personUUID` represents the user ("me"), so the user can be one of the
+/// people a bill is split among. `shares` is a weight, not a fraction: a
+/// person's cost is `amount * (their shares / total shares)`. Equal split is
+/// simply everyone at 1 share.
+///
+/// Person ids are stored as lowercase UUID strings (matching the string
+/// convention `LocalExpense.clientUUID` uses) so the payload is stable and
+/// round-trips cleanly through `JSONEncoder`.
+struct ExpenseSplitEntry: Codable, Equatable, Hashable {
+    /// The person this slice belongs to, as a lowercase UUID string. `nil`
+    /// means the user ("me").
+    let personUUID: String?
+
+    /// Relative weight for this person. Defaults to 1 (equal split).
+    let shares: Int
+
+    init(personUUID: String?, shares: Int) {
+        self.personUUID = personUUID
+        self.shares = max(shares, 0)
+    }
+
+    /// Convenience initialiser from a typed `UUID?` (nil = me). Normalises to
+    /// the lowercase-string storage form.
+    init(person: UUID?, shares: Int) {
+        self.init(personUUID: person?.uuidString.lowercased(), shares: shares)
+    }
+
+    /// The typed person id, or `nil` for the user ("me").
+    var personID: UUID? {
+        guard let personUUID else { return nil }
+        return UUID(uuidString: personUUID)
+    }
+}

--- a/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
@@ -162,6 +162,26 @@ final class LocalExpense {
     // pre-fix data is never re-duplicated on a future re-import.
     var dedupeDescriptor: String = ""
 
+    // MARK: - Trip split / settle-up (#258)
+    //
+    // Full settle-up for trip expenses. Distinct from the #188 `numberOfShares`
+    // model (which stores the user's per-share amount and leaves `sgdAmount`
+    // already divided): when a trip split is set, `originalAmount` / `sgdAmount`
+    // hold the FULL bill and the per-person breakdown lives in `splitsData`, so
+    // the settle-up math can net who paid against who owes. `myShareSGD` below
+    // reconciles the two conventions for personal totals.
+    //
+    // - `paidByPersonUUID`: who fronted the money. nil = the user ("me") paid.
+    // - `splitsData`: JSON-encoded `[ExpenseSplitEntry]` (personUUID + shares).
+    //   A nil personUUID entry is the user's own slice. nil / empty = an
+    //   UNSPLIT expense (today's behaviour) — counts fully in personal totals.
+    //
+    // Both additive with nil defaults so the SwiftData lightweight migration on
+    // existing installs stays safe (add-with-default, never remove) and every
+    // existing call site / row is unaffected (no payer, no splits).
+    var paidByPersonUUID: UUID? = nil
+    var splitsData: Data? = nil
+
     // MARK: - Dead-field parity with other LocalModels
     //
     // These are intentionally unused on Phase A. Kept so that the SwiftData
@@ -196,6 +216,8 @@ final class LocalExpense {
         numberOfShares: Int = 1,
         isRefund: Bool = false,
         dedupeDescriptor: String = "",
+        paidByPersonUUID: UUID? = nil,
+        splitsData: Data? = nil,
         needsSync: Bool = false,
         version: Int = 0
     ) {
@@ -224,6 +246,8 @@ final class LocalExpense {
         self.numberOfShares = numberOfShares
         self.isRefund = isRefund
         self.dedupeDescriptor = dedupeDescriptor
+        self.paidByPersonUUID = paidByPersonUUID
+        self.splitsData = splitsData
         self.needsSync = needsSync
         self.version = version
     }
@@ -268,5 +292,45 @@ final class LocalExpense {
     /// the home-currency figures elsewhere on the row.
     var receiptTotalSGD: Double {
         sgdAmount * Double(max(numberOfShares, 1))
+    }
+
+    // MARK: - Trip split helpers (#258)
+
+    /// Decoded per-person split entries. Empty when the expense is unsplit
+    /// (`splitsData` nil / empty). Read/write: setting an empty array clears
+    /// `splitsData` back to nil so an unsplit expense stores nothing.
+    var splits: [ExpenseSplitEntry] {
+        get {
+            guard let splitsData, !splitsData.isEmpty else { return [] }
+            return (try? JSONDecoder().decode([ExpenseSplitEntry].self, from: splitsData)) ?? []
+        }
+        set {
+            splitsData = newValue.isEmpty ? nil : (try? JSONEncoder().encode(newValue))
+        }
+    }
+
+    /// Whether this expense is split across people via the full settle-up model
+    /// (#258). Distinct from the #188 `isSplit` (equal N-way per-share model).
+    var isGroupSplit: Bool {
+        !splits.isEmpty
+    }
+
+    /// The user's own signed home-currency contribution to personal totals.
+    ///
+    /// - Unsplit expense: the whole signed amount (identical to `signedSGD`),
+    ///   so existing data and non-trip expenses count exactly as before.
+    /// - Group split: `signedSGD * (myShares / totalShares)`, where "me" is the
+    ///   nil-personUUID entry. Zero when the user isn't in the split. Falls back
+    ///   to the full amount if the shares are degenerate (total <= 0), so a
+    ///   malformed split never silently drops a real expense from totals.
+    var myShareSGD: Double {
+        let entries = splits
+        guard !entries.isEmpty else { return signedSGD }
+        let totalShares = entries.reduce(0) { $0 + max($1.shares, 0) }
+        guard totalShares > 0 else { return signedSGD }
+        let myShares = entries
+            .filter { $0.personUUID == nil }
+            .reduce(0) { $0 + max($1.shares, 0) }
+        return signedSGD * (Double(myShares) / Double(totalShares))
     }
 }

--- a/mobile/PersonalDashboard/Models/Local/LocalTrip.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalTrip.swift
@@ -23,6 +23,17 @@ final class LocalTrip {
     /// Free-form notes the user types about the trip. Empty when none.
     var notes: String
 
+    /// Trip participants for expense splitting (#258). JSON-encoded array of
+    /// participant person UUIDs (lowercase UUID strings, for stable
+    /// round-tripping), following the `LocalList.itemsData` stored-Data +
+    /// computed-property pattern. OPTIONAL with a nil default so the SwiftData
+    /// lightweight migration on existing installs can't fail (project rule:
+    /// only ADD fields, always with a default). Nil / empty on every
+    /// pre-existing trip → no participants, expenses stay unsplit exactly as
+    /// before. The people themselves live in `LocalPerson` (reused, not
+    /// duplicated); this only stores which of them are on the trip.
+    var participantsData: Data?
+
     var createdAt: Date
     var updatedAt: Date
 
@@ -32,6 +43,7 @@ final class LocalTrip {
         startDate: Date,
         endDate: Date,
         notes: String = "",
+        participantsData: Data? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -40,7 +52,29 @@ final class LocalTrip {
         self.startDate = startDate
         self.endDate = endDate
         self.notes = notes
+        self.participantsData = participantsData
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+    }
+
+    /// The trip's participants as typed person UUIDs. Decodes on read and
+    /// encodes on write, mirroring `LocalList.items`. Decoding failures fall
+    /// back to an empty list rather than crashing. Order is preserved so the
+    /// chips render in the order the user added people.
+    var participantPersonUUIDs: [UUID] {
+        get { LocalTrip.decodeParticipants(participantsData) }
+        set { participantsData = LocalTrip.encodeParticipants(newValue) }
+    }
+
+    private static func encodeParticipants(_ ids: [UUID]) -> Data? {
+        guard !ids.isEmpty else { return nil }
+        let strings = ids.map { $0.uuidString.lowercased() }
+        return try? JSONEncoder().encode(strings)
+    }
+
+    private static func decodeParticipants(_ data: Data?) -> [UUID] {
+        guard let data, !data.isEmpty else { return [] }
+        let strings = (try? JSONDecoder().decode([String].self, from: data)) ?? []
+        return strings.compactMap { UUID(uuidString: $0) }
     }
 }

--- a/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
+++ b/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
@@ -23,6 +23,37 @@ enum ExpenseEditorTarget: Identifiable, Hashable {
     }
 }
 
+/// Trip context passed to the expense sheet when adding / editing an expense
+/// that belongs to a trip with participants (#258). Its presence (with a
+/// non-empty participant list) swaps the #188 "split N ways" stepper for the
+/// full settle-up UI: a payer picker + a per-person shares editor. Absent (the
+/// Finance surface) the sheet behaves exactly as before.
+struct TripExpenseContext {
+    let tripUUID: UUID
+    /// The trip's participants (people other than the user). Resolved by the
+    /// caller from the trip's `participantPersonUUIDs`.
+    let participants: [LocalPerson]
+}
+
+/// Identifies one party in a trip split: the user ("me") or a specific person.
+enum SplitPartyID: Hashable {
+    case me
+    case person(UUID)
+}
+
+/// Editable per-party split row backing the trip split editor. `included`
+/// gates whether the party is part of this bill; `shares` is their weight.
+struct SplitDraft: Identifiable {
+    let party: SplitPartyID
+    let name: String
+    /// Chip colour hex; nil for the user ("me").
+    let colorHex: String?
+    var included: Bool
+    var shares: Int
+
+    var id: SplitPartyID { party }
+}
+
 /// AddExpense / EditExpense form. One sheet handles create, edit, and
 /// "create-from-scanned-receipt" keyed off `target`. FX conversion runs
 /// on save (cached so it doesn't block on the home currency).
@@ -31,6 +62,18 @@ struct AddExpenseSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let target: ExpenseEditorTarget
+
+    /// Optional trip context (#258). Non-nil (with participants) turns on the
+    /// settle-up split UI and stamps `tripUUID` on save. Defaults to nil so the
+    /// Finance call sites (`AddExpenseSheet(target:)`) are unchanged.
+    var tripContext: TripExpenseContext? = nil
+
+    /// Per-party split editor state (trip context only). Seeded in
+    /// `loadIfNeeded`. Order is [You, participant, participant, …].
+    @State private var splitDrafts: [SplitDraft] = []
+
+    /// Who fronted the money. Defaults to the user.
+    @State private var payerParty: SplitPartyID = .me
 
     @State private var amountText: String = ""
     @State private var currency: String = FinanceSettings.displayCurrencyCode
@@ -129,7 +172,14 @@ struct AddExpenseSheet: View {
                         }
                         personField
                         eventField
-                        sharesField
+                        // Trip context with participants → full settle-up split
+                        // UI (payer + per-person shares). Otherwise the existing
+                        // #188 "split N ways" stepper, visually unchanged.
+                        if tripSplitActive {
+                            tripSplitSection
+                        } else {
+                            sharesField
+                        }
 
                         if let errorMessage {
                             Text(errorMessage)
@@ -531,6 +581,274 @@ struct AddExpenseSheet: View {
         return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value)
     }
 
+    // MARK: - Trip split (#258)
+
+    /// True when a trip context with at least one participant is active — the
+    /// signal to swap in the settle-up UI.
+    private var tripSplitActive: Bool {
+        if let tripContext { return !tripContext.participants.isEmpty }
+        return false
+    }
+
+    /// Parties currently sharing the bill (included, positive shares).
+    private var includedDrafts: [SplitDraft] {
+        splitDrafts.filter { $0.included && $0.shares > 0 }
+    }
+
+    private var totalShares: Int {
+        includedDrafts.reduce(0) { $0 + $1.shares }
+    }
+
+    /// This party's slice of the entered amount, in the entered currency.
+    private func splitAmount(for draft: SplitDraft) -> Double {
+        guard totalShares > 0, draft.included, draft.shares > 0 else { return 0 }
+        return amountValue * Double(draft.shares) / Double(totalShares)
+    }
+
+    /// Whether the bill is shared with someone other than the user. Only then
+    /// do we persist a split; a "just me" configuration stays an unsplit
+    /// personal expense so it counts fully in personal totals.
+    private var hasOtherParticipantsInSplit: Bool {
+        includedDrafts.contains {
+            if case .person = $0.party { return true }
+            return false
+        }
+    }
+
+    private var tripSplitSection: some View {
+        VStack(alignment: .leading, spacing: Space.lg) {
+            payerField
+            splitField
+        }
+    }
+
+    /// "Paid by" picker — who fronted the money. Defaults to You.
+    private var payerField: some View {
+        VStack(alignment: .leading, spacing: Space.fieldLabelGap) {
+            Text("Paid by").eyebrow()
+            Menu {
+                Button { payerParty = .me } label: { Label("You", systemImage: "person.fill") }
+                ForEach(tripContext?.participants ?? [], id: \.clientUUID) { person in
+                    Button { payerParty = .person(person.clientUUID) } label: { Text(person.name) }
+                }
+            } label: {
+                HStack(spacing: Space.sm) {
+                    Circle()
+                        .fill(payerColor)
+                        .frame(width: 12, height: 12)
+                    Text(payerName)
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.ink)
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Tokens.muted)
+                }
+                .padding(Space.md)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                .paperBorder(Tokens.border, radius: Radius.md)
+            }
+            .accessibilityLabel("Paid by \(payerName)")
+        }
+    }
+
+    /// "Split between" editor: a tappable include circle, a colour dot + name,
+    /// the party's slice of the bill, and a shares stepper per included party.
+    private var splitField: some View {
+        VStack(alignment: .leading, spacing: Space.fieldLabelGap) {
+            HStack {
+                Text("Split between").eyebrow()
+                Spacer()
+                Text(hasOtherParticipantsInSplit ? "\(includedDrafts.count) people" : "Just you")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            VStack(spacing: 0) {
+                ForEach($splitDrafts) { $draft in
+                    splitRow($draft)
+                    if draft.id != splitDrafts.last?.id {
+                        Divider().background(Tokens.divider)
+                    }
+                }
+            }
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+            .paperBorder(Tokens.border, radius: Radius.md)
+
+            if hasOtherParticipantsInSplit {
+                tripShareReadout
+            }
+        }
+    }
+
+    private func splitRow(_ draft: Binding<SplitDraft>) -> some View {
+        let d = draft.wrappedValue
+        return HStack(spacing: Space.sm) {
+            Button {
+                draft.wrappedValue.included.toggle()
+            } label: {
+                Image(systemName: d.included ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundStyle(d.included ? Tokens.accentFinance : Tokens.mutedSoft)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(d.included ? "\(d.name) included" : "\(d.name) excluded")
+
+            Circle()
+                .fill(partyColor(d))
+                .frame(width: 10, height: 10)
+            Text(d.name)
+                .font(.edBody)
+                .foregroundStyle(d.included ? Tokens.ink : Tokens.muted)
+                .lineLimit(1)
+
+            Spacer()
+
+            if d.included {
+                Text("\(currency.uppercased()) \(formatShare(splitAmount(for: d)))")
+                    .font(.edCaption)
+                    .monospacedDigit()
+                    .foregroundStyle(Tokens.muted)
+                Stepper("", value: draft.shares, in: 1...20)
+                    .labelsHidden()
+                    .tint(Tokens.accentFinance)
+                    .fixedSize()
+                    .accessibilityLabel("\(d.name) shares: \(d.shares)")
+            }
+        }
+        .padding(.horizontal, Space.md)
+        .padding(.vertical, Space.sm)
+    }
+
+    /// "Your share: CUR X of CUR Y" line, shown when the bill is shared.
+    private var tripShareReadout: some View {
+        let cur = currency.uppercased()
+        let mine = splitDrafts.first { $0.party == .me }.map { splitAmount(for: $0) } ?? 0
+        return HStack(spacing: 4) {
+            Text("Your share:")
+                .font(.edCaption)
+                .foregroundStyle(Tokens.muted)
+            Text("\(cur) \(formatShare(mine))")
+                .font(.edCaption)
+                .monospacedDigit()
+                .foregroundStyle(Tokens.ink)
+            Text("of \(cur) \(formatShare(amountValue))")
+                .font(.edCaption)
+                .monospacedDigit()
+                .foregroundStyle(Tokens.mutedSoft)
+        }
+    }
+
+    private var payerName: String {
+        switch payerParty {
+        case .me: return "You"
+        case .person(let id):
+            return tripContext?.participants.first { $0.clientUUID == id }?.name ?? "You"
+        }
+    }
+
+    private var payerColor: Color {
+        switch payerParty {
+        case .me: return Tokens.accentFinance
+        case .person(let id):
+            if let person = tripContext?.participants.first(where: { $0.clientUUID == id }) {
+                return Color(personHex: person.colorHex)
+            }
+            return Tokens.accentFinance
+        }
+    }
+
+    private func partyColor(_ draft: SplitDraft) -> Color {
+        if let hex = draft.colorHex { return Color(personHex: hex) }
+        return Tokens.accentFinance
+    }
+
+    /// Seed the split editor (trip context only). New expenses default to an
+    /// equal split across everyone; editing a split expense reconstructs its
+    /// stored entries; editing an UNSPLIT trip expense keeps it unsplit (only
+    /// "You" ticked) so it never silently converts to a split on save.
+    private func seedTripSplit() {
+        guard let ctx = tripContext else { return }
+
+        var existingSplits: [ExpenseSplitEntry] = []
+        var existingPayer: UUID?
+        if case .existing(let uuid) = target {
+            let descriptor = FetchDescriptor<LocalExpense>(
+                predicate: #Predicate { $0.clientUUID == uuid }
+            )
+            if let row = try? modelContext.fetch(descriptor).first {
+                existingSplits = row.splits
+                existingPayer = row.paidByPersonUUID
+            }
+        }
+        let editingUnsplit: Bool = {
+            if case .existing = target { return existingSplits.isEmpty }
+            return false
+        }()
+
+        func makeDraft(party: SplitPartyID, name: String, colorHex: String?) -> SplitDraft {
+            let entry: ExpenseSplitEntry? = {
+                switch party {
+                case .me: return existingSplits.first { $0.personUUID == nil }
+                case .person(let id): return existingSplits.first { $0.personID == id }
+                }
+            }()
+            let included: Bool
+            let shares: Int
+            if !existingSplits.isEmpty {
+                included = entry != nil
+                shares = max(entry?.shares ?? 1, 1)
+            } else if editingUnsplit {
+                included = (party == .me)
+                shares = 1
+            } else {
+                included = true
+                shares = 1
+            }
+            return SplitDraft(party: party, name: name, colorHex: colorHex, included: included, shares: shares)
+        }
+
+        var drafts: [SplitDraft] = [makeDraft(party: .me, name: "You", colorHex: nil)]
+        for person in ctx.participants {
+            drafts.append(makeDraft(party: .person(person.clientUUID), name: person.name, colorHex: person.colorHex))
+        }
+        splitDrafts = drafts
+
+        // Payer defaults to You; fall back to You if the stored payer is no
+        // longer on the trip.
+        if let payer = existingPayer, ctx.participants.contains(where: { $0.clientUUID == payer }) {
+            payerParty = .person(payer)
+        } else {
+            payerParty = .me
+        }
+
+        // Trip splits store the FULL bill and carry the breakdown in
+        // `splitsData`; the #188 per-share model must stay off.
+        numberOfShares = 1
+    }
+
+    /// Write the split state onto a row on save (trip context only). Persists a
+    /// split only when someone other than the user shares the bill; otherwise
+    /// clears the split so it's a plain personal expense.
+    private func applyTripSplit(to row: LocalExpense) {
+        guard tripContext != nil else { return }
+        if hasOtherParticipantsInSplit {
+            row.splits = includedDrafts.map { draft in
+                switch draft.party {
+                case .me: return ExpenseSplitEntry(person: nil, shares: draft.shares)
+                case .person(let id): return ExpenseSplitEntry(person: id, shares: draft.shares)
+                }
+            }
+            if case .person(let id) = payerParty {
+                row.paidByPersonUUID = id
+            } else {
+                row.paidByPersonUUID = nil
+            }
+        } else {
+            row.splits = []
+            row.paidByPersonUUID = nil
+        }
+    }
+
     /// Shared "tappable field that opens a picker" row for Person / Event.
     /// Shows the selected name (or a placeholder), a chevron, and a clear
     /// button when a value is set.
@@ -667,6 +985,11 @@ struct AddExpenseSheet: View {
                 }
             }
         }
+
+        // Seed the settle-up split editor after the base fields load (#258).
+        if tripSplitActive {
+            seedTripSplit()
+        }
     }
 
     private func save() async {
@@ -686,7 +1009,11 @@ struct AddExpenseSheet: View {
         // we store (#188). Divide first, then FX-convert the share so
         // `originalAmount` / `sgdAmount` are already the per-person figure and
         // every aggregation site stays correct without change. Equal split only.
-        let shares = max(numberOfShares, 1)
+        //
+        // Trip splits (#258) use a DIFFERENT model: the row stores the FULL
+        // bill and the breakdown lives in `splitsData`, so the #188 division is
+        // forced off (shares = 1) and `applyTripSplit` writes the split after.
+        let shares = tripSplitActive ? 1 : max(numberOfShares, 1)
         let shareAmount = amountValue / Double(shares)
 
         let conversion: (sgdAmount: Double, rate: Double)
@@ -724,6 +1051,13 @@ struct AddExpenseSheet: View {
                     row.receiptImagePath = path
                     try modelContext.save()
                 }
+                // Trip linkage + settle-up split (#258). Stamp the tripUUID and
+                // write the split; only persisted when a trip context is active.
+                if let ctx = tripContext {
+                    row.tripUUID = ctx.tripUUID
+                    applyTripSplit(to: row)
+                    try modelContext.save()
+                }
 
             case .existing(let uuid):
                 let descriptor = FetchDescriptor<LocalExpense>(
@@ -749,6 +1083,13 @@ struct AddExpenseSheet: View {
                     // removed the image, or scan path → manual edit).
                     existing.receiptImagePath = receiptImagePath
                     existing.source = source.rawValue
+                    // Trip linkage + settle-up split (#258). Only touched when a
+                    // trip context is active, so editing a trip expense from the
+                    // Finance surface (no context) round-trips splits untouched.
+                    if let ctx = tripContext {
+                        existing.tripUUID = ctx.tripUUID
+                        applyTripSplit(to: existing)
+                    }
                     try modelContext.save()
                 }
             }

--- a/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
+++ b/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
@@ -95,7 +95,7 @@ struct ExpenseRow: View {
     /// Whether any badge (person, event, or split) should render on the
     /// secondary badge row.
     private var hasBadges: Bool {
-        hasTags || expense.isSplit
+        hasTags || expense.isSplit || expense.isGroupSplit
     }
 
     /// Split badge label, e.g. "1/3 of SGD 90.00" (#188). Shows the user's
@@ -131,7 +131,35 @@ struct ExpenseRow: View {
             if expense.isSplit {
                 splitBadge
             }
+            if expense.isGroupSplit {
+                groupSplitBadge
+            }
         }
+    }
+
+    /// Group-split badge (#258). The row's primary amount shows the FULL bill
+    /// (that's how trip splits store `sgdAmount`), so this badge surfaces the
+    /// user's own share alongside it — "your S$45.00 of S$135.00" — mirroring
+    /// how the finance dashboard now counts only the user's share. Renders only
+    /// for the full settle-up model (`splitsData` set), never for existing rows.
+    private var groupSplitBadge: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "person.2.fill")
+                .font(.system(size: 9, weight: .semibold))
+            Text(groupSplitLabel)
+                .font(.edCaption)
+                .monospacedDigit()
+                .lineLimit(1)
+        }
+        .foregroundStyle(Tokens.muted)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(Tokens.muted.opacity(0.12), in: Capsule())
+        .accessibilityLabel("Split expense, \(groupSplitLabel)")
+    }
+
+    private var groupSplitLabel: String {
+        "your \(FinanceDashboardBand.formatMoney(abs(expense.myShareSGD))) of \(FinanceDashboardBand.formatMoney(expense.sgdAmount))"
     }
 
     /// Split badge (#188). Same capsule shape as `PersonEventBadge` but muted

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -645,8 +645,10 @@ struct FinanceView: View {
         let dict = Dictionary(grouping: rows) { cal.startOfDay(for: $0.date) }
         return dict.keys.sorted(by: >).map { day in
             let dayRows = dict[day] ?? []
-            // Net refunds into the day-group header total (#206).
-            let total = dayRows.reduce(0) { $0 + $1.signedSGD }
+            // Net refunds into the day-group header total (#206), and count only
+            // the user's share of any split trip expense (#258) so the per-day
+            // header matches the my-share dashboard total.
+            let total = dayRows.reduce(0) { $0 + $1.myShareSGD }
             return DailyGroup(day: day, total: total, rows: dayRows)
         }
     }
@@ -804,9 +806,11 @@ struct FinanceView: View {
         var rangeFilter = filter
         rangeFilter.dateRange = range
         let rangeRows = allExpenses.filter { matches($0, filter: rangeFilter) }
-        // All dashboard-band figures net refunds (#206): the headline total,
-        // the delta comparison, the category bars, and the sparkline.
-        let rangeTotal = rangeRows.reduce(0) { $0 + $1.signedSGD }
+        // All dashboard-band figures net refunds (#206) AND count only the
+        // user's share of split trip expenses (#258) — "my share counts": the
+        // headline total, the delta comparison, the category bars, the average
+        // per month, and the sparkline all sum `myShareSGD`.
+        let rangeTotal = rangeRows.reduce(0) { $0 + $1.myShareSGD }
 
         // Average monthly spend: normalise the period total to a 30.44-day month,
         // using elapsed time (range start -> earlier of range end and now) so
@@ -843,11 +847,11 @@ struct FinanceView: View {
         var prevFilter = filter
         prevFilter.dateRange = prevRange
         let prevRows = allExpenses.filter { matches($0, filter: prevFilter) }
-        let prevTotal = prevRows.reduce(0) { $0 + $1.signedSGD }
+        let prevTotal = prevRows.reduce(0) { $0 + $1.myShareSGD }
 
         var byCategory: [ExpenseCategory: Double] = [:]
         for row in rangeRows {
-            byCategory[row.categoryEnum, default: 0] += row.signedSGD
+            byCategory[row.categoryEnum, default: 0] += row.myShareSGD
         }
         let topCategories = byCategory
             .sorted { $0.value > $1.value }
@@ -862,7 +866,7 @@ struct FinanceView: View {
         var dailyDict: [Date: Double] = [:]
         for row in rangeRows {
             let day = cal.startOfDay(for: row.date)
-            dailyDict[day, default: 0] += row.signedSGD
+            dailyDict[day, default: 0] += row.myShareSGD
         }
         var dailyTotals: [(date: Date, total: Double)] = []
         for offset in 0..<max(dayCount, 1) {

--- a/mobile/PersonalDashboard/Views/Itineraries/ItinerariesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/ItinerariesView.swift
@@ -377,6 +377,17 @@ private struct TripEditorSheet: View {
     @State private var loaded: Bool = false
     @FocusState private var nameFocused: Bool
 
+    /// Trip participants for expense splitting (#258). Held as an ordered list
+    /// of `LocalPerson.clientUUID`s; encoded to `participantsData` on save.
+    @State private var participantUUIDs: [UUID] = []
+    /// Selection binding for the reused `PersonPickerSheet` (find-or-create).
+    @State private var pickedParticipant: ExpenseTag?
+    @State private var showingParticipantPicker: Bool = false
+
+    /// All people, so the stored participant UUIDs resolve to names + colours.
+    @Query(sort: [SortDescriptor(\LocalPerson.name, order: .forward)])
+    private var allPeople: [LocalPerson]
+
     private let nameMaxLength = 64
     private let notesMaxLength = 1000
 
@@ -389,6 +400,7 @@ private struct TripEditorSheet: View {
                     VStack(alignment: .leading, spacing: Space.lg) {
                         nameField
                         dateFields
+                        participantsField
                         notesField
                     }
                     .padding(Space.lg)
@@ -466,6 +478,92 @@ private struct TripEditorSheet: View {
         }
     }
 
+    /// Participants for expense splitting (#258). Colcoured person chips with a
+    /// remove affordance, plus an "Add" chip that opens the reused
+    /// `PersonPickerSheet` (find-or-create by name). Horizontally scrollable so
+    /// a large group never blows out the sheet width.
+    private var participantsField: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            HStack {
+                Text("Participants").eyebrow()
+                Spacer()
+                Text("For splitting expenses")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Space.sm) {
+                    ForEach(participantPeople, id: \.clientUUID) { person in
+                        participantChip(person)
+                    }
+                    addParticipantChip
+                }
+                .padding(.vertical, 2)
+            }
+        }
+        .sheet(isPresented: $showingParticipantPicker) {
+            PersonPickerSheet(selection: $pickedParticipant)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .onChange(of: pickedParticipant) { _, newValue in
+            if let tag = newValue, !participantUUIDs.contains(tag.uuid) {
+                participantUUIDs.append(tag.uuid)
+            }
+            // Reset so picking the same person twice in a row still fires.
+            pickedParticipant = nil
+        }
+    }
+
+    /// Resolved participant records, preserving the stored order.
+    private var participantPeople: [LocalPerson] {
+        participantUUIDs.compactMap { id in allPeople.first { $0.clientUUID == id } }
+    }
+
+    private func participantChip(_ person: LocalPerson) -> some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(Color(personHex: person.colorHex))
+                .frame(width: 8, height: 8)
+            Text(person.name)
+                .font(.edFootnote)
+                .foregroundStyle(Tokens.ink)
+                .lineLimit(1)
+            Button {
+                participantUUIDs.removeAll { $0 == person.clientUUID }
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove \(person.name)")
+        }
+        .padding(.leading, Space.sm)
+        .padding(.trailing, Space.xs + 2)
+        .padding(.vertical, 6)
+        .background(Tokens.surface2, in: Capsule())
+    }
+
+    private var addParticipantChip: some View {
+        Button {
+            showingParticipantPicker = true
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "plus")
+                    .font(.system(size: 10, weight: .semibold))
+                Text("Add")
+                    .font(.edFootnote)
+            }
+            .foregroundStyle(Tokens.accent(for: .itineraries))
+            .padding(.horizontal, Space.sm)
+            .padding(.vertical, 6)
+            .background(Tokens.accent(for: .itineraries).opacity(0.12), in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Add participant")
+    }
+
     private var notesField: some View {
         VStack(alignment: .leading, spacing: Space.sm) {
             HStack {
@@ -531,6 +629,7 @@ private struct TripEditorSheet: View {
                 startDate = existing.startDate
                 endDate = existing.endDate
                 notes = existing.notes
+                participantUUIDs = existing.participantPersonUUIDs
             }
         } else {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
@@ -555,6 +654,7 @@ private struct TripEditorSheet: View {
                 endDate: normalisedEnd,
                 notes: cleanNotes
             )
+            trip.participantPersonUUIDs = participantUUIDs
             modelContext.insert(trip)
         case .existing(let uuid):
             let descriptor = FetchDescriptor<LocalTrip>(
@@ -565,6 +665,7 @@ private struct TripEditorSheet: View {
                 existing.startDate = normalisedStart
                 existing.endDate = normalisedEnd
                 existing.notes = cleanNotes
+                existing.participantPersonUUIDs = participantUUIDs
                 existing.updatedAt = Date()
             } else {
                 let trip = LocalTrip(
@@ -573,6 +674,7 @@ private struct TripEditorSheet: View {
                     endDate: normalisedEnd,
                     notes: cleanNotes
                 )
+                trip.participantPersonUUIDs = participantUUIDs
                 modelContext.insert(trip)
             }
         }

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -20,6 +20,18 @@ struct TripDetailView: View {
 
     @Query private var items: [LocalItineraryItem]
 
+    /// All people, so the trip's participant UUIDs resolve to names + colours
+    /// for the expense split context (#258).
+    @Query private var allPeople: [LocalPerson]
+
+    /// Which tab of the trip detail is showing. Defaults to the itinerary so
+    /// existing behaviour is unchanged on open (#258).
+    @State private var tab: TripDetailTab = .itinerary
+
+    /// Drives the expense editor sheet on the Expenses tab. `.new` for the FAB,
+    /// `.existing(uuid)` for a tapped row.
+    @State private var expenseEditorTarget: ExpenseEditorTarget?
+
     /// Drives the item editor. `.new(day:)` carries the pre-filled day;
     /// `.existing(_)` carries the item UUID for edit.
     @State private var editingItem: ItineraryItemEditorTarget?
@@ -51,26 +63,55 @@ struct TripDetailView: View {
                 SortDescriptor(\.createdAt, order: .forward)
             ]
         )
+        _allPeople = Query(sort: [SortDescriptor(\LocalPerson.name, order: .forward)])
+    }
+
+    /// Trip context handed to `AddExpenseSheet` so it stamps `tripUUID` and
+    /// shows the settle-up split UI. Participants preserve their stored order.
+    private var tripExpenseContext: TripExpenseContext {
+        let participants = trip.participantPersonUUIDs.compactMap { id in
+            allPeople.first { $0.clientUUID == id }
+        }
+        return TripExpenseContext(tripUUID: trip.clientUUID, participants: participants)
     }
 
     var body: some View {
         ZStack {
             Tokens.paper.ignoresSafeArea()
 
-            if grouped.isEmpty {
-                emptyState
-            } else {
-                timelineScroll
+            VStack(spacing: 0) {
+                tripTabBar
+
+                switch tab {
+                case .itinerary:
+                    if grouped.isEmpty {
+                        emptyState
+                    } else {
+                        timelineScroll
+                    }
+                case .expenses:
+                    TripExpensesView(trip: trip) { uuid in
+                        expenseEditorTarget = .existing(uuid)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
 
             // FAB sits above the bottom tab bar AND the home indicator. The
             // 96pt bumper at the end of the scroll content guarantees the
-            // last card is not hidden by this overlay.
+            // last card is not hidden by this overlay. Its action is
+            // contextual: add a stop on the itinerary tab, add an expense on
+            // the expenses tab.
             fabOverlay
 
             if isProcessingTicket {
                 ticketProcessingOverlay
             }
+        }
+        .sheet(item: $expenseEditorTarget) { target in
+            AddExpenseSheet(target: target, tripContext: tripExpenseContext)
+                .presentationDetents([.large])
+                .presentationDragIndicator(.visible)
         }
         .sheet(item: $editingItem) { target in
             ItineraryItemEditorSheet(trip: trip, target: target)
@@ -129,6 +170,22 @@ struct TripDetailView: View {
         } message: {
             Text(ticketError ?? "")
         }
+    }
+
+    // MARK: - Tab bar
+
+    /// Segmented switch between the itinerary timeline and the expense ledger
+    /// (#258). Native segmented picker keeps it lightweight and familiar; the
+    /// itinerary is the default so opening a trip is unchanged.
+    private var tripTabBar: some View {
+        Picker("", selection: $tab) {
+            Text("Itinerary").tag(TripDetailTab.itinerary)
+            Text("Expenses").tag(TripDetailTab.expenses)
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, Space.lg)
+        .padding(.top, Space.md)
+        .padding(.bottom, Space.sm)
     }
 
     // MARK: - Ticket processing overlay
@@ -272,49 +329,73 @@ struct TripDetailView: View {
             Spacer()
             HStack {
                 Spacer()
-                Menu {
-                    Button {
-                        Haptics.light()
-                        editingItem = .new(day: defaultDayForNewItem)
-                    } label: {
-                        Label("Add a stop", systemImage: "plus")
-                    }
-                    Divider()
-                    // Camera is hidden on hardware without one (simulator), where
-                    // UIImagePickerController would silently fall back to the
-                    // library and make two menu items redundant.
-                    if UIImagePickerController.isSourceTypeAvailable(.camera) {
-                        Button {
-                            showingTicketCamera = true
-                        } label: {
-                            Label("Scan a ticket", systemImage: "camera")
-                        }
-                    }
-                    Button {
-                        showingTicketPhotoLibrary = true
-                    } label: {
-                        Label("Ticket from Photos", systemImage: "photo")
-                    }
-                    Button {
-                        showingTicketPDFPicker = true
-                    } label: {
-                        Label("Ticket from PDF", systemImage: "doc.text")
-                    }
-                } label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 17, weight: .regular))
-                        .foregroundStyle(Tokens.accentFg)
-                        .frame(width: 48, height: 48)
-                        .background(Tokens.accent(for: .itineraries), in: Circle())
-                        .shadow(color: .black.opacity(0.18), radius: 12, x: 0, y: 6)
+                switch tab {
+                case .itinerary: itineraryFab
+                case .expenses:  expenseFab
                 }
-                .disabled(isProcessingTicket)
-                .accessibilityLabel("Add to trip")
             }
         }
         .padding(.trailing, Space.lg)
         .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
         .allowsHitTesting(true)
+    }
+
+    /// Itinerary FAB: the existing add-stop / scan-ticket menu.
+    private var itineraryFab: some View {
+        Menu {
+            Button {
+                Haptics.light()
+                editingItem = .new(day: defaultDayForNewItem)
+            } label: {
+                Label("Add a stop", systemImage: "plus")
+            }
+            Divider()
+            // Camera is hidden on hardware without one (simulator), where
+            // UIImagePickerController would silently fall back to the
+            // library and make two menu items redundant.
+            if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                Button {
+                    showingTicketCamera = true
+                } label: {
+                    Label("Scan a ticket", systemImage: "camera")
+                }
+            }
+            Button {
+                showingTicketPhotoLibrary = true
+            } label: {
+                Label("Ticket from Photos", systemImage: "photo")
+            }
+            Button {
+                showingTicketPDFPicker = true
+            } label: {
+                Label("Ticket from PDF", systemImage: "doc.text")
+            }
+        } label: {
+            fabCircle
+        }
+        .disabled(isProcessingTicket)
+        .accessibilityLabel("Add to trip")
+    }
+
+    /// Expenses FAB: opens the expense editor scoped to this trip.
+    private var expenseFab: some View {
+        Button {
+            Haptics.light()
+            expenseEditorTarget = .new
+        } label: {
+            fabCircle
+        }
+        .accessibilityLabel("Add trip expense")
+    }
+
+    /// The shared circular "+" glyph both FABs wear.
+    private var fabCircle: some View {
+        Image(systemName: "plus")
+            .font(.system(size: 17, weight: .regular))
+            .foregroundStyle(Tokens.accentFg)
+            .frame(width: 48, height: 48)
+            .background(Tokens.accent(for: .itineraries), in: Circle())
+            .shadow(color: .black.opacity(0.18), radius: 12, x: 0, y: 6)
     }
 
     // MARK: - Ticket upload
@@ -422,6 +503,15 @@ struct TripDetailView: View {
         modelContext.delete(item)
         try? modelContext.save()
     }
+}
+
+// MARK: - Trip detail tabs
+
+/// The two tabs of a trip's detail screen (#258): the itinerary timeline and
+/// the expense ledger.
+enum TripDetailTab: Hashable {
+    case itinerary
+    case expenses
 }
 
 // MARK: - Layout constants

--- a/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
@@ -1,0 +1,293 @@
+import SwiftUI
+import SwiftData
+
+/// The expenses tab of a trip's detail screen (#258).
+///
+/// Trip expenses are ordinary `LocalExpense` rows joined by `tripUUID` (the FK
+/// added in #177), enriched with the settle-up split metadata (#258). This
+/// view surfaces three things: header stats (group total, the user's share,
+/// count), netted settle-up balances ("Rohan is owed S$140"), and the expense
+/// list itself. Adding / editing goes through `AddExpenseSheet` with a trip
+/// context, driven by the parent `TripDetailView` (which owns the sheet + FAB).
+struct TripExpensesView: View {
+    let trip: LocalTrip
+
+    /// Tapping a row bubbles the expense's clientUUID up so the parent opens
+    /// the editor (the parent owns the sheet + trip context).
+    let onEditExpense: (String) -> Void
+
+    /// Trip expenses, newest first. Filtered by the trip FK in the query.
+    @Query private var expenses: [LocalExpense]
+
+    /// People, so participant names / colours resolve for the settle-up rows.
+    @Query(sort: [SortDescriptor(\LocalPerson.name, order: .forward)])
+    private var people: [LocalPerson]
+
+    init(trip: LocalTrip, onEditExpense: @escaping (String) -> Void) {
+        self.trip = trip
+        self.onEditExpense = onEditExpense
+        let tripID = trip.clientUUID
+        _expenses = Query(
+            filter: #Predicate<LocalExpense> { $0.tripUUID == tripID },
+            sort: [
+                SortDescriptor(\.date, order: .reverse),
+                SortDescriptor(\.createdAt, order: .reverse)
+            ]
+        )
+    }
+
+    var body: some View {
+        Group {
+            if expenses.isEmpty {
+                emptyState
+            } else {
+                populated
+            }
+        }
+    }
+
+    // MARK: - Populated
+
+    private var populated: some View {
+        ScrollView {
+            VStack(spacing: Space.lg) {
+                statsCard
+                if !balances.isEmpty {
+                    settleUpCard
+                }
+                expenseList
+                Color.clear.frame(height: 96)
+            }
+            .padding(.horizontal, Space.lg)
+            .padding(.top, Space.lg)
+        }
+        .scrollDismissesKeyboard(.interactively)
+    }
+
+    // MARK: - Stats card
+
+    private var groupTotal: Double {
+        expenses.reduce(0) { $0 + $1.signedSGD }
+    }
+
+    private var yourShare: Double {
+        expenses.reduce(0) { $0 + $1.myShareSGD }
+    }
+
+    private var statsCard: some View {
+        VStack(alignment: .leading, spacing: Space.md) {
+            Text("Group total").eyebrow()
+            Text(FinanceDashboardBand.formatMoney(groupTotal))
+                .font(.edDisplay)
+                .foregroundStyle(Tokens.ink)
+                .tracking(-0.6)
+
+            HStack(spacing: Space.lg) {
+                statTile(label: "Your share", value: FinanceDashboardBand.formatMoney(yourShare))
+                statTile(label: "Expenses", value: "\(expenses.count)")
+            }
+            .padding(.top, Space.xs)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Space.lg)
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        .paperBorder(Tokens.border, radius: Radius.lg)
+    }
+
+    private func statTile(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.edCaption)
+                .foregroundStyle(Tokens.mutedSoft)
+            Text(value)
+                .font(.edBodyMedium)
+                .monospacedDigit()
+                .foregroundStyle(Tokens.inkSoft)
+        }
+    }
+
+    // MARK: - Settle up
+
+    /// Netted per-party balances, sorted with the user first, then the people
+    /// who are owed the most. Only parties whose net is more than a cent show.
+    private var balances: [TripSettlement.Balance] {
+        TripSettlement.compute(expenses: expenses)
+    }
+
+    private var settleUpCard: some View {
+        VStack(alignment: .leading, spacing: Space.md) {
+            Text("Settle up").eyebrow()
+            VStack(spacing: Space.sm) {
+                ForEach(balances) { balance in
+                    settleRow(balance)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Space.lg)
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        .paperBorder(Tokens.border, radius: Radius.lg)
+    }
+
+    private func settleRow(_ balance: TripSettlement.Balance) -> some View {
+        // Positive net = owed money (green); negative = owes (ink). The amount
+        // is shown as a magnitude; the phrasing carries the direction.
+        let owed = balance.net > 0
+        return HStack(spacing: Space.sm) {
+            Circle()
+                .fill(partyColor(balance.party))
+                .frame(width: 10, height: 10)
+            Text(phrase(for: balance))
+                .font(.edFootnote)
+                .foregroundStyle(Tokens.inkSoft)
+                .lineLimit(1)
+            Spacer(minLength: Space.sm)
+            Text(FinanceDashboardBand.formatMoney(abs(balance.net)))
+                .font(.edFootnoteStrong)
+                .monospacedDigit()
+                .foregroundStyle(owed ? Tokens.success : Tokens.ink)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(phrase(for: balance)) \(FinanceDashboardBand.formatMoney(abs(balance.net)))")
+    }
+
+    /// "You are owed" / "You owe" / "Rohan is owed" / "Sam owes".
+    private func phrase(for balance: TripSettlement.Balance) -> String {
+        let owed = balance.net > 0
+        switch balance.party {
+        case .me:
+            return owed ? "You are owed" : "You owe"
+        case .person(let id):
+            let name = personName(id)
+            return owed ? "\(name) is owed" : "\(name) owes"
+        }
+    }
+
+    private func personName(_ id: UUID) -> String {
+        people.first { $0.clientUUID == id }?.name ?? "Someone"
+    }
+
+    private func partyColor(_ party: SplitPartyID) -> Color {
+        switch party {
+        case .me:
+            return Tokens.accentFinance
+        case .person(let id):
+            if let person = people.first(where: { $0.clientUUID == id }) {
+                return Color(personHex: person.colorHex)
+            }
+            return Tokens.accentFinance
+        }
+    }
+
+    // MARK: - Expense list
+
+    private var expenseList: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            Text("Expenses").eyebrow()
+            VStack(spacing: Space.xs) {
+                ForEach(expenses) { expense in
+                    ExpenseRow(expense: expense) {
+                        onEditExpense(expense.clientUUID)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            VStack(spacing: 0) {
+                Image(systemName: "wallet.bifold")
+                    .font(.system(size: 32, weight: .light))
+                    .foregroundStyle(Tokens.mutedSoft)
+                Spacer().frame(height: Space.md)
+                Text("No expenses yet")
+                    .font(.edTitle)
+                    .foregroundStyle(Tokens.ink)
+                    .multilineTextAlignment(.center)
+                Spacer().frame(height: Space.xs)
+                Text(trip.participantPersonUUIDs.isEmpty
+                     ? "Tap + to log a trip expense. Add participants in Edit trip to split the bill."
+                     : "Tap + to log a trip expense and split it with your group.")
+                    .font(.edSubheadline)
+                    .foregroundStyle(Tokens.muted)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: 300)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, Space.lg)
+    }
+}
+
+// MARK: - Settlement math
+
+/// Pure settle-up computation over a trip's expenses (#258).
+///
+/// Runs entirely on the frozen home-currency amounts (`signedSGD`) so a
+/// mixed-currency trip nets correctly and refunds subtract. For each party the
+/// net position is `totalPaid - totalOwedShare`: positive means the party is
+/// owed money by the group, negative means they owe. The group nets to zero.
+///
+/// An UNSPLIT expense is owed entirely by whoever paid it, so it nets to zero
+/// for that party and never creates a balance — exactly right for a personal
+/// cost logged against the trip.
+enum TripSettlement {
+    struct Balance: Identifiable {
+        let party: SplitPartyID
+        /// Home-currency net. > 0 owed money, < 0 owes.
+        let net: Double
+        var id: SplitPartyID { party }
+    }
+
+    /// Below this magnitude (half a cent) a party counts as settled and is
+    /// dropped from the list.
+    private static let epsilon = 0.005
+
+    static func compute(expenses: [LocalExpense]) -> [Balance] {
+        var paid: [SplitPartyID: Double] = [:]
+        var owed: [SplitPartyID: Double] = [:]
+
+        for expense in expenses {
+            let amount = expense.signedSGD
+            let payer: SplitPartyID = expense.paidByPersonUUID.map { .person($0) } ?? .me
+            paid[payer, default: 0] += amount
+
+            let splits = expense.splits
+            if splits.isEmpty {
+                // Unsplit: the payer bears the whole cost (nets to zero).
+                owed[payer, default: 0] += amount
+                continue
+            }
+            let totalShares = splits.reduce(0) { $0 + max($1.shares, 0) }
+            guard totalShares > 0 else {
+                owed[payer, default: 0] += amount
+                continue
+            }
+            for entry in splits {
+                let shares = max(entry.shares, 0)
+                guard shares > 0 else { continue }
+                let party: SplitPartyID = entry.personID.map { .person($0) } ?? .me
+                owed[party, default: 0] += amount * Double(shares) / Double(totalShares)
+            }
+        }
+
+        let parties = Set(paid.keys).union(owed.keys)
+        var balances: [Balance] = parties.map { party in
+            Balance(party: party, net: (paid[party] ?? 0) - (owed[party] ?? 0))
+        }
+        balances.removeAll { abs($0.net) < epsilon }
+
+        // User first, then people owed the most, then people who owe the most.
+        balances.sort { lhs, rhs in
+            if lhs.party == .me { return true }
+            if rhs.party == .me { return false }
+            return lhs.net > rhs.net
+        }
+        return balances
+    }
+}


### PR DESCRIPTION
## Summary

- Trips gain a participant list (`LocalTrip.participantsData`, reusing `LocalPerson` via find-or-create) managed as colored chips in the trip editor
- Expenses gain split metadata: `paidByPersonUUID` (nil means you paid) and `splitsData` with per-person shares; default split is all trip participants at 1 share each
- New Expenses tab on trip detail: group total, your share, netted settle-up balances (computed on frozen home-currency amounts so mixed-currency trips net correctly), expense list, and trip-scoped add/edit via `AddExpenseSheet` with payer picker and shares editor
- Finance dashboard totals are now share-aware: split trip expenses count only your share (headline, category bars, average per month, sparkline, day groups); unsplit expenses count fully, exactly as before
- All data-model changes are additive with nil defaults, so the SwiftData lightweight migration leaves existing installs untouched

Phases 3 and 4 (upload-location routing for receipts/statement PDFs, email split defaults, and `add_expense` tool params) follow in separate PRs per the plan on the issue.

Closes #258

## Test plan

- [x] `xcodegen generate` + `xcodebuild build` clean (0 errors)
- [x] Shipped to device via `devicectl` for QA
- [ ] Device QA: create a trip with participants, add split expenses (equal and uneven shares, different payers), verify settle-up balances and that Finance totals only count your share
- [ ] Verify existing expenses and trips render unchanged after the migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
