### PR TITLE
feat(ios): trip-aware imports and split params for add_expense

### DIFF
--- a/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
+++ b/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
@@ -146,7 +146,27 @@ struct AssistantContextBuilder {
             )) ?? []
             let itemsByTrip = Dictionary(grouping: allItems, by: { $0.tripUUID })
 
-            out += "\n\nEXISTING TRIPS:\n"
+            // Participant names (#258): resolve each trip's participant UUIDs to
+            // LocalPerson names so the model can map "split between all of us" to
+            // the participant list and use those names for split_with / paid_by.
+            let allPeople = (try? context.fetch(FetchDescriptor<LocalPerson>())) ?? []
+            var peopleNamesByUUID: [UUID: String] = [:]
+            for person in allPeople { peopleNamesByUUID[person.clientUUID] = person.name }
+
+            // Per-trip expense totals (#258): a compact "SGD X across N" rollup
+            // so the model can answer trip-spend questions and knows which trips
+            // already have expenses. Sums signedSGD (full bills, refunds netted).
+            let allTripExpenses = (try? context.fetch(FetchDescriptor<LocalExpense>())) ?? []
+            var expenseAggByTrip: [UUID: (total: Double, count: Int)] = [:]
+            for expense in allTripExpenses {
+                guard let tripFK = expense.tripUUID else { continue }
+                var agg = expenseAggByTrip[tripFK] ?? (total: 0, count: 0)
+                agg.total += expense.signedSGD
+                agg.count += 1
+                expenseAggByTrip[tripFK] = agg
+            }
+
+            out += "\n\nEXISTING TRIPS (a trip's participant names are valid split_with / paid_by values for add_expense):\n"
             out += trips.enumerated().map { (idx, trip) -> String in
                 let id = Self.uuidString(trip.clientUUID)
                 let startISO = Self.isoDate.string(from: trip.startDate)
@@ -176,6 +196,18 @@ struct AssistantContextBuilder {
                         line += "\n  Day \(dayNumber) (\(dayISO)): \(pretty)"
                     }
                 }
+
+                // Participants + expense rollup (#258). Both skipped when empty
+                // so a solo trip with no expenses reads exactly as before.
+                let participantNames = trip.participantPersonUUIDs.compactMap { peopleNamesByUUID[$0] }
+                if !participantNames.isEmpty {
+                    let names = participantNames.map { Self.safe($0, maxLen: 80) }.joined(separator: ", ")
+                    line += "\n  Participants: \(names)"
+                }
+                if let agg = expenseAggByTrip[trip.clientUUID], agg.count > 0 {
+                    line += String(format: "\n  Expenses: SGD %.2f across %d", agg.total, agg.count)
+                }
+
                 return line
             }.joined(separator: "\n")
         }

--- a/mobile/PersonalDashboard/AI/ChatDraft.swift
+++ b/mobile/PersonalDashboard/AI/ChatDraft.swift
@@ -325,7 +325,27 @@ extension ChatDraft {
         if !event.isEmpty {
             line += " · \(event)"
         }
+
+        // Trip / group split (#258): who paid + how many ways, when present, so
+        // the confirm card reads "Sam paid · split 4 ways" before the user
+        // commits. Payer is named only when someone other than the user paid.
+        let payer = (dict["paid_by"]?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let splitWith = dict["split_with"]?.arrayValue?.compactMap { $0.stringValue } ?? []
+        if !payer.isEmpty, !isMeToken(payer) {
+            line += " · \(payer) paid"
+        }
+        if splitWith.count > 1 {
+            line += " · split \(splitWith.count) ways"
+        }
         return line
+    }
+
+    /// True when a split name refers to the user rather than another person.
+    /// Mirrors `ExecuteDraftAction.isMeToken` so the preview and the executor
+    /// agree on who the user is.
+    private static func isMeToken(_ raw: String) -> Bool {
+        let t = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return ["me", "myself", "i", "you", "self"].contains(t)
     }
 
     /// Build the preview for `edit_trip`. Falls back to a generic line if

--- a/mobile/PersonalDashboard/AI/EmailToItinerary.swift
+++ b/mobile/PersonalDashboard/AI/EmailToItinerary.swift
@@ -77,9 +77,13 @@ struct EmailToItinerary {
     /// auto-create / auto-edit a trip". A receipt with no matching trip can
     /// still produce an expense; a booking with a fare produces both (#177).
     private var emailTools: [AnthropicTool] {
-        ToolDefinitions.allTools.filter {
-            $0.name == "add_itinerary_item" || $0.name == "add_expense"
-        }
+        // `add_itinerary_item` from the shared set, plus the EMAIL-SAFE
+        // add_expense (#258) — the settle-up params (paid_by / split_with) are
+        // deliberately withheld from this untrusted surface; trip splits are
+        // defaulted in Swift after execution instead.
+        var tools = ToolDefinitions.allTools.filter { $0.name == "add_itinerary_item" }
+        tools.append(ToolDefinitions.addExpenseEmailSafe)
+        return tools
     }
 
     /// - Parameter reconcile: when true (the explicit "Re-scan (ignore
@@ -438,7 +442,14 @@ struct EmailToItinerary {
         addedExpenseUUIDs: inout [UUID],
         skippedExpenseDuplicates: inout Int
     ) async -> AnthropicContentBlock {
-        let input = call.input
+        // Belt-and-braces on the untrusted email surface (#258): even though the
+        // email tool schema doesn't advertise them, strip any settle-up params
+        // an injected email might smuggle in so the shared executor never
+        // find-or-creates people or a split from email content. Trip splits are
+        // defaulted in Swift below instead.
+        var input = call.input
+        input.removeValue(forKey: "paid_by")
+        input.removeValue(forKey: "split_with")
 
         // Build the dedup descriptor from the proposed input, parsing amount /
         // date the same way `ExecuteDraftAction.addExpense` does.
@@ -466,6 +477,12 @@ struct EmailToItinerary {
                     reference: proposed.sourceReference,
                     store: store
                 )
+                // Trip split defaults (#258): when this expense linked to a trip
+                // (trip_id resolved inside addExpense) AND that trip has
+                // participants, default the stored split to everyone at one share
+                // each with the user as payer. Done in Swift — the email path
+                // never asks the model to emit split data.
+                Self.applyTripSplitDefaults(expenseUUID: expenseUUID, store: store)
                 // #180: attach the forwarded receipt to the FIRST newly-created
                 // expense only. Saved lazily here (not before the loop) so a
                 // run that creates no new expense writes no orphan file. If the
@@ -608,6 +625,41 @@ struct EmailToItinerary {
         ).first else { return }
         row.dedupeKey = signature
         row.sourceReference = ExpenseDedupe.normalizeReference(reference)
+        try? store.context.save()
+    }
+
+    /// Default the settle-up split on an email-logged expense (#258).
+    ///
+    /// Runs after `addExpense` (which already stamped `tripUUID` from the tool
+    /// input). When the row is linked to a trip that HAS participants and
+    /// carries no split yet, seed an equal split across everyone (the user +
+    /// each participant, one share each) with the user as the payer — the same
+    /// default the trip AddExpense sheet applies. No-op for a standalone
+    /// expense, a trip with no participants, or a row that somehow already has a
+    /// split. The email path never lets the model emit split data, so this is
+    /// the only place a forwarded trip receipt becomes a group split.
+    private static func applyTripSplitDefaults(expenseUUID: UUID, store: SwiftDataStore) {
+        let key = expenseUUID.uuidString.lowercased()
+        guard let row = try? store.context.fetch(
+            FetchDescriptor<LocalExpense>(predicate: #Predicate { $0.clientUUID == key })
+        ).first else { return }
+        guard let tripUUID = row.tripUUID, row.splits.isEmpty else { return }
+
+        let tripFK = tripUUID
+        guard let trip = try? store.context.fetch(
+            FetchDescriptor<LocalTrip>(predicate: #Predicate { $0.clientUUID == tripFK })
+        ).first else { return }
+
+        let participants = trip.participantPersonUUIDs
+        guard !participants.isEmpty else { return }
+
+        // Full-bill convention: the row already stores the full amount (the
+        // email path never sets number_of_shares), and myShareSGD divides by the
+        // split shares. Everyone at one share = equal split; the user pays.
+        var entries: [ExpenseSplitEntry] = [ExpenseSplitEntry(person: nil, shares: 1)]
+        entries.append(contentsOf: participants.map { ExpenseSplitEntry(person: $0, shares: 1) })
+        row.splits = entries
+        row.paidByPersonUUID = nil
         try? store.context.save()
     }
 

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -133,11 +133,20 @@ struct ExecuteDraftAction {
         let personName = trimmedString(input["person_name"])
         let eventName = trimmedString(input["event_name"])
 
+        // Trip / group settle-up params (#258). When the model supplies
+        // `split_with` and/or `paid_by`, the row stores the FULL bill and the
+        // per-person breakdown lives in `splitsData` (applied after insert via
+        // `applyChatSplit`), so the #188 per-share division must be OFF —
+        // `numberOfShares` is forced to 1 here so `shareAmount` stays the full
+        // amount. Otherwise the #188 model applies as before.
+        let hasSplitParams = (input["split_with"]?.arrayValue?.isEmpty == false)
+            || (trimmedString(input["paid_by"]) != nil)
+
         // Optional split shares (#188). The model emits the FULL receipt total
         // in `original_amount` plus a share count; we store the user's equal
         // share (total / shares). Tolerate a JSON int, double, or numeric
         // string; clamp to >= 1 so a missing / bogus value behaves as unsplit.
-        let numberOfShares = max(
+        let numberOfShares = hasSplitParams ? 1 : max(
             input["number_of_shares"]?.intValue
                 ?? Int(input["number_of_shares"]?.stringValue ?? "")
                 ?? 1,
@@ -219,6 +228,13 @@ struct ExecuteDraftAction {
             tagged = true
         }
         if tagged {
+            try? save()
+        }
+
+        // Trip / group settle-up split (#258). Resolve `paid_by` + `split_with`
+        // names into a stored split (full-bill convention, `numberOfShares`
+        // already forced to 1 above). No-op when neither param is present.
+        if try applyChatSplit(input, to: row) {
             try? save()
         }
 
@@ -453,6 +469,82 @@ struct ExecuteDraftAction {
         f.dateFormat = "d MMM yyyy"
         return f
     }()
+
+    // MARK: - Trip / group split (#258)
+
+    /// Resolve the `paid_by` + `split_with` params on an `add_expense` call into
+    /// a stored settle-up split on `row`. Returns true when a split was
+    /// persisted (so the caller re-saves), false when the params imply a plain
+    /// personal expense (or are absent).
+    ///
+    /// Name mapping mirrors the existing `person_name` handling: each name is
+    /// find-or-created (case-insensitive) via `PersonService`, and the literal
+    /// "me"/"myself"/"I"/"you" maps to the user's own slice (nil personUUID).
+    /// The LLM decides who belongs in the list; this code only maps names — the
+    /// user is included only when the list names them (or when a person paid but
+    /// no split list was given, in which case the whole bill is the user's to
+    /// settle with that payer). Equal split (one share each) in v1.
+    ///
+    /// A split is persisted ONLY when someone other than the user is involved
+    /// (as payer or split party); "the user paid, only the user shares" stays an
+    /// ordinary personal expense so it counts fully in personal totals.
+    private func applyChatSplit(_ input: [String: AnthropicJSONValue], to row: LocalExpense) throws -> Bool {
+        let splitNames = input["split_with"]?.arrayValue?.compactMap { $0.stringValue } ?? []
+        let payerRaw = trimmedString(input["paid_by"])
+        guard !splitNames.isEmpty || payerRaw != nil else { return false }
+
+        let personService = PersonService(store: store)
+
+        // Payer: a named person, or the user ("me" / empty).
+        var payerUUID: UUID? = nil
+        var payerIsPerson = false
+        if let payerRaw, !Self.isMeToken(payerRaw) {
+            let person = try personService.findOrCreate(name: payerRaw)
+            payerUUID = person.clientUUID
+            payerIsPerson = true
+        }
+
+        // Split parties, in the order the model listed them, deduped. The user
+        // is included only when "me" appears in the list.
+        var entries: [ExpenseSplitEntry] = []
+        var seenPersons = Set<UUID>()
+        var includedMe = false
+        for name in splitNames {
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            if Self.isMeToken(trimmed) {
+                if !includedMe {
+                    entries.append(ExpenseSplitEntry(person: nil, shares: 1))
+                    includedMe = true
+                }
+            } else {
+                let person = try personService.findOrCreate(name: trimmed)
+                if seenPersons.insert(person.clientUUID).inserted {
+                    entries.append(ExpenseSplitEntry(person: person.clientUUID, shares: 1))
+                }
+            }
+        }
+
+        // A named payer with no split list → the whole bill is the user's to
+        // settle with that payer (the user owes the full amount).
+        if entries.isEmpty, payerIsPerson {
+            entries.append(ExpenseSplitEntry(person: nil, shares: 1))
+        }
+
+        // Only persist when someone other than the user is involved.
+        let hasOtherParty = payerIsPerson || entries.contains { $0.personUUID != nil }
+        guard hasOtherParty, !entries.isEmpty else { return false }
+
+        row.splits = entries
+        row.paidByPersonUUID = payerUUID
+        return true
+    }
+
+    /// True when a split name refers to the user rather than another person.
+    private static func isMeToken(_ raw: String) -> Bool {
+        let t = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return ["me", "myself", "i", "you", "self"].contains(t)
+    }
 
     // MARK: - CREATE
 

--- a/mobile/PersonalDashboard/AI/StatementImporter.swift
+++ b/mobile/PersonalDashboard/AI/StatementImporter.swift
@@ -173,9 +173,14 @@ struct StatementImporter {
     /// (`StatementExtractionError`); per-line insert failures are caught and
     /// counted in the result, never propagated, so one bad row can't sink the
     /// whole import.
-    func importStatement(pdfData: Data, fileName: String? = nil) async throws -> StatementImportResult {
+    /// `trip` (#258): when non-nil, every inserted row is linked to that trip and
+    /// — if the trip has participants — seeded with an equal split (everyone at
+    /// one share, the user as payer). nil keeps today's Finance behaviour (no
+    /// trip, no split). Dedup is unaffected: trip linkage is stamped AFTER the
+    /// dedup decisions, which never consider it.
+    func importStatement(pdfData: Data, fileName: String? = nil, trip: LocalTrip? = nil) async throws -> StatementImportResult {
         let (lines, meta, truncated) = try await anthropic.extractStatement(pdfData: pdfData)
-        return await insert(lines: lines, meta: meta, fileName: fileName, possiblyTruncated: truncated)
+        return await insert(lines: lines, meta: meta, fileName: fileName, possiblyTruncated: truncated, trip: trip)
     }
 
     /// Bucket + insert already-parsed lines. Split out from `importStatement`
@@ -203,7 +208,8 @@ struct StatementImporter {
         source: ExpenseSource = .pdf,
         receiptImagePath: String? = nil,
         recordsImportHistory: Bool = true,
-        possiblyTruncated: Bool
+        possiblyTruncated: Bool,
+        trip: LocalTrip? = nil
     ) async -> StatementImportResult {
         var imported = 0
         var refunds = 0
@@ -227,6 +233,14 @@ struct StatementImporter {
         let statementFileName = (fileName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let cardLabel = meta.cardLabel
         let paymentMethod = cardLabel.isEmpty ? nil : cardLabel
+
+        // Trip linkage + default split (#258), resolved once. When importing
+        // from a trip, every inserted row is stamped with the trip FK; if the
+        // trip has participants, it also gets an equal split (everyone at one
+        // share, the user as payer) under the full-bill convention
+        // (`numberOfShares` stays 1). nil trip → no linkage, no split.
+        let tripUUID = trip?.clientUUID
+        let tripParticipants = trip?.participantPersonUUIDs ?? []
 
         // One statement line reduced to everything the insert step needs, plus
         // its structural class key. Built in the classification pass below so the
@@ -441,6 +455,18 @@ struct StatementImporter {
                 // statement into a single Activity row titled by its file name,
                 // even when the header couldn't be parsed (empty statementLabel).
                 row.statementFileName = statementFileName
+                // Trip linkage + default split (#258). Stamped after the row is
+                // built; dedup already ran and never considered the trip, so a
+                // re-import stays idempotent regardless of trip linkage.
+                if let tripUUID {
+                    row.tripUUID = tripUUID
+                    if !tripParticipants.isEmpty {
+                        var entries: [ExpenseSplitEntry] = [ExpenseSplitEntry(person: nil, shares: 1)]
+                        entries.append(contentsOf: tripParticipants.map { ExpenseSplitEntry(person: $0, shares: 1) })
+                        row.splits = entries
+                        row.paidByPersonUUID = nil
+                    }
+                }
                 try? store.context.save()
 
                 imported += 1

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -431,34 +431,70 @@ enum ToolDefinitions {
     /// on-device after the tool call lands, so the LLM never needs to know
     /// FX rates. Category is one of the 13 canonical raw values — the model
     /// picks based on merchant + description.
-    private static let addExpense = AnthropicTool(
-        name: "add_expense",
-        description: "Log a NEW expense. Use this when the user says they spent money (e.g., \"I spent $20 on lunch at Starbucks\", \"add a 67 SGD grocery run yesterday\"). Pick the best-fitting category from the enum. If currency isn't specified, default to SGD. Date defaults to today if the user doesn't say. If the user names a person the expense is for/with (\"dinner with Sarah\") set person_name, and if they name an occasion or trip it belongs to (\"for the Bali trip\") set event_name — reuse the EXACT existing names from the PEOPLE / EVENTS context when they refer to one already there, so you don't create near-duplicates. If the user says the bill was split among several people (e.g., \"split 3 ways\", \"between the 4 of us\"), set number_of_shares to that count and pass the FULL receipt total in original_amount — the app records only the user's share.",
-        input_schema: object(
-            properties: [
-                "id": string("UUID string for the new expense. Generate a fresh one for every call (any valid lowercase UUID, e.g., 9b3a8e1c-2f6f-4a3b-9d2c-7e0a1b4c5d6e)."),
-                "date": string("ISO 8601 date the spend happened (e.g., 2026-05-22 or 2026-05-22T18:30:00Z). Use today's date if the user did not specify a date."),
-                "category": string("One of: food_and_dining, groceries, transport, shopping, entertainment, bills_and_utilities, rent, health_and_wellness, travel, subscriptions, personal_care, gifts_and_donations, other. Pick the best fit based on merchant and description (rent/lease payments -> rent)."),
-                "merchant": string("Merchant or vendor name (e.g., \"Starbucks\", \"FairPrice\"). Use empty string if unknown."),
-                "description": string("Short description of the expense (e.g., \"lunch with Sarah\", \"weekly groceries\"). Use empty string if none."),
-                "original_amount": .object([
-                    "type": .string("number"),
-                    "description": .string("Amount paid in the original currency. Must be greater than zero.")
-                ]),
-                "original_currency": string("ISO 4217 currency code (e.g., \"SGD\", \"USD\", \"EUR\"). Default to \"SGD\" if the user did not specify a currency."),
-                "payment_method": string("Optional payment method (e.g., \"Cash\", \"Visa **1234\"). Use empty string if unknown."),
-                "source": string("How this expense was captured. Use \"receipt\" ONLY when logging from a forwarded purchase/receipt email; leave empty otherwise. Allowed values: manual, text, voice, photo, receipt, pdf, recurring."),
-                "trip_id": string("UUID of the EXISTING trip this expense belongs to, when (and only when) it is a travel fare for a trip in the EXISTING TRIPS context (e.g., a flight or hotel charge). Use empty string for any non-travel purchase."),
-                "person_name": string("Name of the person this expense is for or with (e.g., \"Sarah\"), when the user names one. Reuse the exact name from the PEOPLE context if it already exists. Use empty string if none."),
-                "event_name": string("Name of the occasion, group, or trip this expense belongs to (e.g., \"Bali trip\", \"Diwali gifts\"), when the user names one. Reuse the exact name from the EVENTS context if it already exists. Use empty string if none."),
-                "number_of_shares": .object([
-                    "type": .string("integer"),
-                    "description": .string("How many people the bill was split among, when the user says it was shared (e.g. \"split 3 ways\" => 3). When set, original_amount MUST be the FULL receipt total — the app stores only the user's equal share (total / number_of_shares). Omit or use 1 for a normal unshared expense.")
-                ])
-            ],
-            required: ["id", "date", "category", "merchant", "description", "original_amount", "original_currency", "payment_method"]
+    ///
+    /// `includeSplitParams` gates the trip-settle-up params (`paid_by`,
+    /// `split_with`, #258). They ship on the chat / capture surface but are
+    /// deliberately withheld from the email path (`addExpenseEmailSafe`), whose
+    /// content is untrusted — the email path defaults trip splits in Swift
+    /// instead of letting the model emit split data.
+    private static func makeAddExpense(includeSplitParams: Bool) -> AnthropicTool {
+        var properties: [String: AnthropicJSONValue] = [
+            "id": string("UUID string for the new expense. Generate a fresh one for every call (any valid lowercase UUID, e.g., 9b3a8e1c-2f6f-4a3b-9d2c-7e0a1b4c5d6e)."),
+            "date": string("ISO 8601 date the spend happened (e.g., 2026-05-22 or 2026-05-22T18:30:00Z). Use today's date if the user did not specify a date."),
+            "category": string("One of: food_and_dining, groceries, transport, shopping, entertainment, bills_and_utilities, rent, health_and_wellness, travel, subscriptions, personal_care, gifts_and_donations, other. Pick the best fit based on merchant and description (rent/lease payments -> rent)."),
+            "merchant": string("Merchant or vendor name (e.g., \"Starbucks\", \"FairPrice\"). Use empty string if unknown."),
+            "description": string("Short description of the expense (e.g., \"lunch with Sarah\", \"weekly groceries\"). Use empty string if none."),
+            "original_amount": .object([
+                "type": .string("number"),
+                "description": .string("Amount paid in the original currency. Must be greater than zero.")
+            ]),
+            "original_currency": string("ISO 4217 currency code (e.g., \"SGD\", \"USD\", \"EUR\"). Default to \"SGD\" if the user did not specify a currency."),
+            "payment_method": string("Optional payment method (e.g., \"Cash\", \"Visa **1234\"). Use empty string if unknown."),
+            "source": string("How this expense was captured. Use \"receipt\" ONLY when logging from a forwarded purchase/receipt email; leave empty otherwise. Allowed values: manual, text, voice, photo, receipt, pdf, recurring."),
+            "trip_id": string("UUID of the EXISTING trip this expense belongs to, when (and only when) it is a travel fare for a trip in the EXISTING TRIPS context (e.g., a flight or hotel charge). Use empty string for any non-travel purchase."),
+            "person_name": string("Name of the person this expense is for or with (e.g., \"Sarah\"), when the user names one. Reuse the exact name from the PEOPLE context if it already exists. Use empty string if none."),
+            "event_name": string("Name of the occasion, group, or trip this expense belongs to (e.g., \"Bali trip\", \"Diwali gifts\"), when the user names one. Reuse the exact name from the EVENTS context if it already exists. Use empty string if none."),
+            "number_of_shares": .object([
+                "type": .string("integer"),
+                "description": .string("How many people the bill was split among, when the user says it was shared (e.g. \"split 3 ways\" => 3). When set, original_amount MUST be the FULL receipt total — the app stores only the user's equal share (total / number_of_shares). Omit or use 1 for a normal unshared expense. Prefer split_with (named people) over this when you know who was involved.")
+            ])
+        ]
+
+        // Trip settle-up params (#258). Optional; only meaningful for a trip
+        // expense (trip_id set) or when the user explicitly names who paid or
+        // who a bill is split between. When set, pass the FULL bill in
+        // original_amount and leave number_of_shares at 1 — the app records the
+        // per-person breakdown from split_with and nets it in settle-up.
+        if includeSplitParams {
+            properties["paid_by"] = string("OPTIONAL. Who fronted the money: a person's name, or \"me\" for the user. Only set when this is a trip expense (trip_id set) or the user says who paid (e.g. \"Sam paid\"). Reuse the exact name from the trip's participants / the PEOPLE context. Omit or use empty string when the user paid a normal solo expense.")
+            properties["split_with"] = arrayOf(
+                .object(["type": .string("string")]),
+                description: "OPTIONAL. The people the bill is split among, by name; include \"me\" for the user when their share is part of it. Equal split (one share each in v1). Only set when the user is splitting a bill — usually a trip expense (e.g. \"split between all of us\", \"me and Sam\"). Reuse the exact names from the trip's participants / the PEOPLE context. When set, pass the FULL bill in original_amount and leave number_of_shares at 1. Omit for a normal solo expense."
+            )
+        }
+
+        let description = "Log a NEW expense. Use this when the user says they spent money (e.g., \"I spent $20 on lunch at Starbucks\", \"add a 67 SGD grocery run yesterday\"). Pick the best-fitting category from the enum. If currency isn't specified, default to SGD. Date defaults to today if the user doesn't say. If the user names a person the expense is for/with (\"dinner with Sarah\") set person_name, and if they name an occasion or trip it belongs to (\"for the Bali trip\") set event_name — reuse the EXACT existing names from the PEOPLE / EVENTS context when they refer to one already there, so you don't create near-duplicates. If the user says the bill was split among several people (e.g., \"split 3 ways\", \"between the 4 of us\"), set number_of_shares to that count and pass the FULL receipt total in original_amount — the app records only the user's share."
+            + (includeSplitParams
+               ? " For a TRIP expense, or whenever the user names who paid or who a bill is shared with, set paid_by and/or split_with with the exact person names (use \"me\" for the user) instead of number_of_shares — these drive the trip settle-up. Only set them when a split/payer is actually implied."
+               : "")
+
+        return AnthropicTool(
+            name: "add_expense",
+            description: description,
+            input_schema: object(
+                properties: properties,
+                required: ["id", "date", "category", "merchant", "description", "original_amount", "original_currency", "payment_method"]
+            )
         )
-    )
+    }
+
+    /// Chat / capture add_expense — carries the trip settle-up params (#258).
+    private static let addExpense = makeAddExpense(includeSplitParams: true)
+
+    /// Email-path add_expense — WITHOUT the settle-up params (#258). The email
+    /// content is untrusted, so the model is never offered `paid_by` /
+    /// `split_with` there; the email path defaults trip splits in Swift.
+    static let addExpenseEmailSafe = makeAddExpense(includeSplitParams: false)
 
     /// Create a recurring monthly expense TEMPLATE (#236). Does NOT log an
     /// expense immediately — it defines a fixed monthly charge that the app

--- a/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
@@ -333,4 +333,23 @@ final class LocalExpense {
             .reduce(0) { $0 + max($1.shares, 0) }
         return signedSGD * (Double(myShares) / Double(totalShares))
     }
+
+    /// Signed amount in the currency the expense was captured in: negative for
+    /// refunds, mirroring `signedSGD`.
+    var signedOriginal: Double {
+        isRefund ? -originalAmount : originalAmount
+    }
+
+    /// `myShareSGD`'s twin in the captured currency, for surfaces that display
+    /// amounts as-added rather than converted (#258). Same shares math.
+    var myShareOriginal: Double {
+        let entries = splits
+        guard !entries.isEmpty else { return signedOriginal }
+        let totalShares = entries.reduce(0) { $0 + max($1.shares, 0) }
+        guard totalShares > 0 else { return signedOriginal }
+        let myShares = entries
+            .filter { $0.personUUID == nil }
+            .reduce(0) { $0 + max($1.shares, 0) }
+        return signedOriginal * (Double(myShares) / Double(totalShares))
+    }
 }

--- a/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
+++ b/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
@@ -712,7 +712,20 @@ struct AddExpenseSheet: View {
                     .font(.edCaption)
                     .monospacedDigit()
                     .foregroundStyle(Tokens.muted)
-                Stepper("", value: draft.shares, in: 1...20)
+                // Minusing down to 0 removes the person from the split (same
+                // as unticking them); shares reset to 1 so re-including starts
+                // clean rather than at a stale zero.
+                Stepper("", value: Binding(
+                    get: { draft.wrappedValue.shares },
+                    set: { newValue in
+                        if newValue <= 0 {
+                            draft.wrappedValue.included = false
+                            draft.wrappedValue.shares = 1
+                        } else {
+                            draft.wrappedValue.shares = newValue
+                        }
+                    }
+                ), in: 0...20)
                     .labelsHidden()
                     .tint(Tokens.accentFinance)
                     .fixedSize()

--- a/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
+++ b/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
@@ -170,7 +170,11 @@ struct AddExpenseSheet: View {
                         if let statement = statementLabel.trimmedNonEmpty {
                             statementAttribution(statement)
                         }
-                        personField
+                        // The "for/with person" tag (#183) is redundant on a
+                        // trip expense — "Split between" carries who it's for.
+                        if tripContext == nil {
+                            personField
+                        }
                         eventField
                         // Trip context with participants → full settle-up split
                         // UI (payer + per-person shares). Otherwise the existing

--- a/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
+++ b/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
@@ -712,28 +712,57 @@ struct AddExpenseSheet: View {
                     .font(.edCaption)
                     .monospacedDigit()
                     .foregroundStyle(Tokens.muted)
-                // Minusing down to 0 removes the person from the split (same
-                // as unticking them); shares reset to 1 so re-including starts
-                // clean rather than at a stale zero.
-                Stepper("", value: Binding(
-                    get: { draft.wrappedValue.shares },
-                    set: { newValue in
-                        if newValue <= 0 {
-                            draft.wrappedValue.included = false
-                            draft.wrappedValue.shares = 1
-                        } else {
-                            draft.wrappedValue.shares = newValue
-                        }
-                    }
-                ), in: 0...20)
-                    .labelsHidden()
-                    .tint(Tokens.accentFinance)
-                    .fixedSize()
-                    .accessibilityLabel("\(d.name) shares: \(d.shares)")
+                shareControl(draft)
             }
         }
         .padding(.horizontal, Space.md)
         .padding(.vertical, Space.sm)
+    }
+
+    /// Custom −/n/+ share control: unlike a bare `Stepper`, the current share
+    /// count sits visibly between the buttons. Minusing below 1 removes the
+    /// person from the split (same as unticking them); shares reset to 1 so
+    /// re-including starts clean.
+    private func shareControl(_ draft: Binding<SplitDraft>) -> some View {
+        HStack(spacing: 0) {
+            Button {
+                if draft.wrappedValue.shares <= 1 {
+                    draft.wrappedValue.included = false
+                    draft.wrappedValue.shares = 1
+                } else {
+                    draft.wrappedValue.shares -= 1
+                }
+            } label: {
+                Image(systemName: "minus")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Tokens.ink)
+                    .frame(width: 30, height: 26)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Fewer shares for \(draft.wrappedValue.name)")
+
+            Text("\(draft.wrappedValue.shares)")
+                .font(.edFootnoteStrong)
+                .monospacedDigit()
+                .foregroundStyle(Tokens.ink)
+                .frame(minWidth: 20)
+
+            Button {
+                draft.wrappedValue.shares = min(draft.wrappedValue.shares + 1, 20)
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Tokens.ink)
+                    .frame(width: 30, height: 26)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("More shares for \(draft.wrappedValue.name)")
+        }
+        .background(Tokens.surface2, in: RoundedRectangle(cornerRadius: Radius.sm))
+        .accessibilityElement(children: .contain)
+        .accessibilityValue("\(draft.wrappedValue.name) shares: \(draft.wrappedValue.shares)")
     }
 
     /// "Your share: CUR X of CUR Y" line, shown when the bill is shared.

--- a/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
+++ b/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
@@ -5,6 +5,11 @@ import SwiftData
 /// in by the parent so we don't couple the row to a sheet binding).
 struct ExpenseRow: View {
     let expense: LocalExpense
+    /// When true the row leads with the amount in the currency the expense was
+    /// CAPTURED in, and the converted display-currency figure becomes the
+    /// sub-label (trip surfaces default to as-added amounts, #258). False —
+    /// the Finance list — keeps the display-currency-first layout.
+    var showsOriginalFirst: Bool = false
     let onTap: () -> Void
 
     /// People, so a tagged expense's chip renders in that person's colour.
@@ -57,12 +62,12 @@ struct ExpenseRow: View {
                 // Refunds are money coming IN: shown in the success (green)
                 // colour with a leading "+" so they read as a credit against
                 // spend, distinct from a normal debit (#206).
-                Text(sgdAmountLabel)
+                Text(showsOriginalFirst ? originalAmountLabel : sgdAmountLabel)
                     .font(.edBodyMedium)
                     .monospacedDigit()
                     .foregroundStyle(expense.isRefund ? Tokens.success : Tokens.ink)
                 if showsOriginalAmount {
-                    Text(originalAmountLabel)
+                    Text(showsOriginalFirst ? sgdAmountLabel : originalAmountLabel)
                         .font(.edCaption)
                         .monospacedDigit()
                         .foregroundStyle(expense.isRefund ? Tokens.success.opacity(0.8) : Tokens.mutedSoft)
@@ -159,7 +164,13 @@ struct ExpenseRow: View {
     }
 
     private var groupSplitLabel: String {
-        "your \(FinanceDashboardBand.formatMoney(abs(expense.myShareSGD))) of \(FinanceDashboardBand.formatMoney(expense.sgdAmount))"
+        if showsOriginalFirst {
+            let code = expense.originalCurrency.uppercased()
+            let mine = TripExpensesView.formatOriginal(abs(expense.myShareOriginal), code: code)
+            let full = TripExpensesView.formatOriginal(expense.originalAmount, code: code)
+            return "your \(mine) of \(full)"
+        }
+        return "your \(FinanceDashboardBand.formatMoney(abs(expense.myShareSGD))) of \(FinanceDashboardBand.formatMoney(expense.sgdAmount))"
     }
 
     /// Split badge (#188). Same capsule shape as `PersonEventBadge` but muted

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -49,10 +49,16 @@ struct FinanceView: View {
     @State private var showingPhotoLibrary: Bool = false
     @State private var showingPDFPicker: Bool = false
 
-    /// Separate file-picker flag for the batch statement import (#184). Kept
-    /// distinct from `showingPDFPicker` (the single-receipt path) so the two
-    /// PDF flows don't share presentation state.
-    @State private var showingStatementPicker: Bool = false
+    /// Which flow the PDF picker serves. SwiftUI honours only one
+    /// `.fileImporter` per view — stacking a second silently breaks both — so
+    /// the single-receipt and statement paths share one picker and dispatch
+    /// on this purpose (#261).
+    @State private var pdfPickPurpose: PDFPickPurpose = .receipt
+
+    private enum PDFPickPurpose {
+        case receipt
+        case statement
+    }
 
     /// Presents the recurring-expense management sheet (#236).
     @State private var showingRecurring: Bool = false
@@ -115,11 +121,11 @@ struct FinanceView: View {
         .photoLibraryPicker(isPresented: $showingPhotoLibrary) { data in
             handleCaptureData(data, source: .photoLibrary)
         }
-        .pdfPicker(isPresented: $showingPDFPicker) { data, _ in
-            handleCaptureData(data, source: .pdf)
-        }
-        .pdfPicker(isPresented: $showingStatementPicker) { data, fileName in
-            handleStatementData(data, fileName: fileName)
+        .pdfPicker(isPresented: $showingPDFPicker) { data, fileName in
+            switch pdfPickPurpose {
+            case .receipt:   handleCaptureData(data, source: .pdf)
+            case .statement: handleStatementData(data, fileName: fileName)
+            }
         }
         .alert(
             // Source-agnostic: this summary now backs both statement imports
@@ -186,7 +192,8 @@ struct FinanceView: View {
                 Label("PDF from Files", systemImage: "doc.text")
             }
             Button {
-                showingStatementPicker = true
+                pdfPickPurpose = .statement
+                showingPDFPicker = true
             } label: {
                 Label("Import statement", systemImage: "doc.text.magnifyingglass")
             }
@@ -217,7 +224,9 @@ struct FinanceView: View {
         switch source {
         case .camera:        showingCamera = true
         case .photoLibrary:  showingPhotoLibrary = true
-        case .pdf:           showingPDFPicker = true
+        case .pdf:
+            pdfPickPurpose = .receipt
+            showingPDFPicker = true
         }
     }
 

--- a/mobile/PersonalDashboard/Views/Itineraries/ItinerariesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/ItinerariesView.swift
@@ -487,12 +487,14 @@ private struct TripEditorSheet: View {
             HStack {
                 Text("Participants").eyebrow()
                 Spacer()
-                Text("For splitting expenses")
+                // Headcount includes the user — "3 going" means You + 2.
+                Text("\(participantPeople.count + 1) going")
                     .font(.edCaption)
                     .foregroundStyle(Tokens.mutedSoft)
             }
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: Space.sm) {
+                    youChip
                     ForEach(participantPeople, id: \.clientUUID) { person in
                         participantChip(person)
                     }
@@ -518,6 +520,23 @@ private struct TripEditorSheet: View {
     /// Resolved participant records, preserving the stored order.
     private var participantPeople: [LocalPerson] {
         participantUUIDs.compactMap { id in allPeople.first { $0.clientUUID == id } }
+    }
+
+    /// The user's own chip — always first, not removable. Makes the headcount
+    /// readable at a glance ("You, Rohan, Sam" = 3 going).
+    private var youChip: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(Tokens.accentFinance)
+                .frame(width: 8, height: 8)
+            Text("You")
+                .font(.edFootnote)
+                .foregroundStyle(Tokens.ink)
+        }
+        .padding(.horizontal, Space.sm)
+        .padding(.vertical, 6)
+        .background(Tokens.surface2, in: Capsule())
+        .accessibilityLabel("You are going")
     }
 
     private func participantChip(_ person: LocalPerson) -> some View {

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -52,6 +52,24 @@ struct TripDetailView: View {
     /// happy and degraded paths always produce a card instead).
     @State private var ticketError: String?
 
+    // MARK: Expense upload / import state (#258)
+    /// Receipt-capture pickers for the Expenses tab. Kept distinct from the
+    /// ticket pickers above so the two upload flows don't share presentation
+    /// state. Mirrors FinanceView's capture menu, but scoped to this trip.
+    @State private var showingExpenseCamera: Bool = false
+    @State private var showingExpensePhotoLibrary: Bool = false
+    @State private var showingExpensePDFPicker: Bool = false
+    /// Separate flag for the batch statement import (distinct from the
+    /// single-receipt PDF picker above).
+    @State private var showingStatementPicker: Bool = false
+    /// Blocks the expense FAB and shows a lightweight overlay while a receipt /
+    /// statement upload extracts + imports in the background.
+    @State private var isProcessingExpenseUpload: Bool = false
+    /// Summary shown after a statement / multi-expense photo import completes.
+    @State private var statementImportSummary: String?
+    /// Hard-failure alert when an upload couldn't be processed at all.
+    @State private var expenseCaptureError: String?
+
     init(trip: LocalTrip) {
         self.trip = trip
         let tripID = trip.clientUUID
@@ -106,6 +124,10 @@ struct TripDetailView: View {
 
             if isProcessingTicket {
                 ticketProcessingOverlay
+            }
+
+            if isProcessingExpenseUpload {
+                expenseProcessingOverlay
             }
         }
         .sheet(item: $expenseEditorTarget) { target in
@@ -170,6 +192,49 @@ struct TripDetailView: View {
         } message: {
             Text(ticketError ?? "")
         }
+        // Expense-upload pickers (#258). Receipt/photo/PDF flow into the review
+        // sheet (which already carries this trip's context); a statement PDF
+        // batch-imports every line, linked to the trip.
+        .fullScreenCover(isPresented: $showingExpenseCamera) {
+            CameraPicker { data in
+                showingExpenseCamera = false
+                handleExpenseCaptureData(data, source: .camera)
+            }
+            .ignoresSafeArea()
+        }
+        .photoLibraryPicker(isPresented: $showingExpensePhotoLibrary) { data in
+            handleExpenseCaptureData(data, source: .photoLibrary)
+        }
+        .pdfPicker(isPresented: $showingExpensePDFPicker) { data, _ in
+            handleExpenseCaptureData(data, source: .pdf)
+        }
+        .pdfPicker(isPresented: $showingStatementPicker) { data, fileName in
+            handleStatementData(data, fileName: fileName)
+        }
+        .alert(
+            "Import complete",
+            isPresented: Binding(
+                get: { statementImportSummary != nil },
+                set: { if !$0 { statementImportSummary = nil } }
+            ),
+            presenting: statementImportSummary
+        ) { _ in
+            Button("OK", role: .cancel) { statementImportSummary = nil }
+        } message: { summary in
+            Text(summary)
+        }
+        .alert(
+            "Couldn't process receipt",
+            isPresented: Binding(
+                get: { expenseCaptureError != nil },
+                set: { if !$0 { expenseCaptureError = nil } }
+            ),
+            presenting: expenseCaptureError
+        ) { _ in
+            Button("OK", role: .cancel) { expenseCaptureError = nil }
+        } message: { message in
+            Text(message)
+        }
     }
 
     // MARK: - Tab bar
@@ -197,6 +262,26 @@ struct TripDetailView: View {
                 ProgressView()
                     .tint(Tokens.accent(for: .itineraries))
                 Text("Reading ticket…")
+                    .font(.edFootnote)
+                    .foregroundStyle(Tokens.inkSoft)
+            }
+            .padding(Space.xl)
+            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+            .paperBorder(Tokens.border, radius: Radius.lg)
+            .shadowMd()
+        }
+        .transition(.opacity)
+    }
+
+    /// Expense-upload processing overlay (#258). Same treatment as the ticket
+    /// overlay but finance-tinted and labelled for receipt / statement reads.
+    private var expenseProcessingOverlay: some View {
+        ZStack {
+            Color.black.opacity(0.12).ignoresSafeArea()
+            VStack(spacing: Space.md) {
+                ProgressView()
+                    .tint(Tokens.accentFinance)
+                Text("Reading receipt…")
                     .font(.edFootnote)
                     .foregroundStyle(Tokens.inkSoft)
             }
@@ -377,14 +462,46 @@ struct TripDetailView: View {
         .accessibilityLabel("Add to trip")
     }
 
-    /// Expenses FAB: opens the expense editor scoped to this trip.
+    /// Expenses FAB: a capture menu scoped to this trip (#258). Mirrors the
+    /// Finance capture menu — scan / photo / PDF / statement / manual — but
+    /// every path stamps this trip (and its default split) on the result.
     private var expenseFab: some View {
-        Button {
-            Haptics.light()
-            expenseEditorTarget = .new
+        Menu {
+            // Camera is hidden on hardware without one (simulator), where
+            // UIImagePickerController would silently fall back to the library.
+            if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                Button {
+                    showingExpenseCamera = true
+                } label: {
+                    Label("Scan receipt", systemImage: "camera")
+                }
+            }
+            Button {
+                showingExpensePhotoLibrary = true
+            } label: {
+                Label("Photo from library", systemImage: "photo.on.rectangle")
+            }
+            Button {
+                showingExpensePDFPicker = true
+            } label: {
+                Label("PDF from Files", systemImage: "doc.text")
+            }
+            Button {
+                showingStatementPicker = true
+            } label: {
+                Label("Import statement", systemImage: "doc.text.magnifyingglass")
+            }
+            Divider()
+            Button {
+                Haptics.light()
+                expenseEditorTarget = .new
+            } label: {
+                Label("Enter manually", systemImage: "pencil")
+            }
         } label: {
             fabCircle
         }
+        .disabled(isProcessingExpenseUpload)
         .accessibilityLabel("Add trip expense")
     }
 
@@ -435,6 +552,169 @@ struct TripDetailView: View {
             ticketError = (error as? LocalizedError)?.errorDescription
                 ?? "We couldn't save that ticket. Please try again."
         }
+    }
+
+    // MARK: - Expense upload / import (#258)
+
+    /// Picker callback for the receipt/photo/PDF flows. `data == nil` is a
+    /// cancel. Otherwise save + extract in the background.
+    private func handleExpenseCaptureData(_ data: Data?, source: FinanceCaptureSource) {
+        guard let data else { return }
+        Task { await processExpenseCapture(data: data, captureSource: source) }
+    }
+
+    /// Save the asset, extract it, and route into the trip-scoped review sheet.
+    /// Mirrors `FinanceView.processCapturedAsset`, but a single extracted
+    /// expense flows into the review sheet (which already carries this trip's
+    /// context — tripUUID + default split + payer You) rather than auto-adding,
+    /// so the user reviews the split before saving. A photo yielding 2+ lines
+    /// batch-imports through the trip-aware statement pipeline.
+    private func processExpenseCapture(data: Data, captureSource: FinanceCaptureSource) async {
+        let storage = ReceiptStorage.shared
+        let client = AnthropicClient()
+
+        withAnimation(.easeInOut(duration: 0.15)) { isProcessingExpenseUpload = true }
+        defer { withAnimation(.easeInOut(duration: 0.15)) { isProcessingExpenseUpload = false } }
+
+        // Persist the file. Images compress once (off the main actor) and reuse
+        // the JPEG for both the disk save and the Vision call, matching Finance.
+        let relativePath: String
+        let expenseSource: ExpenseSource
+        let visionImageData: Data?
+        do {
+            switch captureSource {
+            case .camera:
+                let compressed = try await Task.detached(priority: .userInitiated) {
+                    try storage.compress(imageData: data)
+                }.value
+                relativePath = try storage.saveCompressedJpeg(compressed)
+                expenseSource = .receipt
+                visionImageData = compressed
+            case .photoLibrary:
+                let compressed = try await Task.detached(priority: .userInitiated) {
+                    try storage.compress(imageData: data)
+                }.value
+                relativePath = try storage.saveCompressedJpeg(compressed)
+                expenseSource = .photo
+                visionImageData = compressed
+            case .pdf:
+                relativePath = try storage.save(pdfData: data)
+                expenseSource = .pdf
+                visionImageData = nil
+            }
+        } catch {
+            expenseCaptureError = error.localizedDescription
+            return
+        }
+
+        do {
+            switch captureSource {
+            case .camera, .photoLibrary:
+                let lines = try await client.extractExpenses(
+                    imageData: visionImageData ?? data,
+                    mediaType: "image/jpeg"
+                )
+                await handleExtractedTripPhotoLines(
+                    lines,
+                    receiptImagePath: relativePath,
+                    source: expenseSource
+                )
+            case .pdf:
+                let extracted = try await client.extractExpense(pdfData: data)
+                let prefill = PrefilledExpense.fromExtraction(
+                    extracted,
+                    receiptImagePath: relativePath,
+                    source: expenseSource
+                )
+                expenseEditorTarget = .prefilled(prefill)
+            }
+        } catch {
+            // Save the receipt regardless; open the review sheet with a banner.
+            let message: String = {
+                if let typed = error as? ReceiptExtractionError { return typed.localizedDescription }
+                if let typed = error as? StatementExtractionError { return typed.localizedDescription }
+                return "We saved your receipt but couldn't read it. Fill in the details below."
+            }()
+            let prefill = PrefilledExpense.fromFailure(
+                receiptImagePath: relativePath,
+                source: expenseSource,
+                message: message
+            )
+            expenseEditorTarget = .prefilled(prefill)
+        }
+    }
+
+    /// Route the expenses extracted from ONE photo, trip-scoped (#258):
+    /// 0 → review sheet with a banner; 1 → review sheet prefilled (trip context
+    /// seeds the split); 2+ → batch-import through the trip-aware statement
+    /// pipeline sharing the one saved receipt image.
+    private func handleExtractedTripPhotoLines(
+        _ lines: [ExtractedStatementLine],
+        receiptImagePath: String,
+        source: ExpenseSource
+    ) async {
+        switch lines.count {
+        case 0:
+            let prefill = PrefilledExpense.fromFailure(
+                receiptImagePath: receiptImagePath,
+                source: source,
+                message: "We saved your photo but couldn't read any expenses. Fill in the details below."
+            )
+            expenseEditorTarget = .prefilled(prefill)
+        case 1:
+            let prefill = PrefilledExpense.from(
+                line: lines[0],
+                receiptImagePath: receiptImagePath,
+                source: source
+            )
+            expenseEditorTarget = .prefilled(prefill)
+        default:
+            let result = await StatementImporter.default().insert(
+                lines: lines,
+                fileName: nil,
+                source: source,
+                receiptImagePath: receiptImagePath,
+                recordsImportHistory: false,
+                possiblyTruncated: false,
+                trip: trip
+            )
+            statementImportSummary = tripImportSummary(result.summaryLine)
+        }
+    }
+
+    /// Statement picker callback. `data == nil` is a cancel.
+    private func handleStatementData(_ data: Data?, fileName: String?) {
+        guard let data else { return }
+        Task { await importTripStatement(pdfData: data, fileName: fileName) }
+    }
+
+    /// Batch-import a statement PDF, linked to this trip (#258). Every inserted
+    /// row gets the trip FK and — when the trip has participants — the default
+    /// equal split. Dedup is unchanged.
+    private func importTripStatement(pdfData: Data, fileName: String? = nil) async {
+        withAnimation(.easeInOut(duration: 0.15)) { isProcessingExpenseUpload = true }
+        defer { withAnimation(.easeInOut(duration: 0.15)) { isProcessingExpenseUpload = false } }
+
+        do {
+            let result = try await StatementImporter.default().importStatement(
+                pdfData: pdfData,
+                fileName: fileName,
+                trip: trip
+            )
+            statementImportSummary = tripImportSummary(result.summaryLine)
+        } catch {
+            let message: String = {
+                if let typed = error as? StatementExtractionError { return typed.localizedDescription }
+                return "We couldn't read this statement. Make sure it's a text-based PDF (not a photo) and try again."
+            }()
+            expenseCaptureError = message
+        }
+    }
+
+    /// Append the trip name to a batch-import summary so it's clear the rows
+    /// landed on this trip (#258).
+    private func tripImportSummary(_ base: String) -> String {
+        "\(base) · Added to \(trip.name)"
     }
 
     // MARK: - Grouping

--- a/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripDetailView.swift
@@ -38,8 +38,6 @@ struct TripDetailView: View {
 
     // MARK: Ticket upload / scan state (#222)
     @State private var showingTicketCamera: Bool = false
-    @State private var showingTicketPhotoLibrary: Bool = false
-    @State private var showingTicketPDFPicker: Bool = false
     /// Blocks the FAB and shows a lightweight "Reading ticket…" overlay while
     /// the decode + extraction pipeline runs.
     @State private var isProcessingTicket: Bool = false
@@ -53,15 +51,9 @@ struct TripDetailView: View {
     @State private var ticketError: String?
 
     // MARK: Expense upload / import state (#258)
-    /// Receipt-capture pickers for the Expenses tab. Kept distinct from the
-    /// ticket pickers above so the two upload flows don't share presentation
-    /// state. Mirrors FinanceView's capture menu, but scoped to this trip.
+    /// Camera cover for the Expenses tab, distinct from the ticket camera so
+    /// the two capture flows keep separate handlers.
     @State private var showingExpenseCamera: Bool = false
-    @State private var showingExpensePhotoLibrary: Bool = false
-    @State private var showingExpensePDFPicker: Bool = false
-    /// Separate flag for the batch statement import (distinct from the
-    /// single-receipt PDF picker above).
-    @State private var showingStatementPicker: Bool = false
     /// Blocks the expense FAB and shows a lightweight overlay while a receipt /
     /// statement upload extracts + imports in the background.
     @State private var isProcessingExpenseUpload: Bool = false
@@ -69,6 +61,27 @@ struct TripDetailView: View {
     @State private var statementImportSummary: String?
     /// Hard-failure alert when an upload couldn't be processed at all.
     @State private var expenseCaptureError: String?
+
+    // MARK: Shared pickers (#261)
+    /// SwiftUI honours only one `.fileImporter` (and one `.photosPicker`) per
+    /// view — stacking a second silently breaks presentation — so the ticket
+    /// and expense flows share one picker of each kind and dispatch on a
+    /// purpose set by the menu button that opened it.
+    @State private var showingPDFPicker: Bool = false
+    @State private var pdfPickPurpose: PDFPickPurpose = .ticket
+    @State private var showingPhotoLibrary: Bool = false
+    @State private var photoPickPurpose: PhotoPickPurpose = .ticket
+
+    private enum PDFPickPurpose {
+        case ticket
+        case expenseReceipt
+        case statement
+    }
+
+    private enum PhotoPickPurpose {
+        case ticket
+        case expense
+    }
 
     init(trip: LocalTrip) {
         self.trip = trip
@@ -149,11 +162,18 @@ struct TripDetailView: View {
             }
             .ignoresSafeArea()
         }
-        .photoLibraryPicker(isPresented: $showingTicketPhotoLibrary) { data in
-            handleTicketData(data, isPDF: false)
+        .photoLibraryPicker(isPresented: $showingPhotoLibrary) { data in
+            switch photoPickPurpose {
+            case .ticket:  handleTicketData(data, isPDF: false)
+            case .expense: handleExpenseCaptureData(data, source: .photoLibrary)
+            }
         }
-        .pdfPicker(isPresented: $showingTicketPDFPicker) { data, _ in
-            handleTicketData(data, isPDF: true)
+        .pdfPicker(isPresented: $showingPDFPicker) { data, fileName in
+            switch pdfPickPurpose {
+            case .ticket:         handleTicketData(data, isPDF: true)
+            case .expenseReceipt: handleExpenseCaptureData(data, source: .pdf)
+            case .statement:      handleStatementData(data, fileName: fileName)
+            }
         }
         // Full-screen scan surface for a ticket card tap (or right after a
         // successful upload).
@@ -192,8 +212,9 @@ struct TripDetailView: View {
         } message: {
             Text(ticketError ?? "")
         }
-        // Expense-upload pickers (#258). Receipt/photo/PDF flow into the review
-        // sheet (which already carries this trip's context); a statement PDF
+        // Expense camera (#258). Photo / PDF / statement uploads go through the
+        // shared pickers above (#261); receipt results flow into the review
+        // sheet (which already carries this trip's context), a statement PDF
         // batch-imports every line, linked to the trip.
         .fullScreenCover(isPresented: $showingExpenseCamera) {
             CameraPicker { data in
@@ -201,15 +222,6 @@ struct TripDetailView: View {
                 handleExpenseCaptureData(data, source: .camera)
             }
             .ignoresSafeArea()
-        }
-        .photoLibraryPicker(isPresented: $showingExpensePhotoLibrary) { data in
-            handleExpenseCaptureData(data, source: .photoLibrary)
-        }
-        .pdfPicker(isPresented: $showingExpensePDFPicker) { data, _ in
-            handleExpenseCaptureData(data, source: .pdf)
-        }
-        .pdfPicker(isPresented: $showingStatementPicker) { data, fileName in
-            handleStatementData(data, fileName: fileName)
         }
         .alert(
             "Import complete",
@@ -446,12 +458,14 @@ struct TripDetailView: View {
                 }
             }
             Button {
-                showingTicketPhotoLibrary = true
+                photoPickPurpose = .ticket
+                showingPhotoLibrary = true
             } label: {
                 Label("Ticket from Photos", systemImage: "photo")
             }
             Button {
-                showingTicketPDFPicker = true
+                pdfPickPurpose = .ticket
+                showingPDFPicker = true
             } label: {
                 Label("Ticket from PDF", systemImage: "doc.text")
             }
@@ -477,17 +491,20 @@ struct TripDetailView: View {
                 }
             }
             Button {
-                showingExpensePhotoLibrary = true
+                photoPickPurpose = .expense
+                showingPhotoLibrary = true
             } label: {
                 Label("Photo from library", systemImage: "photo.on.rectangle")
             }
             Button {
-                showingExpensePDFPicker = true
+                pdfPickPurpose = .expenseReceipt
+                showingPDFPicker = true
             } label: {
                 Label("PDF from Files", systemImage: "doc.text")
             }
             Button {
-                showingStatementPicker = true
+                pdfPickPurpose = .statement
+                showingPDFPicker = true
             } label: {
                 Label("Import statement", systemImage: "doc.text.magnifyingglass")
             }

--- a/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
@@ -9,6 +9,12 @@ import SwiftData
 /// count), netted settle-up balances ("Rohan is owed S$140"), and the expense
 /// list itself. Adding / editing goes through `AddExpenseSheet` with a trip
 /// context, driven by the parent `TripDetailView` (which owns the sheet + FAB).
+/// Participants are managed in the trip editor (Edit trip on the Itineraries
+/// list), not here.
+///
+/// Amounts default to the currency each expense was CAPTURED in — a trip's
+/// spend reads naturally in euros on a Europe trip. A toggle on the stats card
+/// converts the whole tab to the chosen display currency on demand.
 struct TripExpensesView: View {
     let trip: LocalTrip
 
@@ -23,13 +29,9 @@ struct TripExpensesView: View {
     @Query(sort: [SortDescriptor(\LocalPerson.name, order: .forward)])
     private var people: [LocalPerson]
 
-    /// In-place participant management (#261 QA follow-up). Splitting is only
-    /// offered once the trip has participants, and burying that in the trip
-    /// editor on the Itineraries list made it undiscoverable — so the Expenses
-    /// tab manages the group directly. Reuses `PersonPickerSheet`
-    /// (find-or-create by name), same as the trip editor.
-    @State private var pickedParticipant: ExpenseTag?
-    @State private var showingParticipantPicker: Bool = false
+    /// False (default) = amounts render in the currency each expense was
+    /// captured in. True = everything converts to the chosen display currency.
+    @State private var showConverted: Bool = false
 
     init(trip: LocalTrip, onEditExpense: @escaping (String) -> Void) {
         self.trip = trip
@@ -45,144 +47,137 @@ struct TripExpensesView: View {
     }
 
     var body: some View {
+        Group {
+            if expenses.isEmpty {
+                emptyState
+            } else {
+                populated
+            }
+        }
+    }
+
+    // MARK: - Populated
+
+    private var populated: some View {
         ScrollView {
             VStack(spacing: Space.lg) {
-                peopleCard
-                if expenses.isEmpty {
-                    emptyState
-                } else {
-                    statsCard
-                    if !balances.isEmpty {
-                        settleUpCard
-                    }
-                    expenseList
+                statsCard
+                if !balances.isEmpty {
+                    settleUpCard
                 }
+                expenseList
                 Color.clear.frame(height: 96)
             }
             .padding(.horizontal, Space.lg)
             .padding(.top, Space.lg)
         }
         .scrollDismissesKeyboard(.interactively)
-        .sheet(isPresented: $showingParticipantPicker) {
-            PersonPickerSheet(selection: $pickedParticipant)
-                .presentationDetents([.medium, .large])
-                .presentationDragIndicator(.visible)
-        }
-        .onChange(of: pickedParticipant) { _, newValue in
-            if let tag = newValue, !trip.participantPersonUUIDs.contains(tag.uuid) {
-                trip.participantPersonUUIDs.append(tag.uuid)
-            }
-            // Reset so picking the same person twice in a row still fires.
-            pickedParticipant = nil
-        }
     }
 
-    // MARK: - People
+    // MARK: - Currency mode
 
-    /// Resolved participant records, preserving the stored order.
-    private var participantPeople: [LocalPerson] {
-        trip.participantPersonUUIDs.compactMap { id in
-            people.first { $0.clientUUID == id }
+    /// Per-currency signed totals in capture currency, largest spend first.
+    private var totalsByCurrency: [(code: String, total: Double, myShare: Double)] {
+        var totals: [String: (total: Double, myShare: Double)] = [:]
+        for expense in expenses {
+            let code = expense.originalCurrency.uppercased()
+            var entry = totals[code] ?? (0, 0)
+            entry.total += expense.signedOriginal
+            entry.myShare += expense.myShareOriginal
+            totals[code] = entry
         }
+        return totals
+            .map { (code: $0.key, total: $0.value.total, myShare: $0.value.myShare) }
+            .sorted { abs($0.total) > abs($1.total) }
     }
 
-    /// Who's on this trip. Add / remove writes straight to the trip, so the
-    /// next expense immediately offers the split UI. Removing someone never
-    /// touches splits already stored on expenses — settle-up resolves names
-    /// from the people table, not this list.
-    private var peopleCard: some View {
-        VStack(alignment: .leading, spacing: Space.sm) {
-            HStack {
-                Text("People").eyebrow()
-                Spacer()
-                Text("For splitting expenses")
-                    .font(.edCaption)
-                    .foregroundStyle(Tokens.mutedSoft)
-            }
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Space.sm) {
-                    ForEach(participantPeople, id: \.clientUUID) { person in
-                        participantChip(person)
-                    }
-                    addParticipantChip
-                }
-                .padding(.vertical, 2)
-            }
-            if participantPeople.isEmpty {
-                Text("Add the people on this trip to split expenses and see who owes whom.")
-                    .font(.edCaption)
-                    .foregroundStyle(Tokens.muted)
-            }
-        }
-        .padding(Space.lg)
-        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
-        .paperBorder(Tokens.border, radius: Radius.lg)
+    /// Non-nil when every expense was captured in the same currency — the only
+    /// case where settle-up can run natively in the capture currency.
+    private var singleCurrencyCode: String? {
+        let codes = Set(expenses.map { $0.originalCurrency.uppercased() })
+        return codes.count == 1 ? codes.first : nil
     }
 
-    private func participantChip(_ person: LocalPerson) -> some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(Color(personHex: person.colorHex))
-                .frame(width: 8, height: 8)
-            Text(person.name)
-                .font(.edFootnote)
-                .foregroundStyle(Tokens.ink)
-                .lineLimit(1)
-            Button {
-                trip.participantPersonUUIDs.removeAll { $0 == person.clientUUID }
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundStyle(Tokens.mutedSoft)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Remove \(person.name)")
-        }
-        .padding(.leading, Space.sm)
-        .padding(.trailing, Space.xs + 2)
-        .padding(.vertical, 6)
-        .background(Tokens.surface2, in: Capsule())
+    /// "EUR 1,240.50", signed. Capture-currency counterpart of
+    /// `FinanceDashboardBand.formatMoney` (which converts to the display
+    /// currency and uses its symbol).
+    static func formatOriginal(_ value: Double, code: String) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 2
+        let amount = formatter.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value)
+        return "\(code) \(amount)"
     }
 
-    private var addParticipantChip: some View {
+    private var displayCurrencyCode: String {
+        FinanceSettings.displayCurrencyCode.uppercased()
+    }
+
+    /// Small capsule that flips the tab between as-captured and converted
+    /// amounts. Labelled with the mode a tap switches TO.
+    private var currencyToggle: some View {
         Button {
-            showingParticipantPicker = true
+            withAnimation(.easeInOut(duration: 0.15)) { showConverted.toggle() }
         } label: {
             HStack(spacing: 4) {
-                Image(systemName: "plus")
-                    .font(.system(size: 10, weight: .semibold))
-                Text("Add")
-                    .font(.edFootnote)
+                Image(systemName: "arrow.left.arrow.right")
+                    .font(.system(size: 9, weight: .semibold))
+                Text(showConverted ? "As added" : displayCurrencyCode)
+                    .font(.edCaption)
             }
             .foregroundStyle(Tokens.accentFinance)
             .padding(.horizontal, Space.sm)
-            .padding(.vertical, 6)
+            .padding(.vertical, 4)
             .background(Tokens.accentFinance.opacity(0.12), in: Capsule())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Add participant")
+        .accessibilityLabel(showConverted
+            ? "Show amounts in the currency they were added in"
+            : "Show amounts in \(displayCurrencyCode)")
     }
 
     // MARK: - Stats card
 
-    private var groupTotal: Double {
+    private var groupTotalSGD: Double {
         expenses.reduce(0) { $0 + $1.signedSGD }
     }
 
-    private var yourShare: Double {
+    private var yourShareSGD: Double {
         expenses.reduce(0) { $0 + $1.myShareSGD }
     }
 
     private var statsCard: some View {
         VStack(alignment: .leading, spacing: Space.md) {
-            Text("Group total").eyebrow()
-            Text(FinanceDashboardBand.formatMoney(groupTotal))
-                .font(.edDisplay)
-                .foregroundStyle(Tokens.ink)
-                .tracking(-0.6)
+            HStack {
+                Text("Group total").eyebrow()
+                Spacer()
+                currencyToggle
+            }
+
+            if showConverted {
+                Text(FinanceDashboardBand.formatMoney(groupTotalSGD))
+                    .font(.edDisplay)
+                    .foregroundStyle(Tokens.ink)
+                    .tracking(-0.6)
+            } else {
+                let totals = totalsByCurrency
+                if let first = totals.first {
+                    Text(Self.formatOriginal(first.total, code: first.code))
+                        .font(.edDisplay)
+                        .foregroundStyle(Tokens.ink)
+                        .tracking(-0.6)
+                }
+                ForEach(totals.dropFirst(), id: \.code) { entry in
+                    Text(Self.formatOriginal(entry.total, code: entry.code))
+                        .font(.edBodyMedium)
+                        .monospacedDigit()
+                        .foregroundStyle(Tokens.inkSoft)
+                }
+            }
 
             HStack(spacing: Space.lg) {
-                statTile(label: "Your share", value: FinanceDashboardBand.formatMoney(yourShare))
+                statTile(label: "Your share", value: yourShareLabel)
                 statTile(label: "Expenses", value: "\(expenses.count)")
             }
             .padding(.top, Space.xs)
@@ -191,6 +186,15 @@ struct TripExpensesView: View {
         .padding(Space.lg)
         .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
         .paperBorder(Tokens.border, radius: Radius.lg)
+    }
+
+    private var yourShareLabel: String {
+        if showConverted {
+            return FinanceDashboardBand.formatMoney(yourShareSGD)
+        }
+        return totalsByCurrency
+            .map { Self.formatOriginal($0.myShare, code: $0.code) }
+            .joined(separator: " · ")
     }
 
     private func statTile(label: String, value: String) -> some View {
@@ -207,15 +211,41 @@ struct TripExpensesView: View {
 
     // MARK: - Settle up
 
+    /// True when the settle-up card can run natively in the capture currency:
+    /// the user wants as-added amounts AND the trip is single-currency. A
+    /// mixed-currency trip has no meaningful "as added" net, so it falls back
+    /// to the display currency (flagged in the card).
+    private var settlesInCaptureCurrency: Bool {
+        !showConverted && singleCurrencyCode != nil
+    }
+
     /// Netted per-party balances, sorted with the user first, then the people
     /// who are owed the most. Only parties whose net is more than a cent show.
     private var balances: [TripSettlement.Balance] {
-        TripSettlement.compute(expenses: expenses)
+        if settlesInCaptureCurrency {
+            return TripSettlement.compute(expenses: expenses) { $0.signedOriginal }
+        }
+        return TripSettlement.compute(expenses: expenses)
+    }
+
+    private func settleAmount(_ value: Double) -> String {
+        if settlesInCaptureCurrency, let code = singleCurrencyCode {
+            return Self.formatOriginal(value, code: code)
+        }
+        return FinanceDashboardBand.formatMoney(value)
     }
 
     private var settleUpCard: some View {
         VStack(alignment: .leading, spacing: Space.md) {
-            Text("Settle up").eyebrow()
+            HStack {
+                Text("Settle up").eyebrow()
+                if !showConverted && singleCurrencyCode == nil {
+                    Spacer()
+                    Text("in \(displayCurrencyCode) · mixed currencies")
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.mutedSoft)
+                }
+            }
             VStack(spacing: Space.sm) {
                 ForEach(balances) { balance in
                     settleRow(balance)
@@ -241,13 +271,13 @@ struct TripExpensesView: View {
                 .foregroundStyle(Tokens.inkSoft)
                 .lineLimit(1)
             Spacer(minLength: Space.sm)
-            Text(FinanceDashboardBand.formatMoney(abs(balance.net)))
+            Text(settleAmount(abs(balance.net)))
                 .font(.edFootnoteStrong)
                 .monospacedDigit()
                 .foregroundStyle(owed ? Tokens.success : Tokens.ink)
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(phrase(for: balance)) \(FinanceDashboardBand.formatMoney(abs(balance.net)))")
+        .accessibilityLabel("\(phrase(for: balance)) \(settleAmount(abs(balance.net)))")
     }
 
     /// "You are owed" / "You owe" / "Rohan is owed" / "Sam owes".
@@ -285,7 +315,7 @@ struct TripExpensesView: View {
             Text("Expenses").eyebrow()
             VStack(spacing: Space.xs) {
                 ForEach(expenses) { expense in
-                    ExpenseRow(expense: expense) {
+                    ExpenseRow(expense: expense, showsOriginalFirst: !showConverted) {
                         onEditExpense(expense.clientUUID)
                     }
                 }
@@ -295,28 +325,31 @@ struct TripExpensesView: View {
 
     // MARK: - Empty state
 
-    /// Rendered inside the scroll column, under the people card.
     private var emptyState: some View {
         VStack(spacing: 0) {
-            Image(systemName: "wallet.bifold")
-                .font(.system(size: 32, weight: .light))
-                .foregroundStyle(Tokens.mutedSoft)
-            Spacer().frame(height: Space.md)
-            Text("No expenses yet")
-                .font(.edTitle)
-                .foregroundStyle(Tokens.ink)
-                .multilineTextAlignment(.center)
-            Spacer().frame(height: Space.xs)
-            Text(trip.participantPersonUUIDs.isEmpty
-                 ? "Add the people above, then tap + to log an expense and split it."
-                 : "Tap + to log a trip expense and split it with your group.")
-                .font(.edSubheadline)
-                .foregroundStyle(Tokens.muted)
-                .multilineTextAlignment(.center)
+            Spacer()
+            VStack(spacing: 0) {
+                Image(systemName: "wallet.bifold")
+                    .font(.system(size: 32, weight: .light))
+                    .foregroundStyle(Tokens.mutedSoft)
+                Spacer().frame(height: Space.md)
+                Text("No expenses yet")
+                    .font(.edTitle)
+                    .foregroundStyle(Tokens.ink)
+                    .multilineTextAlignment(.center)
+                Spacer().frame(height: Space.xs)
+                Text(trip.participantPersonUUIDs.isEmpty
+                     ? "Tap + to log a trip expense. Add people in Edit trip to split the bill."
+                     : "Tap + to log a trip expense and split it with your group.")
+                    .font(.edSubheadline)
+                    .foregroundStyle(Tokens.muted)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: 300)
+            Spacer()
         }
-        .frame(maxWidth: 300)
-        .frame(maxWidth: .infinity)
-        .padding(.top, Space.xxl)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, Space.lg)
     }
 }
 
@@ -324,10 +357,12 @@ struct TripExpensesView: View {
 
 /// Pure settle-up computation over a trip's expenses (#258).
 ///
-/// Runs entirely on the frozen home-currency amounts (`signedSGD`) so a
-/// mixed-currency trip nets correctly and refunds subtract. For each party the
-/// net position is `totalPaid - totalOwedShare`: positive means the party is
-/// owed money by the group, negative means they owe. The group nets to zero.
+/// Runs on a caller-supplied signed amount per expense — the frozen
+/// home-currency `signedSGD` by default (correct for mixed-currency trips),
+/// or `signedOriginal` when the whole trip shares one capture currency. For
+/// each party the net position is `totalPaid - totalOwedShare`: positive means
+/// the party is owed money by the group, negative means they owe. The group
+/// nets to zero.
 ///
 /// An UNSPLIT expense is owed entirely by whoever paid it, so it nets to zero
 /// for that party and never creates a balance — exactly right for a personal
@@ -335,7 +370,7 @@ struct TripExpensesView: View {
 enum TripSettlement {
     struct Balance: Identifiable {
         let party: SplitPartyID
-        /// Home-currency net. > 0 owed money, < 0 owes.
+        /// Signed net in the caller's amount basis. > 0 owed money, < 0 owes.
         let net: Double
         var id: SplitPartyID { party }
     }
@@ -344,31 +379,34 @@ enum TripSettlement {
     /// dropped from the list.
     private static let epsilon = 0.005
 
-    static func compute(expenses: [LocalExpense]) -> [Balance] {
+    static func compute(
+        expenses: [LocalExpense],
+        amount: (LocalExpense) -> Double = { $0.signedSGD }
+    ) -> [Balance] {
         var paid: [SplitPartyID: Double] = [:]
         var owed: [SplitPartyID: Double] = [:]
 
         for expense in expenses {
-            let amount = expense.signedSGD
+            let value = amount(expense)
             let payer: SplitPartyID = expense.paidByPersonUUID.map { .person($0) } ?? .me
-            paid[payer, default: 0] += amount
+            paid[payer, default: 0] += value
 
             let splits = expense.splits
             if splits.isEmpty {
                 // Unsplit: the payer bears the whole cost (nets to zero).
-                owed[payer, default: 0] += amount
+                owed[payer, default: 0] += value
                 continue
             }
             let totalShares = splits.reduce(0) { $0 + max($1.shares, 0) }
             guard totalShares > 0 else {
-                owed[payer, default: 0] += amount
+                owed[payer, default: 0] += value
                 continue
             }
             for entry in splits {
                 let shares = max(entry.shares, 0)
                 guard shares > 0 else { continue }
                 let party: SplitPartyID = entry.personID.map { .person($0) } ?? .me
-                owed[party, default: 0] += amount * Double(shares) / Double(totalShares)
+                owed[party, default: 0] += value * Double(shares) / Double(totalShares)
             }
         }
 

--- a/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
@@ -29,10 +29,11 @@ struct TripExpensesView: View {
     @Query(sort: [SortDescriptor(\LocalPerson.name, order: .forward)])
     private var people: [LocalPerson]
 
-    /// Whose numbers the summary card shows (and, for non-You selections,
-    /// which expenses the list narrows to). Defaults to the user — the tab's
-    /// core question is "how much have I spent on this trip".
-    @State private var filterParty: SplitPartyID = .me
+    /// Whose numbers the summary card shows (and, for non-default selections,
+    /// which expenses the list narrows to). Multi-select; never empty.
+    /// Defaults to just the user — the tab's core question is "how much have
+    /// I spent on this trip".
+    @State private var filterParties: Set<SplitPartyID> = [.me]
     /// Currency the summary card renders in. `nil` = the Settings display
     /// currency; otherwise one of the currencies captured on this trip
     /// (converted through the trip's own frozen FX observations).
@@ -84,7 +85,7 @@ struct TripExpensesView: View {
                 participants: participantPeople,
                 currencyOptions: filterCurrencyOptions,
                 displayCode: displayCurrencyCode,
-                party: $filterParty,
+                parties: $filterParties,
                 currency: $filterCurrency
             )
             .presentationDetents([.medium, .large])
@@ -134,39 +135,64 @@ struct TripExpensesView: View {
         return Self.formatOriginal(sgdValue / rate, code: code)
     }
 
-    private var filterPartyName: String {
-        switch filterParty {
-        case .me: return "You"
-        case .person(let id): return personName(id)
+    /// Selected party names in stable order: You first, then trip-participant
+    /// order.
+    private var selectedPartyNames: [String] {
+        var names: [String] = []
+        if filterParties.contains(.me) { names.append("You") }
+        for person in participantPeople where filterParties.contains(.person(person.clientUUID)) {
+            names.append(person.name)
         }
+        return names
+    }
+
+    /// "Your spend" / "Rohan's spend" / "You + Rohan" / "3 people".
+    private var summaryTitle: String {
+        let names = selectedPartyNames
+        if filterParties == [.me] { return "Your spend" }
+        if names.count == 1 { return names[0] == "You" ? "Your spend" : "\(names[0])'s spend" }
+        if names.count == 2 { return "\(names[0]) + \(names[1])" }
+        return "\(names.count) people"
+    }
+
+    /// Short list-header suffix for the active selection.
+    private var selectionShortLabel: String {
+        let names = selectedPartyNames
+        if names.count <= 2 { return names.joined(separator: " + ") }
+        return "\(names.count) people"
     }
 
     /// The card that answers "how much have I spent on this trip" — and the
-    /// same for any participant via the filter. Spent = their consumed share
-    /// across the bills; Paid = what they fronted; the net line is the
-    /// settle-up position.
+    /// same for any set of participants via the filter. Spent = their combined
+    /// consumed share across the bills; Paid = what they fronted; the net line
+    /// is their combined settle-up position.
     private var personSummaryCard: some View {
-        let totals = TripSettlement.totals(expenses: expenses)[filterParty] ?? (paid: 0, owed: 0)
-        let net = totals.paid - totals.owed
-        let isMe = filterParty == .me
+        let allTotals = TripSettlement.totals(expenses: expenses)
+        let paid = filterParties.reduce(0) { $0 + (allTotals[$1]?.paid ?? 0) }
+        let owed = filterParties.reduce(0) { $0 + (allTotals[$1]?.owed ?? 0) }
+        let net = paid - owed
+        let meOnly = filterParties == [.me]
+        let single = filterParties.count == 1
+        let owedLabel: String = {
+            if meOnly { return net >= 0 ? "You are owed" : "You owe" }
+            if single { return net >= 0 ? "Is owed" : "Owes" }
+            return net >= 0 ? "Owed" : "Owe"
+        }()
         return VStack(alignment: .leading, spacing: Space.md) {
             HStack {
-                Text(isMe ? "Your spend" : "\(filterPartyName)'s spend").eyebrow()
+                Text(summaryTitle).eyebrow()
                 Spacer()
                 filterButton
             }
 
-            Text(formatFiltered(totals.owed))
+            Text(formatFiltered(owed))
                 .font(.edDisplay)
                 .foregroundStyle(Tokens.ink)
                 .tracking(-0.6)
 
             HStack(spacing: Space.lg) {
-                statTile(label: "Paid", value: formatFiltered(totals.paid))
-                statTile(
-                    label: net >= 0 ? (isMe ? "You are owed" : "Is owed") : (isMe ? "You owe" : "Owes"),
-                    value: formatFiltered(abs(net))
-                )
+                statTile(label: "Paid", value: formatFiltered(paid))
+                statTile(label: owedLabel, value: formatFiltered(abs(net)))
             }
             .padding(.top, Space.xs)
         }
@@ -180,19 +206,13 @@ struct TripExpensesView: View {
         Button {
             showingFilter = true
         } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "line.3.horizontal.decrease.circle")
-                    .font(.system(size: 11, weight: .semibold))
-                Text(filterCurrency ?? displayCurrencyCode)
-                    .font(.edCaption)
-            }
-            .foregroundStyle(Tokens.accentFinance)
-            .padding(.horizontal, Space.sm)
-            .padding(.vertical, 4)
-            .background(Tokens.accentFinance.opacity(0.12), in: Capsule())
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .font(.system(size: 18, weight: .regular))
+                .foregroundStyle(Tokens.accentFinance)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Filter by person and currency")
+        .accessibilityLabel("Filter by people and currency")
     }
 
     // MARK: - Currency mode
@@ -420,17 +440,19 @@ struct TripExpensesView: View {
         }
     }
 
-    /// The list narrows to the filtered participant's expenses; the default
-    /// You selection keeps the full list (the summary card already answers
-    /// the "my spend" question without hiding group context).
+    /// The list narrows to expenses involving ANY selected participant; the
+    /// default You-only selection keeps the full list (the summary card
+    /// already answers the "my spend" question without hiding group context).
     private var visibleExpenses: [LocalExpense] {
-        guard filterParty != .me else { return Array(expenses) }
-        return expenses.filter { involves($0, party: filterParty) }
+        guard filterParties != [.me] else { return Array(expenses) }
+        return expenses.filter { expense in
+            filterParties.contains { involves(expense, party: $0) }
+        }
     }
 
     private var expenseList: some View {
         VStack(alignment: .leading, spacing: Space.sm) {
-            Text(filterParty == .me ? "Expenses" : "Expenses · \(filterPartyName)").eyebrow()
+            Text(filterParties == [.me] ? "Expenses" : "Expenses · \(selectionShortLabel)").eyebrow()
             VStack(spacing: Space.xs) {
                 ForEach(visibleExpenses) { expense in
                     ExpenseRow(expense: expense, showsOriginalFirst: true) {
@@ -438,8 +460,8 @@ struct TripExpensesView: View {
                     }
                 }
             }
-            if filterParty != .me && visibleExpenses.isEmpty {
-                Text("No expenses involve \(filterPartyName) yet.")
+            if filterParties != [.me] && visibleExpenses.isEmpty {
+                Text("No expenses involve this selection yet.")
                     .font(.edCaption)
                     .foregroundStyle(Tokens.muted)
             }
@@ -478,16 +500,17 @@ struct TripExpensesView: View {
 
 // MARK: - Filter sheet
 
-/// Person + currency filter for the trip expenses summary (#258). Person picks
-/// whose spend the summary card shows (and narrows the list for non-You
-/// picks); currency picks what the summary renders in — the Settings display
-/// currency, or any currency captured on the trip.
+/// People + currency filter for the trip expenses summary (#258). People are
+/// multi-select — the summary card shows the combined spend/paid/net of the
+/// selection and the list narrows to expenses involving any of them. Currency
+/// picks what the summary renders in — the Settings display currency, or any
+/// currency captured on the trip.
 private struct TripExpenseFilterSheet: View {
     let participants: [LocalPerson]
     /// Trip capture currencies, excluding the display currency.
     let currencyOptions: [String]
     let displayCode: String
-    @Binding var party: SplitPartyID
+    @Binding var parties: Set<SplitPartyID>
     @Binding var currency: String?
 
     @Environment(\.dismiss) private var dismiss
@@ -538,9 +561,21 @@ private struct TripExpenseFilterSheet: View {
         }
     }
 
+    /// Toggle a party in the multi-select. The selection can never go empty —
+    /// removing the last member snaps back to You.
+    private func toggle(_ rowParty: SplitPartyID) {
+        if parties.contains(rowParty) {
+            parties.remove(rowParty)
+            if parties.isEmpty { parties = [.me] }
+        } else {
+            parties.insert(rowParty)
+        }
+    }
+
     private func partyRow(_ rowParty: SplitPartyID, name: String, colorHex: String?) -> some View {
-        Button {
-            party = rowParty
+        let selected = parties.contains(rowParty)
+        return Button {
+            toggle(rowParty)
         } label: {
             HStack(spacing: Space.sm) {
                 Circle()
@@ -550,18 +585,16 @@ private struct TripExpenseFilterSheet: View {
                     .font(.edBody)
                     .foregroundStyle(Tokens.ink)
                 Spacer()
-                if party == rowParty {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(Tokens.accentFinance)
-                }
+                Image(systemName: selected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 16, weight: .regular))
+                    .foregroundStyle(selected ? Tokens.accentFinance : Tokens.mutedSoft)
             }
             .padding(.horizontal, Space.md)
             .padding(.vertical, Space.sm + 2)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(party == rowParty ? "\(name), selected" : name)
+        .accessibilityLabel(selected ? "\(name), selected" : name)
     }
 
     private func currencyChip(_ code: String?, label: String) -> some View {

--- a/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
@@ -29,10 +29,6 @@ struct TripExpensesView: View {
     @Query(sort: [SortDescriptor(\LocalPerson.name, order: .forward)])
     private var people: [LocalPerson]
 
-    /// False (default) = amounts render in the currency each expense was
-    /// captured in. True = everything converts to the chosen display currency.
-    @State private var showConverted: Bool = false
-
     init(trip: LocalTrip, onEditExpense: @escaping (String) -> Void) {
         self.trip = trip
         self.onEditExpense = onEditExpense
@@ -114,29 +110,6 @@ struct TripExpensesView: View {
         FinanceSettings.displayCurrencyCode.uppercased()
     }
 
-    /// Small capsule that flips the tab between as-captured and converted
-    /// amounts. Labelled with the mode a tap switches TO.
-    private var currencyToggle: some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.15)) { showConverted.toggle() }
-        } label: {
-            HStack(spacing: 4) {
-                Image(systemName: "arrow.left.arrow.right")
-                    .font(.system(size: 9, weight: .semibold))
-                Text(showConverted ? "As added" : displayCurrencyCode)
-                    .font(.edCaption)
-            }
-            .foregroundStyle(Tokens.accentFinance)
-            .padding(.horizontal, Space.sm)
-            .padding(.vertical, 4)
-            .background(Tokens.accentFinance.opacity(0.12), in: Capsule())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(showConverted
-            ? "Show amounts in the currency they were added in"
-            : "Show amounts in \(displayCurrencyCode)")
-    }
-
     // MARK: - Stats card
 
     private var groupTotalSGD: Double {
@@ -147,37 +120,46 @@ struct TripExpensesView: View {
         expenses.reduce(0) { $0 + $1.myShareSGD }
     }
 
+    /// Whether the per-currency breakdown adds information: hidden when the
+    /// trip has a single currency that IS the display currency (the Total row
+    /// would just repeat it).
+    private var showsCurrencyBreakdown: Bool {
+        let totals = totalsByCurrency
+        if totals.count == 1, totals[0].code == displayCurrencyCode { return false }
+        return !totals.isEmpty
+    }
+
     private var statsCard: some View {
         VStack(alignment: .leading, spacing: Space.md) {
-            HStack {
-                Text("Group total").eyebrow()
-                Spacer()
-                currencyToggle
-            }
+            Text("Group total").eyebrow()
 
-            if showConverted {
-                Text(FinanceDashboardBand.formatMoney(groupTotalSGD))
-                    .font(.edDisplay)
-                    .foregroundStyle(Tokens.ink)
-                    .tracking(-0.6)
-            } else {
-                let totals = totalsByCurrency
-                if let first = totals.first {
-                    Text(Self.formatOriginal(first.total, code: first.code))
+            VStack(alignment: .leading, spacing: Space.xs) {
+                // As-added spend, one same-weight line per capture currency.
+                if showsCurrencyBreakdown {
+                    ForEach(totalsByCurrency, id: \.code) { entry in
+                        Text(Self.formatOriginal(entry.total, code: entry.code))
+                            .font(.edBodyMedium)
+                            .monospacedDigit()
+                            .foregroundStyle(Tokens.inkSoft)
+                    }
+                    Divider().background(Tokens.divider)
+                }
+                // The one number that sums the whole trip: converted into the
+                // display currency chosen in Settings.
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Total")
+                        .font(.edCaption)
+                        .foregroundStyle(Tokens.mutedSoft)
+                    Spacer()
+                    Text(FinanceDashboardBand.formatMoney(groupTotalSGD))
                         .font(.edDisplay)
                         .foregroundStyle(Tokens.ink)
                         .tracking(-0.6)
                 }
-                ForEach(totals.dropFirst(), id: \.code) { entry in
-                    Text(Self.formatOriginal(entry.total, code: entry.code))
-                        .font(.edBodyMedium)
-                        .monospacedDigit()
-                        .foregroundStyle(Tokens.inkSoft)
-                }
             }
 
             HStack(spacing: Space.lg) {
-                statTile(label: "Your share", value: yourShareLabel)
+                statTile(label: "Your share", value: FinanceDashboardBand.formatMoney(yourShareSGD))
                 statTile(label: "Expenses", value: "\(expenses.count)")
             }
             .padding(.top, Space.xs)
@@ -186,15 +168,6 @@ struct TripExpensesView: View {
         .padding(Space.lg)
         .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
         .paperBorder(Tokens.border, radius: Radius.lg)
-    }
-
-    private var yourShareLabel: String {
-        if showConverted {
-            return FinanceDashboardBand.formatMoney(yourShareSGD)
-        }
-        return totalsByCurrency
-            .map { Self.formatOriginal($0.myShare, code: $0.code) }
-            .joined(separator: " · ")
     }
 
     private func statTile(label: String, value: String) -> some View {
@@ -212,11 +185,11 @@ struct TripExpensesView: View {
     // MARK: - Settle up
 
     /// True when the settle-up card can run natively in the capture currency:
-    /// the user wants as-added amounts AND the trip is single-currency. A
-    /// mixed-currency trip has no meaningful "as added" net, so it falls back
-    /// to the display currency (flagged in the card).
+    /// the whole trip shares one currency. A mixed-currency trip has no
+    /// meaningful "as added" net, so it falls back to the display currency
+    /// (flagged in the card).
     private var settlesInCaptureCurrency: Bool {
-        !showConverted && singleCurrencyCode != nil
+        singleCurrencyCode != nil
     }
 
     /// Netted per-party balances, sorted with the user first, then the people
@@ -239,7 +212,7 @@ struct TripExpensesView: View {
         VStack(alignment: .leading, spacing: Space.md) {
             HStack {
                 Text("Settle up").eyebrow()
-                if !showConverted && singleCurrencyCode == nil {
+                if singleCurrencyCode == nil {
                     Spacer()
                     Text("in \(displayCurrencyCode) · mixed currencies")
                         .font(.edCaption)
@@ -315,7 +288,7 @@ struct TripExpensesView: View {
             Text("Expenses").eyebrow()
             VStack(spacing: Space.xs) {
                 ForEach(expenses) { expense in
-                    ExpenseRow(expense: expense, showsOriginalFirst: !showConverted) {
+                    ExpenseRow(expense: expense, showsOriginalFirst: true) {
                         onEditExpense(expense.clientUUID)
                     }
                 }

--- a/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
@@ -29,6 +29,16 @@ struct TripExpensesView: View {
     @Query(sort: [SortDescriptor(\LocalPerson.name, order: .forward)])
     private var people: [LocalPerson]
 
+    /// Whose numbers the summary card shows (and, for non-You selections,
+    /// which expenses the list narrows to). Defaults to the user — the tab's
+    /// core question is "how much have I spent on this trip".
+    @State private var filterParty: SplitPartyID = .me
+    /// Currency the summary card renders in. `nil` = the Settings display
+    /// currency; otherwise one of the currencies captured on this trip
+    /// (converted through the trip's own frozen FX observations).
+    @State private var filterCurrency: String? = nil
+    @State private var showingFilter: Bool = false
+
     init(trip: LocalTrip, onEditExpense: @escaping (String) -> Void) {
         self.trip = trip
         self.onEditExpense = onEditExpense
@@ -58,6 +68,7 @@ struct TripExpensesView: View {
         ScrollView {
             VStack(spacing: Space.lg) {
                 statsCard
+                personSummaryCard
                 if !balances.isEmpty {
                     settleUpCard
                 }
@@ -68,6 +79,120 @@ struct TripExpensesView: View {
             .padding(.top, Space.lg)
         }
         .scrollDismissesKeyboard(.interactively)
+        .sheet(isPresented: $showingFilter) {
+            TripExpenseFilterSheet(
+                participants: participantPeople,
+                currencyOptions: filterCurrencyOptions,
+                displayCode: displayCurrencyCode,
+                party: $filterParty,
+                currency: $filterCurrency
+            )
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+        }
+    }
+
+    /// Trip participants resolved to live person records, preserving order.
+    private var participantPeople: [LocalPerson] {
+        trip.participantPersonUUIDs.compactMap { id in
+            people.first { $0.clientUUID == id }
+        }
+    }
+
+    // MARK: - Person summary (filterable)
+
+    /// Currencies the summary can render in: every capture currency on the
+    /// trip. The Settings display currency is the `nil` option and always
+    /// offered first by the sheet.
+    private var filterCurrencyOptions: [String] {
+        totalsByCurrency.map { $0.code }.filter { $0 != displayCurrencyCode }
+    }
+
+    /// Aggregate conversion rate (code → SGD) observed on this trip's own
+    /// expenses: total frozen SGD over total captured amount. Weighted by
+    /// spend, stable across extraction noise, and works offline. Nil when the
+    /// trip has no usable observation for the code.
+    private func tripRateToSGD(for code: String) -> Double? {
+        let matching = expenses.filter { $0.originalCurrency.uppercased() == code }
+        let original = matching.reduce(0) { $0 + $1.originalAmount }
+        let sgd = matching.reduce(0) { $0 + $1.sgdAmount }
+        guard original > 0, sgd > 0 else { return nil }
+        return sgd / original
+    }
+
+    /// Format a home-currency (SGD) value in the summary's selected currency.
+    private func formatFiltered(_ sgdValue: Double) -> String {
+        guard let code = filterCurrency, code != displayCurrencyCode else {
+            return FinanceDashboardBand.formatMoney(sgdValue)
+        }
+        if code == "SGD" {
+            return Self.formatOriginal(sgdValue, code: code)
+        }
+        guard let rate = tripRateToSGD(for: code) else {
+            return FinanceDashboardBand.formatMoney(sgdValue)
+        }
+        return Self.formatOriginal(sgdValue / rate, code: code)
+    }
+
+    private var filterPartyName: String {
+        switch filterParty {
+        case .me: return "You"
+        case .person(let id): return personName(id)
+        }
+    }
+
+    /// The card that answers "how much have I spent on this trip" — and the
+    /// same for any participant via the filter. Spent = their consumed share
+    /// across the bills; Paid = what they fronted; the net line is the
+    /// settle-up position.
+    private var personSummaryCard: some View {
+        let totals = TripSettlement.totals(expenses: expenses)[filterParty] ?? (paid: 0, owed: 0)
+        let net = totals.paid - totals.owed
+        let isMe = filterParty == .me
+        return VStack(alignment: .leading, spacing: Space.md) {
+            HStack {
+                Text(isMe ? "Your spend" : "\(filterPartyName)'s spend").eyebrow()
+                Spacer()
+                filterButton
+            }
+
+            Text(formatFiltered(totals.owed))
+                .font(.edDisplay)
+                .foregroundStyle(Tokens.ink)
+                .tracking(-0.6)
+
+            HStack(spacing: Space.lg) {
+                statTile(label: "Paid", value: formatFiltered(totals.paid))
+                statTile(
+                    label: net >= 0 ? (isMe ? "You are owed" : "Is owed") : (isMe ? "You owe" : "Owes"),
+                    value: formatFiltered(abs(net))
+                )
+            }
+            .padding(.top, Space.xs)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Space.lg)
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        .paperBorder(Tokens.border, radius: Radius.lg)
+    }
+
+    private var filterButton: some View {
+        Button {
+            showingFilter = true
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "line.3.horizontal.decrease.circle")
+                    .font(.system(size: 11, weight: .semibold))
+                Text(filterCurrency ?? displayCurrencyCode)
+                    .font(.edCaption)
+            }
+            .foregroundStyle(Tokens.accentFinance)
+            .padding(.horizontal, Space.sm)
+            .padding(.vertical, 4)
+            .background(Tokens.accentFinance.opacity(0.12), in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Filter by person and currency")
     }
 
     // MARK: - Currency mode
@@ -283,15 +408,40 @@ struct TripExpensesView: View {
 
     // MARK: - Expense list
 
+    /// Whether an expense involves the given party — they paid it, or they
+    /// hold a positive share of the split.
+    private func involves(_ expense: LocalExpense, party: SplitPartyID) -> Bool {
+        let payer: SplitPartyID = expense.paidByPersonUUID.map { .person($0) } ?? .me
+        if payer == party { return true }
+        return expense.splits.contains { entry in
+            guard entry.shares > 0 else { return false }
+            let entryParty: SplitPartyID = entry.personID.map { .person($0) } ?? .me
+            return entryParty == party
+        }
+    }
+
+    /// The list narrows to the filtered participant's expenses; the default
+    /// You selection keeps the full list (the summary card already answers
+    /// the "my spend" question without hiding group context).
+    private var visibleExpenses: [LocalExpense] {
+        guard filterParty != .me else { return Array(expenses) }
+        return expenses.filter { involves($0, party: filterParty) }
+    }
+
     private var expenseList: some View {
         VStack(alignment: .leading, spacing: Space.sm) {
-            Text("Expenses").eyebrow()
+            Text(filterParty == .me ? "Expenses" : "Expenses · \(filterPartyName)").eyebrow()
             VStack(spacing: Space.xs) {
-                ForEach(expenses) { expense in
+                ForEach(visibleExpenses) { expense in
                     ExpenseRow(expense: expense, showsOriginalFirst: true) {
                         onEditExpense(expense.clientUUID)
                     }
                 }
+            }
+            if filterParty != .me && visibleExpenses.isEmpty {
+                Text("No expenses involve \(filterPartyName) yet.")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.muted)
             }
         }
     }
@@ -326,6 +476,114 @@ struct TripExpensesView: View {
     }
 }
 
+// MARK: - Filter sheet
+
+/// Person + currency filter for the trip expenses summary (#258). Person picks
+/// whose spend the summary card shows (and narrows the list for non-You
+/// picks); currency picks what the summary renders in — the Settings display
+/// currency, or any currency captured on the trip.
+private struct TripExpenseFilterSheet: View {
+    let participants: [LocalPerson]
+    /// Trip capture currencies, excluding the display currency.
+    let currencyOptions: [String]
+    let displayCode: String
+    @Binding var party: SplitPartyID
+    @Binding var currency: String?
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Space.xl) {
+                    VStack(alignment: .leading, spacing: Space.sm) {
+                        Text("Show spend for").eyebrow()
+                        VStack(spacing: 0) {
+                            partyRow(.me, name: "You", colorHex: nil)
+                            ForEach(participants, id: \.clientUUID) { person in
+                                Divider().background(Tokens.divider)
+                                partyRow(.person(person.clientUUID), name: person.name, colorHex: person.colorHex)
+                            }
+                        }
+                        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                        .paperBorder(Tokens.border, radius: Radius.md)
+                    }
+
+                    VStack(alignment: .leading, spacing: Space.sm) {
+                        Text("Currency").eyebrow()
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: Space.sm) {
+                                currencyChip(nil, label: displayCode)
+                                ForEach(currencyOptions, id: \.self) { code in
+                                    currencyChip(code, label: code)
+                                }
+                            }
+                            .padding(.vertical, 2)
+                        }
+                        Text("Converted with the rates frozen on this trip's expenses.")
+                            .font(.edCaption)
+                            .foregroundStyle(Tokens.mutedSoft)
+                    }
+                }
+                .padding(Space.lg)
+            }
+            .background(Tokens.paper)
+            .navigationTitle("Filter")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func partyRow(_ rowParty: SplitPartyID, name: String, colorHex: String?) -> some View {
+        Button {
+            party = rowParty
+        } label: {
+            HStack(spacing: Space.sm) {
+                Circle()
+                    .fill(colorHex.map { Color(personHex: $0) } ?? Tokens.accentFinance)
+                    .frame(width: 10, height: 10)
+                Text(name)
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.ink)
+                Spacer()
+                if party == rowParty {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Tokens.accentFinance)
+                }
+            }
+            .padding(.horizontal, Space.md)
+            .padding(.vertical, Space.sm + 2)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(party == rowParty ? "\(name), selected" : name)
+    }
+
+    private func currencyChip(_ code: String?, label: String) -> some View {
+        let selected = currency == code
+        return Button {
+            currency = code
+        } label: {
+            Text(label)
+                .font(.edFootnote)
+                .foregroundStyle(selected ? Tokens.accentFg : Tokens.ink)
+                .padding(.horizontal, Space.md)
+                .padding(.vertical, 6)
+                .background(
+                    selected ? Tokens.accentFinance : Tokens.surface2,
+                    in: Capsule()
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(selected ? "\(label), selected" : label)
+    }
+}
+
 // MARK: - Settlement math
 
 /// Pure settle-up computation over a trip's expenses (#258).
@@ -352,40 +610,45 @@ enum TripSettlement {
     /// dropped from the list.
     private static let epsilon = 0.005
 
-    static func compute(
+    /// Per-party (paid, owed) totals in the caller's amount basis. `paid` is
+    /// what the party fronted; `owed` is their consumed share of the bills.
+    /// The building block behind both the netted balances and the per-person
+    /// summary card ("spent" = owed, "is owed" = paid - owed).
+    static func totals(
         expenses: [LocalExpense],
         amount: (LocalExpense) -> Double = { $0.signedSGD }
-    ) -> [Balance] {
-        var paid: [SplitPartyID: Double] = [:]
-        var owed: [SplitPartyID: Double] = [:]
+    ) -> [SplitPartyID: (paid: Double, owed: Double)] {
+        var totals: [SplitPartyID: (paid: Double, owed: Double)] = [:]
 
         for expense in expenses {
             let value = amount(expense)
             let payer: SplitPartyID = expense.paidByPersonUUID.map { .person($0) } ?? .me
-            paid[payer, default: 0] += value
+            totals[payer, default: (0, 0)].paid += value
 
             let splits = expense.splits
-            if splits.isEmpty {
-                // Unsplit: the payer bears the whole cost (nets to zero).
-                owed[payer, default: 0] += value
-                continue
-            }
             let totalShares = splits.reduce(0) { $0 + max($1.shares, 0) }
-            guard totalShares > 0 else {
-                owed[payer, default: 0] += value
+            guard !splits.isEmpty, totalShares > 0 else {
+                // Unsplit (or degenerate): the payer bears the whole cost.
+                totals[payer, default: (0, 0)].owed += value
                 continue
             }
             for entry in splits {
                 let shares = max(entry.shares, 0)
                 guard shares > 0 else { continue }
                 let party: SplitPartyID = entry.personID.map { .person($0) } ?? .me
-                owed[party, default: 0] += value * Double(shares) / Double(totalShares)
+                totals[party, default: (0, 0)].owed += value * Double(shares) / Double(totalShares)
             }
         }
+        return totals
+    }
 
-        let parties = Set(paid.keys).union(owed.keys)
-        var balances: [Balance] = parties.map { party in
-            Balance(party: party, net: (paid[party] ?? 0) - (owed[party] ?? 0))
+    static func compute(
+        expenses: [LocalExpense],
+        amount: (LocalExpense) -> Double = { $0.signedSGD }
+    ) -> [Balance] {
+        let totals = totals(expenses: expenses, amount: amount)
+        var balances: [Balance] = totals.map { party, entry in
+            Balance(party: party, net: entry.paid - entry.owed)
         }
         balances.removeAll { abs($0.net) < epsilon }
 

--- a/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
@@ -23,6 +23,14 @@ struct TripExpensesView: View {
     @Query(sort: [SortDescriptor(\LocalPerson.name, order: .forward)])
     private var people: [LocalPerson]
 
+    /// In-place participant management (#261 QA follow-up). Splitting is only
+    /// offered once the trip has participants, and burying that in the trip
+    /// editor on the Itineraries list made it undiscoverable — so the Expenses
+    /// tab manages the group directly. Reuses `PersonPickerSheet`
+    /// (find-or-create by name), same as the trip editor.
+    @State private var pickedParticipant: ExpenseTag?
+    @State private var showingParticipantPicker: Bool = false
+
     init(trip: LocalTrip, onEditExpense: @escaping (String) -> Void) {
         self.trip = trip
         self.onEditExpense = onEditExpense
@@ -37,31 +45,122 @@ struct TripExpensesView: View {
     }
 
     var body: some View {
-        Group {
-            if expenses.isEmpty {
-                emptyState
-            } else {
-                populated
-            }
-        }
-    }
-
-    // MARK: - Populated
-
-    private var populated: some View {
         ScrollView {
             VStack(spacing: Space.lg) {
-                statsCard
-                if !balances.isEmpty {
-                    settleUpCard
+                peopleCard
+                if expenses.isEmpty {
+                    emptyState
+                } else {
+                    statsCard
+                    if !balances.isEmpty {
+                        settleUpCard
+                    }
+                    expenseList
                 }
-                expenseList
                 Color.clear.frame(height: 96)
             }
             .padding(.horizontal, Space.lg)
             .padding(.top, Space.lg)
         }
         .scrollDismissesKeyboard(.interactively)
+        .sheet(isPresented: $showingParticipantPicker) {
+            PersonPickerSheet(selection: $pickedParticipant)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .onChange(of: pickedParticipant) { _, newValue in
+            if let tag = newValue, !trip.participantPersonUUIDs.contains(tag.uuid) {
+                trip.participantPersonUUIDs.append(tag.uuid)
+            }
+            // Reset so picking the same person twice in a row still fires.
+            pickedParticipant = nil
+        }
+    }
+
+    // MARK: - People
+
+    /// Resolved participant records, preserving the stored order.
+    private var participantPeople: [LocalPerson] {
+        trip.participantPersonUUIDs.compactMap { id in
+            people.first { $0.clientUUID == id }
+        }
+    }
+
+    /// Who's on this trip. Add / remove writes straight to the trip, so the
+    /// next expense immediately offers the split UI. Removing someone never
+    /// touches splits already stored on expenses — settle-up resolves names
+    /// from the people table, not this list.
+    private var peopleCard: some View {
+        VStack(alignment: .leading, spacing: Space.sm) {
+            HStack {
+                Text("People").eyebrow()
+                Spacer()
+                Text("For splitting expenses")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Space.sm) {
+                    ForEach(participantPeople, id: \.clientUUID) { person in
+                        participantChip(person)
+                    }
+                    addParticipantChip
+                }
+                .padding(.vertical, 2)
+            }
+            if participantPeople.isEmpty {
+                Text("Add the people on this trip to split expenses and see who owes whom.")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.muted)
+            }
+        }
+        .padding(Space.lg)
+        .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        .paperBorder(Tokens.border, radius: Radius.lg)
+    }
+
+    private func participantChip(_ person: LocalPerson) -> some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(Color(personHex: person.colorHex))
+                .frame(width: 8, height: 8)
+            Text(person.name)
+                .font(.edFootnote)
+                .foregroundStyle(Tokens.ink)
+                .lineLimit(1)
+            Button {
+                trip.participantPersonUUIDs.removeAll { $0 == person.clientUUID }
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(Tokens.mutedSoft)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove \(person.name)")
+        }
+        .padding(.leading, Space.sm)
+        .padding(.trailing, Space.xs + 2)
+        .padding(.vertical, 6)
+        .background(Tokens.surface2, in: Capsule())
+    }
+
+    private var addParticipantChip: some View {
+        Button {
+            showingParticipantPicker = true
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "plus")
+                    .font(.system(size: 10, weight: .semibold))
+                Text("Add")
+                    .font(.edFootnote)
+            }
+            .foregroundStyle(Tokens.accentFinance)
+            .padding(.horizontal, Space.sm)
+            .padding(.vertical, 6)
+            .background(Tokens.accentFinance.opacity(0.12), in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Add participant")
     }
 
     // MARK: - Stats card
@@ -196,31 +295,28 @@ struct TripExpensesView: View {
 
     // MARK: - Empty state
 
+    /// Rendered inside the scroll column, under the people card.
     private var emptyState: some View {
         VStack(spacing: 0) {
-            Spacer()
-            VStack(spacing: 0) {
-                Image(systemName: "wallet.bifold")
-                    .font(.system(size: 32, weight: .light))
-                    .foregroundStyle(Tokens.mutedSoft)
-                Spacer().frame(height: Space.md)
-                Text("No expenses yet")
-                    .font(.edTitle)
-                    .foregroundStyle(Tokens.ink)
-                    .multilineTextAlignment(.center)
-                Spacer().frame(height: Space.xs)
-                Text(trip.participantPersonUUIDs.isEmpty
-                     ? "Tap + to log a trip expense. Add participants in Edit trip to split the bill."
-                     : "Tap + to log a trip expense and split it with your group.")
-                    .font(.edSubheadline)
-                    .foregroundStyle(Tokens.muted)
-                    .multilineTextAlignment(.center)
-            }
-            .frame(maxWidth: 300)
-            Spacer()
+            Image(systemName: "wallet.bifold")
+                .font(.system(size: 32, weight: .light))
+                .foregroundStyle(Tokens.mutedSoft)
+            Spacer().frame(height: Space.md)
+            Text("No expenses yet")
+                .font(.edTitle)
+                .foregroundStyle(Tokens.ink)
+                .multilineTextAlignment(.center)
+            Spacer().frame(height: Space.xs)
+            Text(trip.participantPersonUUIDs.isEmpty
+                 ? "Add the people above, then tap + to log an expense and split it."
+                 : "Tap + to log a trip expense and split it with your group.")
+                .font(.edSubheadline)
+                .foregroundStyle(Tokens.muted)
+                .multilineTextAlignment(.center)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, Space.lg)
+        .frame(maxWidth: 300)
+        .frame(maxWidth: .infinity)
+        .padding(.top, Space.xxl)
     }
 }
 


### PR DESCRIPTION
## Summary

Final phases of trip expenses (#258): import routing by upload location, plus split-aware chat/voice capture.

- Trip Expenses tab FAB is now a capture menu: scan receipt, photo, PDF receipt, statement import, or manual entry. Single receipts flow into the trip-scoped review sheet with the split pre-seeded (all participants at 1 share, payer You); multi-line photos and statement PDFs batch-import trip-aware
- `StatementImporter` gains an optional trip parameter: rows imported from a trip get the trip link and a default equal split; dedup logic is untouched, and imports from Finance behave exactly as today
- Email-matched expenses now default their split to the trip's participants when the trip has any (applied in Swift after insert; the email LLM tool surface stays split-free)
- Chat/voice `add_expense` gains optional `paid_by` and `split_with` (person names, "me" supported); names resolve via find-or-create, trip participants and per-trip expense totals are surfaced in the assistant context, and draft cards show payer and split ("Sam paid, split 4 ways")
- Defense in depth on the email path: it uses a param-free variant of the tool schema AND the handler strips split params before execution, so forwarded email content cannot create people or splits

Closes #258
Closes #261

## Test plan

Also fixes #261 in this branch: SwiftUI honours only one fileImporter (and one photosPicker) per view, so the stacked PDF pickers never opened. FinanceView had this latent since #190; both views now share a single purpose-dispatched picker of each kind.


- [x] `xcodegen generate` + `xcodebuild build` clean (0 errors)
- [x] Shipped to device via `devicectl` for QA
- [ ] Device QA: import a statement PDF from inside a trip (rows tagged + split), scan a receipt from the trip tab, chat "add 80 euro dinner to the trip, Sam paid, split between all of us", and confirm Finance-side uploads stay personal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

