### PR TITLE
fix(ios): label the spend summary's big number as Spent

### DIFF
--- a/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
@@ -185,10 +185,18 @@ struct TripExpensesView: View {
                 filterButton
             }
 
-            Text(formatFiltered(owed))
-                .font(.edDisplay)
-                .foregroundStyle(Tokens.ink)
-                .tracking(-0.6)
+            // Spent = consumed share of the bills; Paid = fronted out of
+            // pocket; the net tile is Paid − Spent (their settle-up position).
+            HStack(alignment: .firstTextBaseline) {
+                Text("Spent")
+                    .font(.edCaption)
+                    .foregroundStyle(Tokens.mutedSoft)
+                Spacer()
+                Text(formatFiltered(owed))
+                    .font(.edDisplay)
+                    .foregroundStyle(Tokens.ink)
+                    .tracking(-0.6)
+            }
 
             HStack(spacing: Space.lg) {
                 statTile(label: "Paid", value: formatFiltered(paid))


### PR DESCRIPTION
## Summary

- The per-person spend summary's headline amount had no label, making Spent vs Paid vs Owed unreadable (the three relate as Spent = Paid - Owed). The big number now carries a Spent caption, matching the Total row on the group card.

## Test plan

- [x] xcodebuild clean
- [x] Shipped to device
- [ ] Glance at the Mom + Papa filter card: Spent / Paid / Owed all labelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)