### PR TITLE
feat(ios): Finance shows only my share of trip expenses; deletes are per-surface

### DIFF
--- a/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
+++ b/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
@@ -159,7 +159,8 @@ struct AssistantContextBuilder {
             let allTripExpenses = (try? context.fetch(FetchDescriptor<LocalExpense>())) ?? []
             var expenseAggByTrip: [UUID: (total: Double, count: Int)] = [:]
             for expense in allTripExpenses {
-                guard let tripFK = expense.tripUUID else { continue }
+                // Rows removed from the trip surface (#264) don't count here.
+                guard let tripFK = expense.tripUUID, !expense.hiddenFromTrip else { continue }
                 var agg = expenseAggByTrip[tripFK] ?? (total: 0, count: 0)
                 agg.total += expense.signedSGD
                 agg.count += 1
@@ -245,9 +246,11 @@ struct AssistantContextBuilder {
         let now = Date()
         if let last30Cutoff = cal.date(byAdding: .day, value: -30, to: now) {
             let cutoff = cal.startOfDay(for: last30Cutoff)
+            // Rows removed from Finance (#264) are invisible to the finance
+            // block — they only back their trip's rollup above.
             if let recent = try? context.fetch(
                 FetchDescriptor<LocalExpense>(
-                    predicate: #Predicate { $0.date >= cutoff },
+                    predicate: #Predicate { $0.date >= cutoff && !$0.hiddenFromFinance },
                     sortBy: [
                         SortDescriptor(\LocalExpense.date, order: .reverse),
                         SortDescriptor(\LocalExpense.createdAt, order: .reverse)
@@ -258,14 +261,16 @@ struct AssistantContextBuilder {
                 let monthComps = cal.dateComponents([.year, .month], from: now)
                 let monthStart = cal.date(from: monthComps) ?? now
                 let monthRows = recent.filter { $0.date >= monthStart }
-                // Net refunds against spend (#206) so the figure the assistant
-                // reports matches the Finance UI's netted totals.
-                let monthTotal = monthRows.reduce(0.0) { $0 + $1.signedSGD }
+                // Net refunds against spend (#206) and count only the user's
+                // share of group-split trip expenses (#258/#264) so the figure
+                // the assistant reports matches the Finance UI's totals.
+                let monthTotal = monthRows.reduce(0.0) { $0 + $1.myShareSGD }
 
-                // Category totals this month, biggest first (refunds netted).
+                // Category totals this month, biggest first (refunds netted,
+                // share-based — same convention as the month total).
                 var byCategory: [String: Double] = [:]
                 for row in monthRows {
-                    byCategory[row.category, default: 0] += row.signedSGD
+                    byCategory[row.category, default: 0] += row.myShareSGD
                 }
                 let topCategories = byCategory
                     .sorted { $0.value > $1.value }

--- a/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalExpense.swift
@@ -182,6 +182,18 @@ final class LocalExpense {
     var paidByPersonUUID: UUID? = nil
     var splitsData: Data? = nil
 
+    // MARK: - Per-surface visibility (#264)
+    //
+    // A trip expense is ONE row shown on two surfaces (the trip's Expenses tab
+    // and the Finance list). Deleting it from one surface must not affect the
+    // other, so each surface owns a hide flag instead of hard-deleting the
+    // shared row. Only when BOTH flags are set (no surface shows it) does the
+    // row get physically deleted. The row keeps existing while hidden so
+    // `ExpenseDedupe` still sees it and a re-import can't resurrect a
+    // duplicate. Both additive with defaults for a safe lightweight migration.
+    var hiddenFromFinance: Bool = false
+    var hiddenFromTrip: Bool = false
+
     // MARK: - Dead-field parity with other LocalModels
     //
     // These are intentionally unused on Phase A. Kept so that the SwiftData
@@ -218,6 +230,8 @@ final class LocalExpense {
         dedupeDescriptor: String = "",
         paidByPersonUUID: UUID? = nil,
         splitsData: Data? = nil,
+        hiddenFromFinance: Bool = false,
+        hiddenFromTrip: Bool = false,
         needsSync: Bool = false,
         version: Int = 0
     ) {
@@ -248,6 +262,8 @@ final class LocalExpense {
         self.dedupeDescriptor = dedupeDescriptor
         self.paidByPersonUUID = paidByPersonUUID
         self.splitsData = splitsData
+        self.hiddenFromFinance = hiddenFromFinance
+        self.hiddenFromTrip = hiddenFromTrip
         self.needsSync = needsSync
         self.version = version
     }

--- a/mobile/PersonalDashboard/Services/ExpenseService.swift
+++ b/mobile/PersonalDashboard/Services/ExpenseService.swift
@@ -245,8 +245,23 @@ struct ExpenseService {
     }
 
     func deleteExpense(_ expense: LocalExpense) throws {
-        store.context.delete(expense)
+        Self.removeFromFinance(expense, context: store.context)
         try save()
+    }
+
+    /// Finance-side removal honouring the per-surface visibility model (#264).
+    /// A trip expense still visible on its trip is only HIDDEN from Finance —
+    /// the shared row keeps backing the trip's totals and settle-up. Anything
+    /// else (a personal expense, or a trip row already hidden from the trip)
+    /// has no remaining surface and is physically deleted. Caller saves; the
+    /// receipt-file cleanup stays with callers that own it (FinanceView) since
+    /// it needs the sibling-reference check.
+    static func removeFromFinance(_ expense: LocalExpense, context: ModelContext) {
+        if expense.tripUUID != nil && !expense.hiddenFromTrip {
+            expense.hiddenFromFinance = true
+        } else {
+            context.delete(expense)
+        }
     }
 
     /// Bulk-delete expenses matching an optional filter (#204, #251). The four
@@ -283,6 +298,9 @@ struct ExpenseService {
         // "no import-source constraint" and never narrows the match.
         let sourceNeedle = source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let matches = all.filter { row in
+            // Rows already hidden from Finance are invisible to the user's
+            // "clear my expenses" mental model — leave them for the trip (#264).
+            if row.hiddenFromFinance { return false }
             if let after, !(row.date > after) { return false }
             if let before, !(row.date < before) { return false }
             if let categoryRaw, row.category != categoryRaw { return false }
@@ -295,7 +313,9 @@ struct ExpenseService {
         }
         guard !matches.isEmpty else { return 0 }
         for row in matches {
-            store.context.delete(row)
+            // Same per-surface rule as a single Finance delete (#264): a bulk
+            // clear must not silently gut a trip's settle-up.
+            Self.removeFromFinance(row, context: store.context)
         }
         try save()
         return matches.count
@@ -390,12 +410,15 @@ struct ExpenseService {
         let lo = range.lowerBound
         let hi = range.upperBound
         let descriptor = FetchDescriptor<LocalExpense>(
-            predicate: #Predicate { $0.date >= lo && $0.date <= hi }
+            predicate: #Predicate { $0.date >= lo && $0.date <= hi && !$0.hiddenFromFinance }
         )
         return try store.context.fetch(descriptor)
     }
 
     private static func matches(_ expense: LocalExpense, filter: ExpenseFilter) -> Bool {
+        // Rows removed from Finance (#264) are invisible to every Finance
+        // surface — list, analytics, filters — while still backing their trip.
+        if expense.hiddenFromFinance { return false }
         if let range = filter.dateRange {
             if !range.contains(expense.date) { return false }
         }

--- a/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
+++ b/mobile/PersonalDashboard/Views/Finance/ExpenseRow.swift
@@ -18,6 +18,10 @@ struct ExpenseRow: View {
     @Query(sort: [SortDescriptor(\LocalPerson.name, order: .forward)])
     private var people: [LocalPerson]
 
+    /// Trips, so a trip-tagged row in the FINANCE list can name the trip it
+    /// belongs to (#264). Trips are few; same cheap-query rationale as people.
+    @Query private var trips: [LocalTrip]
+
     var body: some View {
         HStack(spacing: Space.md) {
             Image(systemName: expense.categoryEnum.sfSymbol)
@@ -97,10 +101,24 @@ struct ExpenseRow: View {
         personLabel != nil || eventLabel != nil
     }
 
-    /// Whether any badge (person, event, or split) should render on the
+    /// Whether any badge (person, event, split, or trip) should render on the
     /// secondary badge row.
     private var hasBadges: Bool {
-        hasTags || expense.isSplit || expense.isGroupSplit
+        hasTags || expense.isSplit || expense.isGroupSplit || showsTripBadge
+    }
+
+    /// The Finance list leads with the user's SHARE of a group-split trip
+    /// expense (#264) — the full bill belongs to the trip surface. Trip
+    /// surfaces (original-first) keep leading with the full amount, where the
+    /// existing "your X of Y" badge carries the share.
+    private var leadsWithShare: Bool {
+        !showsOriginalFirst && expense.isGroupSplit
+    }
+
+    /// Finance-list rows reference the trip a row belongs to (#264). Trip
+    /// surfaces don't — the whole screen IS the trip.
+    private var showsTripBadge: Bool {
+        !showsOriginalFirst && expense.tripUUID != nil
     }
 
     /// Split badge label, e.g. "1/3 of SGD 90.00" (#188). Shows the user's
@@ -136,10 +154,44 @@ struct ExpenseRow: View {
             if expense.isSplit {
                 splitBadge
             }
-            if expense.isGroupSplit {
+            if showsTripBadge {
+                tripBadge
+            } else if expense.isGroupSplit {
                 groupSplitBadge
             }
         }
+    }
+
+    /// Trip-reference badge on FINANCE rows (#264): names the trip, and — for
+    /// a group split, where the primary amount above is the user's share —
+    /// carries the full bill so the whole picture stays on the row
+    /// ("Italy · of S$300.00"). Replaces `groupSplitBadge` in the Finance list.
+    private var tripBadge: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "airplane")
+                .font(.system(size: 9, weight: .semibold))
+            Text(tripBadgeLabel)
+                .font(.edCaption)
+                .monospacedDigit()
+                .lineLimit(1)
+        }
+        .foregroundStyle(Tokens.muted)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(Tokens.muted.opacity(0.12), in: Capsule())
+        .accessibilityLabel("Trip expense, \(tripBadgeLabel)")
+    }
+
+    private var tripName: String {
+        guard let uuid = expense.tripUUID,
+              let trip = trips.first(where: { $0.clientUUID == uuid }) else { return "Trip" }
+        let name = trip.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? "Trip" : name
+    }
+
+    private var tripBadgeLabel: String {
+        guard expense.isGroupSplit else { return tripName }
+        return "\(tripName) · of \(FinanceDashboardBand.formatMoney(expense.sgdAmount))"
     }
 
     /// Group-split badge (#258). The row's primary amount shows the FULL bill
@@ -228,8 +280,12 @@ struct ExpenseRow: View {
     /// Primary SGD amount, with a leading "+" for refunds so a credit is
     /// unmistakable at a glance (the colour alone isn't enough for the
     /// colour-blind, and "+" carries the meaning in VoiceOver too) (#206).
+    /// In the Finance list a group-split trip expense shows the user's SHARE
+    /// (#264) — matching the share-based totals around it — with the full bill
+    /// relegated to the trip badge.
     private var sgdAmountLabel: String {
-        let base = FinanceDashboardBand.formatMoney(expense.sgdAmount)
+        let value = leadsWithShare ? abs(expense.myShareSGD) : expense.sgdAmount
+        let base = FinanceDashboardBand.formatMoney(value)
         return expense.isRefund ? "+\(base)" : base
     }
 
@@ -244,19 +300,24 @@ struct ExpenseRow: View {
     }
 
     private var originalAmountLabel: String {
+        // Same share-first rule as `sgdAmountLabel` (#264): when the Finance
+        // list leads with the user's share, the original-currency sub-label
+        // shows the share too, so the two figures describe the same money.
+        let value = leadsWithShare ? abs(expense.myShareOriginal) : expense.originalAmount
         let formatter = NumberFormatter()
         formatter.minimumFractionDigits = 2
         formatter.maximumFractionDigits = 2
         formatter.numberStyle = .decimal
-        let amount = formatter.string(from: NSNumber(value: expense.originalAmount)) ?? "\(expense.originalAmount)"
+        let amount = formatter.string(from: NSNumber(value: value)) ?? "\(value)"
         let base = "\(expense.originalCurrency.uppercased()) \(amount)"
         return expense.isRefund ? "+\(base)" : base
     }
 
     private var accessibilityLabel: String {
+        let spokenValue = leadsWithShare ? abs(expense.myShareSGD) : expense.sgdAmount
         let amountSpoken = expense.isRefund
-            ? "refund \(FinanceDashboardBand.formatMoney(expense.sgdAmount))"
-            : FinanceDashboardBand.formatMoney(expense.sgdAmount)
+            ? "refund \(FinanceDashboardBand.formatMoney(spokenValue))"
+            : FinanceDashboardBand.formatMoney(spokenValue)
         var pieces: [String] = [primaryLine, amountSpoken, expense.categoryEnum.displayName]
         if showsOriginalAmount {
             pieces.append("\(originalAmountLabel) original")
@@ -266,6 +327,7 @@ struct ExpenseRow: View {
         }
         if let personLabel { pieces.append("for \(personLabel)") }
         if let eventLabel { pieces.append("event \(eventLabel)") }
+        if showsTripBadge { pieces.append("on trip \(tripName)") }
         if expense.isSplit { pieces.append("split \(expense.numberOfShares) ways, your \(splitLabel)") }
         return pieces.joined(separator: ", ") + ". Tap to edit."
     }

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -512,7 +512,7 @@ struct FinanceView: View {
 
     @ViewBuilder
     private var content: some View {
-        if allExpenses.isEmpty {
+        if !allExpenses.contains(where: { !$0.hiddenFromFinance }) {
             emptyState
         } else {
             populatedContent
@@ -752,6 +752,11 @@ struct FinanceView: View {
     /// so we don't fetch through the service when SwiftData already gave
     /// us the array via `@Query`.
     private func matches(_ expense: LocalExpense, filter: ExpenseFilter) -> Bool {
+        // Removed-from-Finance rows (#264) stay in the store to back their
+        // trip's settle-up, but no Finance surface — list, dashboard band,
+        // insights — may see them. Guard here so every aggregation site that
+        // funnels through this matcher is covered at once.
+        if expense.hiddenFromFinance { return false }
         if let range = filter.dateRange {
             if !range.contains(expense.date) { return false }
         }
@@ -906,11 +911,25 @@ struct FinanceView: View {
         let label = expense.merchant?.trimmingCharacters(in: .whitespacesAndNewlines)
             ?? expense.expenseDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
             ?? expense.categoryEnum.displayName
-        let amount = FinanceDashboardBand.formatMoney(expense.sgdAmount)
+        // Match the amount the row leads with: the user's share for a group
+        // split, the full amount otherwise (#264).
+        let shown = expense.isGroupSplit ? abs(expense.myShareSGD) : expense.sgdAmount
+        let amount = FinanceDashboardBand.formatMoney(shown)
+        if expense.tripUUID != nil && !expense.hiddenFromTrip {
+            return "\(label) · \(amount)\nRemoves it from your finances only — it stays on the trip."
+        }
         return "\(label) · \(amount)"
     }
 
     private func delete(_ expense: LocalExpense) {
+        // Per-surface delete (#264): a trip expense still visible on its trip
+        // is only hidden from Finance — the shared row keeps backing the
+        // trip's totals and settle-up, so the receipt file must survive too.
+        if expense.tripUUID != nil && !expense.hiddenFromTrip {
+            expense.hiddenFromFinance = true
+            try? modelContext.save()
+            return
+        }
         // Receipt file is the expense's only off-row dependency, so its
         // lifecycle is tied to the row. Clean up first, then the row —
         // if the file delete fails (read-only volume, etc.) we still

--- a/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Itineraries/TripExpensesView.swift
@@ -40,12 +40,20 @@ struct TripExpensesView: View {
     @State private var filterCurrency: String? = nil
     @State private var showingFilter: Bool = false
 
+    /// Expense the user has swiped-to-delete and we're confirming (#264).
+    @State private var pendingDelete: LocalExpense?
+
+    @Environment(\.modelContext) private var modelContext
+
     init(trip: LocalTrip, onEditExpense: @escaping (String) -> Void) {
         self.trip = trip
         self.onEditExpense = onEditExpense
         let tripID = trip.clientUUID
+        // Rows removed from the trip (#264) stay in the store to keep backing
+        // the Finance list, but no trip surface — totals, settle-up, list —
+        // may see them. Filtering in the predicate covers all of them at once.
         _expenses = Query(
-            filter: #Predicate<LocalExpense> { $0.tripUUID == tripID },
+            filter: #Predicate<LocalExpense> { $0.tripUUID == tripID && !$0.hiddenFromTrip },
             sort: [
                 SortDescriptor(\.date, order: .reverse),
                 SortDescriptor(\.createdAt, order: .reverse)
@@ -61,6 +69,65 @@ struct TripExpensesView: View {
                 populated
             }
         }
+        .confirmationDialog(
+            "Remove this expense?",
+            isPresented: deleteDialogBinding,
+            titleVisibility: .visible
+        ) {
+            Button("Remove", role: .destructive) {
+                if let row = pendingDelete {
+                    delete(row)
+                }
+                pendingDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDelete = nil
+            }
+        } message: {
+            Text(pendingDelete.map { deleteMessage(for: $0) } ?? "")
+        }
+    }
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(
+            get: { pendingDelete != nil },
+            set: { newValue in if !newValue { pendingDelete = nil } }
+        )
+    }
+
+    private func deleteMessage(for expense: LocalExpense) -> String {
+        let label = expense.merchant?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? expense.expenseDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
+            ?? expense.categoryEnum.displayName
+        let amount = Self.formatOriginal(expense.originalAmount, code: expense.originalCurrency.uppercased())
+        if expense.hiddenFromFinance {
+            return "\(label) · \(amount)"
+        }
+        return "\(label) · \(amount)\nRemoves it from this trip only — it stays in your finances."
+    }
+
+    /// Trip-side delete honouring the per-surface visibility model (#264): a
+    /// row still visible in Finance is only HIDDEN from the trip; a row the
+    /// user already removed from Finance has no remaining surface and is
+    /// physically deleted (receipt file cleaned up unless a sibling row from
+    /// the same multi-expense import still references it).
+    private func delete(_ expense: LocalExpense) {
+        if !expense.hiddenFromFinance {
+            expense.hiddenFromTrip = true
+            try? modelContext.save()
+            return
+        }
+        if let path = expense.receiptImagePath {
+            let all = (try? modelContext.fetch(FetchDescriptor<LocalExpense>())) ?? []
+            let stillReferenced = all.contains {
+                $0.clientUUID != expense.clientUUID && $0.receiptImagePath == path
+            }
+            if !stillReferenced {
+                try? ReceiptStorage.shared.delete(relativePath: path)
+            }
+        }
+        modelContext.delete(expense)
+        try? modelContext.save()
     }
 
     // MARK: - Populated
@@ -465,6 +532,9 @@ struct TripExpensesView: View {
                 ForEach(visibleExpenses) { expense in
                     ExpenseRow(expense: expense, showsOriginalFirst: true) {
                         onEditExpense(expense.clientUUID)
+                    }
+                    .swipeToDeleteTrash {
+                        pendingDelete = expense
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Finance list rows for group-split trip expenses lead with the user's share (converted + original-currency sub-label); the badge names the trip and carries the full bill ("Italy · of S$300.00"). Unsplit trip rows get a trip-name badge too.
- New additive `LocalExpense` flags `hiddenFromFinance` / `hiddenFromTrip` disassociate the two surfaces: deleting a trip expense from Finance only hides it there (trip totals and settle-up untouched); a new swipe-to-delete on the trip Expenses tab hides it from the trip only. A row hidden on both surfaces is hard-deleted (receipt file cleaned up only then).
- Bulk deletes (chat `clear_expenses`, delete-by-statement) follow the same per-surface rule; dedup still sees hidden rows so re-imports can't resurrect duplicates.
- Assistant context respects both flags and now reports share-based month/category totals, matching the Finance UI.

Closes #264

## Test plan
- [x] Clean static build (`xcodegen generate` + `xcodebuild`)
- [x] Shipped to device (build `5ba98af`); owner QA on Finance list display, Finance-side delete, trip-side delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)