### PR TITLE
feat(ios): task priority with colored left-edge bar

### DIFF
--- a/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
+++ b/mobile/PersonalDashboard/AI/AssistantContextBuilder.swift
@@ -51,6 +51,11 @@ struct AssistantContextBuilder {
                 if let tag = todo.tag, !tag.isEmpty {
                     line += " [\(Self.safe(tag, maxLen: 50))]"
                 }
+                // Surface priority (when set) so the model can target "make the
+                // taxes task p0" and skip a redundant edit if it is already there.
+                if let p = TaskPriority(rawValue: todo.priority), p != .none {
+                    line += " {\(p.label)}"
+                }
                 if todo.completed {
                     line += " ✓"
                 }

--- a/mobile/PersonalDashboard/AI/ChatDraft.swift
+++ b/mobile/PersonalDashboard/AI/ChatDraft.swift
@@ -64,6 +64,13 @@ extension ChatDraft {
             if let title = dict["title"]?.stringValue, !title.isEmpty, title != "null" {
                 summary += ": \"\(title)\""
             }
+            if let raw = dict["priority"]?.stringValue, !raw.isEmpty {
+                if raw == "null" {
+                    summary += " {clear priority}"
+                } else if let p = TaskPriority(aiString: raw) {
+                    summary += " {\(p.label)}"
+                }
+            }
             return summary
 
         case .updateNote:
@@ -106,6 +113,9 @@ extension ChatDraft {
             }
             if let tag = dict["tag"]?.stringValue, !tag.isEmpty, tag != "null" {
                 summary += " [\(tag)]"
+            }
+            if let p = TaskPriority(aiString: dict["priority"]?.stringValue), p != .none {
+                summary += " {\(p.label)}"
             }
             return summary
 

--- a/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
+++ b/mobile/PersonalDashboard/AI/ExecuteDraftAction.swift
@@ -556,6 +556,8 @@ struct ExecuteDraftAction {
         let description = trimmedString(input["description"])
         let dueDate = parseISODate(trimmedString(input["due_at"]))
         let tag = trimmedString(input["tag"])
+        // Empty / unknown -> no priority (0). Parseable value -> its raw Int.
+        let priority = TaskPriority(aiString: trimmedString(input["priority"]))?.rawValue ?? 0
 
         let now = Date()
         let row = LocalTodo(
@@ -564,6 +566,7 @@ struct ExecuteDraftAction {
             completed: false,
             dueDate: dueDate,
             tag: tag,
+            priority: priority,
             createdAt: now,
             updatedAt: now,
             needsSync: false
@@ -672,6 +675,16 @@ struct ExecuteDraftAction {
                 row.tag = nil; changed = true
             } else if !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 row.tag = raw.trimmingCharacters(in: .whitespacesAndNewlines); changed = true
+            }
+        }
+        // "null" -> clear to none, empty -> keep, parseable value -> set. Mirrors
+        // the tag sentinel above.
+        if let raw = input["priority"]?.stringValue {
+            if raw == "null" {
+                row.priority = 0; changed = true
+            } else if !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                      let parsed = TaskPriority(aiString: raw) {
+                row.priority = parsed.rawValue; changed = true
             }
         }
         guard changed else {

--- a/mobile/PersonalDashboard/AI/ToolDefinitions.swift
+++ b/mobile/PersonalDashboard/AI/ToolDefinitions.swift
@@ -78,9 +78,10 @@ enum ToolDefinitions {
                 "title": string("The title or main text of the task"),
                 "description": string("Optional additional details or notes about the task"),
                 "due_at": string("Due date in ISO 8601 format (e.g., 2024-01-15T14:00:00.000Z). Parse relative dates like \"tomorrow\", \"next week\", etc. Use empty string if no due date."),
-                "tag": string("Category tag for the task (e.g., \"Work\", \"Personal\", \"Shopping\", \"Health\"). Use empty string if no tag.")
+                "tag": string("Category tag for the task (e.g., \"Work\", \"Personal\", \"Shopping\", \"Health\"). Use empty string if no tag."),
+                "priority": string("Task priority. Use \"p0\" (highest/urgent), \"p1\" (medium), or \"p2\" (low). Use empty string when the user does not indicate a priority.")
             ],
-            required: ["title", "description", "due_at", "tag"]
+            required: ["title", "description", "due_at", "tag", "priority"]
         )
     )
 
@@ -140,9 +141,10 @@ enum ToolDefinitions {
                 "title": string("New title for the task. Use empty string ONLY to keep current title unchanged (at least one other field must have a value)."),
                 "description": string("New description for the task. Use empty string to keep unchanged, or \"null\" to clear/delete the description."),
                 "due_at": string("New due date in ISO 8601 format. Use empty string to keep unchanged, or \"null\" to remove. At least one field must actually change."),
-                "tag": string("New tag for the task. Use empty string to keep unchanged, or \"null\" to remove. At least one field must actually change.")
+                "tag": string("New tag for the task. Use empty string to keep unchanged, or \"null\" to remove. At least one field must actually change."),
+                "priority": string("New priority: \"p0\" (highest), \"p1\" (medium), or \"p2\" (low). Use empty string to keep unchanged, or \"null\" to clear it back to no priority.")
             ],
-            required: ["id", "title", "description", "due_at", "tag"]
+            required: ["id", "title", "description", "due_at", "tag", "priority"]
         )
     )
 

--- a/mobile/PersonalDashboard/Design/Tokens.swift
+++ b/mobile/PersonalDashboard/Design/Tokens.swift
@@ -129,14 +129,21 @@ enum Tokens {
     static let dangerSoft   = Color.paper(0xFEE2E2, 0x450A0A)
     static let info         = Color.paper(0x0E7490, 0x22D3EE)
 
-    /// Edge-bar color for a task priority. Reuses the existing semantic tokens
-    /// (no new hex): P0 danger, P1 warning, P2/none success.
+    /// Edge-bar color for a task priority. Uses dedicated priority hues rather
+    /// than the alert `danger`/`warning` tokens: those two sit too close in
+    /// light mode (brick red vs brownish amber) to tell apart on a thin bar.
+    /// These are picked for maximum hue separation — a true red, a golden
+    /// yellow, and a green — each light/dark-aware. P2 and none share green.
+    static let priorityRed    = Color.paper(0xDC2626, 0xF87171)
+    static let priorityYellow = Color.paper(0xEAB308, 0xFACC15)
+    static let priorityGreen  = Color.paper(0x16A34A, 0x4ADE80)
+
     static func priorityColor(for p: TaskPriority) -> Color {
         switch p {
-        case .p0:   return danger
-        case .p1:   return warning
-        case .p2:   return success
-        case .none: return success
+        case .p0:   return priorityRed
+        case .p1:   return priorityYellow
+        case .p2:   return priorityGreen
+        case .none: return priorityGreen
         }
     }
 

--- a/mobile/PersonalDashboard/Design/Tokens.swift
+++ b/mobile/PersonalDashboard/Design/Tokens.swift
@@ -129,6 +129,17 @@ enum Tokens {
     static let dangerSoft   = Color.paper(0xFEE2E2, 0x450A0A)
     static let info         = Color.paper(0x0E7490, 0x22D3EE)
 
+    /// Edge-bar color for a task priority. Reuses the existing semantic tokens
+    /// (no new hex): P0 danger, P1 warning, P2/none success.
+    static func priorityColor(for p: TaskPriority) -> Color {
+        switch p {
+        case .p0:   return danger
+        case .p1:   return warning
+        case .p2:   return success
+        case .none: return success
+        }
+    }
+
     static func accent(for section: AppSection) -> Color {
         switch section {
         case .chat:        return accentChat

--- a/mobile/PersonalDashboard/Models/Local/LocalTodo.swift
+++ b/mobile/PersonalDashboard/Models/Local/LocalTodo.swift
@@ -26,6 +26,11 @@ final class LocalTodo {
     /// the row shows a tappable "MAP" chip only when it resolves to a URL.
     var googleMapsLink: String = ""
 
+    /// Task priority as a raw `Int` (see `TaskPriority`). Local-only, stored
+    /// with a default so adding it to an existing install is a safe lightweight
+    /// migration (no data loss). Drives the colored left-edge bar on task rows.
+    var priority: Int = 0
+
     var version: Int64
 
     var createdAt: Date
@@ -44,6 +49,7 @@ final class LocalTodo {
         position: Int? = nil,
         address: String = "",
         googleMapsLink: String = "",
+        priority: Int = 0,
         version: Int64 = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
@@ -59,6 +65,7 @@ final class LocalTodo {
         self.position = position
         self.address = address
         self.googleMapsLink = googleMapsLink
+        self.priority = priority
         self.version = version
         self.createdAt = createdAt
         self.updatedAt = updatedAt
@@ -83,7 +90,8 @@ final class LocalTodo {
             updatedAt: updatedAt,
             deletedAt: deletedAt,
             address: address,
-            googleMapsLink: googleMapsLink
+            googleMapsLink: googleMapsLink,
+            priority: priority
         )
     }
 }

--- a/mobile/PersonalDashboard/Models/TaskPriority.swift
+++ b/mobile/PersonalDashboard/Models/TaskPriority.swift
@@ -22,6 +22,17 @@ enum TaskPriority: Int, CaseIterable, Sendable {
         }
     }
 
+    /// Ordering weight for task lists: P0 first, then P1, then P2/none last.
+    /// `p2` and `none` share the lowest rank since they read as the same
+    /// (green) priority. Lower value sorts to the top.
+    var sortRank: Int {
+        switch self {
+        case .p0:          return 0
+        case .p1:          return 1
+        case .p2, .none:   return 2
+        }
+    }
+
     /// Parse a value supplied by the AI tools. Accepts "p0"/"p1"/"p2"
     /// (case-insensitive) plus common synonyms ("high"/"medium"/"low").
     /// Empty or unrecognised input returns `nil` so callers decide whether that

--- a/mobile/PersonalDashboard/Models/TaskPriority.swift
+++ b/mobile/PersonalDashboard/Models/TaskPriority.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Priority level for a task. Local-only concept — the server sync contract has
+/// no column for it, so it lives on `LocalTodo.priority` as the raw `Int` and is
+/// omitted from `Todo`'s `CodingKeys` (same treatment as `address`).
+///
+/// `none` is the default (raw value 0). It renders the same neutral edge accent
+/// as `p2` so an unprioritised task still reads as calm/green rather than blank.
+enum TaskPriority: Int, CaseIterable, Sendable {
+    case none = 0
+    case p0 = 1
+    case p1 = 2
+    case p2 = 3
+
+    /// Short label for the editor picker and the AI context line.
+    var label: String {
+        switch self {
+        case .none: return "None"
+        case .p0:   return "P0"
+        case .p1:   return "P1"
+        case .p2:   return "P2"
+        }
+    }
+
+    /// Parse a value supplied by the AI tools. Accepts "p0"/"p1"/"p2"
+    /// (case-insensitive) plus common synonyms ("high"/"medium"/"low").
+    /// Empty or unrecognised input returns `nil` so callers decide whether that
+    /// means "leave unchanged" (edit) or "no priority" (create).
+    init?(aiString raw: String?) {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !trimmed.isEmpty else { return nil }
+        switch trimmed {
+        case "p0", "high", "urgent", "critical": self = .p0
+        case "p1", "medium", "med", "normal":    self = .p1
+        case "p2", "low":                        self = .p2
+        case "none", "no", "0":                  self = .none
+        default:                                 return nil
+        }
+    }
+}

--- a/mobile/PersonalDashboard/Models/Todo.swift
+++ b/mobile/PersonalDashboard/Models/Todo.swift
@@ -28,6 +28,15 @@ struct Todo: Codable, Identifiable, Hashable, Sendable {
     /// Optional Google Maps URL. Local-only, same handling as `address`.
     var googleMapsLink: String = ""
 
+    /// Task priority as a raw `Int` (see `TaskPriority`). Local-only, same
+    /// handling as `address`/`googleMapsLink`: defaulted and omitted from
+    /// `CodingKeys` so the server sync contract is untouched.
+    var priority: Int = 0
+
+    /// Typed view of `priority` for the UI. Unknown raw values fall back to
+    /// `.none` so a bad stored value never renders a blank/missing bar.
+    var taskPriority: TaskPriority { TaskPriority(rawValue: priority) ?? .none }
+
     /// Server JSON has both `id` (int) and `client_uuid`; we map our `id`
     /// to `client_uuid` and ignore the server's int. The decoder's
     /// `.convertFromSnakeCase` strategy turns `client_uuid` into
@@ -66,6 +75,7 @@ struct TodoCreateRequest: Encodable {
     let tag: String?
     var address: String = ""
     var googleMapsLink: String = ""
+    var priority: Int = 0
 }
 
 struct TodoUpdateRequest: Encodable {
@@ -77,4 +87,6 @@ struct TodoUpdateRequest: Encodable {
     /// `nil` leaves the stored value untouched; a value (incl. "") overwrites.
     var address: String? = nil
     var googleMapsLink: String? = nil
+    /// `nil` leaves the stored priority untouched; a value overwrites it.
+    var priority: Int? = nil
 }

--- a/mobile/PersonalDashboard/Services/TodoService.swift
+++ b/mobile/PersonalDashboard/Services/TodoService.swift
@@ -37,6 +37,7 @@ struct TodoService {
             tag: request.tag,
             address: request.address,
             googleMapsLink: request.googleMapsLink,
+            priority: request.priority,
             createdAt: now,
             updatedAt: now
         )
@@ -54,6 +55,7 @@ struct TodoService {
         if let tag = request.tag { row.tag = tag }
         if let address = request.address { row.address = address }
         if let googleMapsLink = request.googleMapsLink { row.googleMapsLink = googleMapsLink }
+        if let priority = request.priority { row.priority = priority }
         row.updatedAt = Date()
         try store.context.save()
         return row.toDTO()

--- a/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
@@ -41,9 +41,9 @@ final class TodosViewModel {
         await load()
     }
 
-    func create(title: String, description: String? = nil, dueDate: Date? = nil, tag: String? = nil, address: String = "", googleMapsLink: String = "") async {
+    func create(title: String, description: String? = nil, dueDate: Date? = nil, tag: String? = nil, address: String = "", googleMapsLink: String = "", priority: Int = 0) async {
         do {
-            let request = TodoCreateRequest(title: title, description: description, dueDate: dueDate, tag: tag, address: address, googleMapsLink: googleMapsLink)
+            let request = TodoCreateRequest(title: title, description: description, dueDate: dueDate, tag: tag, address: address, googleMapsLink: googleMapsLink, priority: priority)
             let new = try await service.create(request)
             todos.insert(new, at: 0)
         } catch {
@@ -65,7 +65,7 @@ final class TodosViewModel {
         }
     }
 
-    func update(_ todo: Todo, title: String? = nil, description: String? = nil, dueDate: Date? = nil, tag: String? = nil, address: String? = nil, googleMapsLink: String? = nil) async {
+    func update(_ todo: Todo, title: String? = nil, description: String? = nil, dueDate: Date? = nil, tag: String? = nil, address: String? = nil, googleMapsLink: String? = nil, priority: Int? = nil) async {
         do {
             let request = TodoUpdateRequest(
                 title: title,
@@ -74,7 +74,8 @@ final class TodosViewModel {
                 dueDate: dueDate,
                 tag: tag,
                 address: address,
-                googleMapsLink: googleMapsLink
+                googleMapsLink: googleMapsLink,
+                priority: priority
             )
             let updated = try await service.update(todo, request)
             if let index = todos.firstIndex(where: { $0.id == todo.id }) {

--- a/mobile/PersonalDashboard/Views/Tasks/TagChipPicker.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TagChipPicker.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+
+// MARK: - Wrapping flow layout
+
+/// A minimal flow layout: lays subviews left-to-right and wraps to the next
+/// line when the current row runs out of horizontal space. iOS 17+ `Layout`.
+/// The app has no other flow/wrap primitive, so this is the reusable one.
+struct WrapLayout: Layout {
+    var spacing: CGFloat = Space.sm
+    var lineSpacing: CGFloat = Space.sm
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let rows = computeRows(maxWidth: maxWidth, subviews: subviews)
+        let height = rows.reduce(CGFloat(0)) { $0 + $1.height }
+            + lineSpacing * CGFloat(max(0, rows.count - 1))
+        let width = maxWidth.isFinite ? maxWidth : (rows.map(\.width).max() ?? 0)
+        return CGSize(width: width, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        let rows = computeRows(maxWidth: bounds.width, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            var x = bounds.minX
+            for index in row.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(
+                    at: CGPoint(x: x, y: y),
+                    anchor: .topLeading,
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + spacing
+            }
+            y += row.height + lineSpacing
+        }
+    }
+
+    private struct Row {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func computeRows(maxWidth: CGFloat, subviews: Subviews) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let projected = current.indices.isEmpty
+                ? size.width
+                : current.width + spacing + size.width
+            if !current.indices.isEmpty && projected > maxWidth {
+                rows.append(current)
+                current = Row(indices: [index], width: size.width, height: size.height)
+            } else {
+                current.indices.append(index)
+                current.width = current.indices.count == 1 ? size.width : current.width + spacing + size.width
+                current.height = max(current.height, size.height)
+            }
+        }
+        if !current.indices.isEmpty { rows.append(current) }
+        return rows
+    }
+}
+
+// MARK: - Tag chip picker
+
+/// Single-select tag picker rendered as wrapping capsule chips. A todo carries
+/// exactly one tag, so tapping an unselected chip selects it and tapping the
+/// selected chip clears the selection. A trailing "New tag" affordance reveals
+/// an inline field for creating a tag that isn't in the list yet.
+struct TagChipPicker: View {
+    /// The selected tag. Empty string means "no tag". Single-select.
+    @Binding var selection: String
+    /// Existing distinct tags, already sorted by the caller. The picker folds
+    /// in the current selection so a brand-new or one-off tag still shows.
+    let tags: [String]
+
+    @State private var isAddingNew = false
+    @State private var newTagText = ""
+    @FocusState private var newTagFocused: Bool
+
+    /// Chips to render: the caller's tags plus the current selection if it's
+    /// not already present (covers a freshly-added tag and an edited todo's
+    /// sole-owner tag).
+    private var displayTags: [String] {
+        var result = tags
+        let sel = selection.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !sel.isEmpty && !result.contains(where: { $0.caseInsensitiveCompare(sel) == .orderedSame }) {
+            result.append(sel)
+        }
+        return result
+    }
+
+    var body: some View {
+        WrapLayout(spacing: Space.sm, lineSpacing: Space.sm) {
+            ForEach(displayTags, id: \.self) { tag in
+                chip(tag)
+            }
+            addNewChip
+        }
+    }
+
+    private func isSelected(_ tag: String) -> Bool {
+        selection.caseInsensitiveCompare(tag) == .orderedSame && !selection.isEmpty
+    }
+
+    private func chip(_ tag: String) -> some View {
+        let selected = isSelected(tag)
+        return Button {
+            selection = selected ? "" : tag
+        } label: {
+            Text(tag)
+                .font(.edFootnote)
+                .foregroundStyle(selected ? Tokens.accentTasks : Tokens.ink)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 6)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(selected ? Tokens.accentTasks.opacity(0.12) : Tokens.surface)
+                )
+                .overlay(
+                    Capsule(style: .continuous)
+                        .stroke(selected ? Tokens.accentTasks : Tokens.border,
+                                lineWidth: selected ? 1 : 0.5)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(selected ? [.isSelected, .isButton] : .isButton)
+    }
+
+    @ViewBuilder
+    private var addNewChip: some View {
+        if isAddingNew {
+            TextField("New tag", text: $newTagText)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .focused($newTagFocused)
+                .submitLabel(.done)
+                .onSubmit { commitNewTag() }
+                .frame(minWidth: 120, maxWidth: 200)
+                .padding(.horizontal, Space.md)
+                .padding(.vertical, Space.sm)
+                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                .paperBorder(Tokens.border, radius: Radius.md)
+        } else {
+            Button {
+                isAddingNew = true
+                DispatchQueue.main.async { newTagFocused = true }
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("New tag")
+                        .font(.edFootnote)
+                }
+                .foregroundStyle(Tokens.muted)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 6)
+                .background(Capsule(style: .continuous).fill(Tokens.surface))
+                .overlay(
+                    Capsule(style: .continuous)
+                        .stroke(Tokens.border, style: StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
+                )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Add new tag")
+        }
+    }
+
+    private func commitNewTag() {
+        let trimmed = newTagText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { selection = trimmed }
+        newTagText = ""
+        isAddingNew = false
+        newTagFocused = false
+    }
+}

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -655,6 +655,13 @@ private struct TaskRow: View {
         .padding(.vertical, Space.sm)
         .padding(.horizontal, Space.md)
         .background(Color.clear)
+        // Thin colored left-edge bar keyed to the task's priority. Spans the row
+        // height at the leading edge; reads as a subtle accent, not a block.
+        .overlay(alignment: .leading) {
+            RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+                .fill(Tokens.priorityColor(for: todo.taskPriority))
+                .frame(width: Space.xs)
+        }
         .contentShape(Rectangle())
         .onTapGesture {
             // When a tap-below draft is active, actively flip draftFocused in the parent
@@ -715,6 +722,7 @@ private struct TaskEditorSheet: View {
     @State private var hasDueDate: Bool = false
     @State private var dueDate: Date = Date().addingTimeInterval(3600)
     @State private var tag: String = ""
+    @State private var priority: TaskPriority = .none
     @State private var address: String = ""
     @State private var googleMapsLink: String = ""
     @State private var isResolvingAddress = false
@@ -773,6 +781,14 @@ private struct TaskEditorSheet: View {
                                 .padding(Space.md)
                                 .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
                                 .paperBorder(Tokens.border, radius: Radius.md)
+                        }
+                        labeled("Priority") {
+                            Picker("Priority", selection: $priority) {
+                                ForEach(TaskPriority.allCases, id: \.self) { p in
+                                    Text(p.label).tag(p)
+                                }
+                            }
+                            .pickerStyle(.segmented)
                         }
                         VStack(alignment: .leading, spacing: Space.fieldLabelGap) {
                             HStack(spacing: Space.sm) {
@@ -856,6 +872,7 @@ private struct TaskEditorSheet: View {
         descriptionText = todo.description ?? ""
         if let due = todo.dueDate { hasDueDate = true; dueDate = due }
         tag = todo.tag ?? ""
+        priority = todo.taskPriority
         address = todo.address
         googleMapsLink = todo.googleMapsLink
     }
@@ -892,9 +909,9 @@ private struct TaskEditorSheet: View {
         let finalAddress = address.trimmingCharacters(in: .whitespacesAndNewlines)
         let finalMapsLink = googleMapsLink.trimmingCharacters(in: .whitespacesAndNewlines)
         if let existing = todo {
-            await viewModel.update(existing, title: trimmed, description: finalDescription, dueDate: finalDue, tag: finalTag, address: finalAddress, googleMapsLink: finalMapsLink)
+            await viewModel.update(existing, title: trimmed, description: finalDescription, dueDate: finalDue, tag: finalTag, address: finalAddress, googleMapsLink: finalMapsLink, priority: priority.rawValue)
         } else {
-            await viewModel.create(title: trimmed, description: finalDescription, dueDate: finalDue, tag: finalTag, address: finalAddress, googleMapsLink: finalMapsLink)
+            await viewModel.create(title: trimmed, description: finalDescription, dueDate: finalDue, tag: finalTag, address: finalAddress, googleMapsLink: finalMapsLink, priority: priority.rawValue)
         }
         dismiss()
     }

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -8,7 +8,7 @@ struct TasksView: View {
     @State private var completedExpanded: Bool = false
     // Per-section tap-below inline draft state.
     // draftBucket == nil → no draft active; non-nil → draft in that section.
-    private enum DraftBucket: String { case today, thisWeek, later, noDate }
+    private enum DraftBucket: String { case today, tomorrow, thisWeek, later, noDate }
     @State private var draftBucket: DraftBucket? = nil
     @State private var draftText: String = ""
     @FocusState private var draftFocused: Bool
@@ -147,6 +147,9 @@ struct TasksView: View {
         switch bucket {
         case .today:
             return cal.date(bySettingHour: 23, minute: 0, second: 0, of: today)
+        case .tomorrow:
+            let eod = cal.date(bySettingHour: 23, minute: 0, second: 0, of: today)!
+            return cal.date(byAdding: .day, value: 1, to: eod)
         case .thisWeek:
             let eod = cal.date(bySettingHour: 23, minute: 0, second: 0, of: today)!
             return cal.date(byAdding: .day, value: 3, to: eod)
@@ -262,6 +265,9 @@ struct TasksView: View {
         if !buckets.today.isEmpty || draftBucket == .today {
             taskSection(title: "Today", count: buckets.today.count, accent: Tokens.warning, soft: Tokens.warningSoft, todos: buckets.today, bucket: .today)
         }
+        if !buckets.tomorrow.isEmpty || draftBucket == .tomorrow {
+            taskSection(title: "Tomorrow", count: buckets.tomorrow.count, accent: Tokens.info, soft: Tokens.paper2, todos: buckets.tomorrow, bucket: .tomorrow)
+        }
         if !buckets.thisWeek.isEmpty || draftBucket == .thisWeek {
             taskSection(title: "This Week", count: buckets.thisWeek.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: buckets.thisWeek, bucket: .thisWeek)
         }
@@ -279,10 +285,23 @@ struct TasksView: View {
     private struct TaskBuckets {
         var overdue: [Todo] = []
         var today: [Todo] = []
+        var tomorrow: [Todo] = []
         var thisWeek: [Todo] = []
         var later: [Todo] = []
         var noDate: [Todo] = []
         var completed: [Todo] = []
+    }
+
+    /// Sort order shared by every open bucket: highest priority first
+    /// (P0 → P1 → P2/none), and within one priority the most recently created
+    /// task on top. Keeps the date-based sections intact while ranking rows
+    /// inside each section by urgency.
+    private func prioritySorted(_ todos: [Todo]) -> [Todo] {
+        todos.sorted { a, b in
+            let ra = a.taskPriority.sortRank, rb = b.taskPriority.sortRank
+            if ra != rb { return ra < rb }
+            return a.createdAt > b.createdAt
+        }
     }
 
     private func computeBuckets() -> TaskBuckets {
@@ -290,6 +309,7 @@ struct TasksView: View {
         let cal = Calendar.current
         let today = cal.startOfDay(for: now)
         let tomorrow = cal.date(byAdding: .day, value: 1, to: today)!
+        let dayAfterTomorrow = cal.date(byAdding: .day, value: 2, to: today)!
         let weekEnd = cal.date(byAdding: .day, value: 7, to: today)!
 
         var b = TaskBuckets()
@@ -299,9 +319,16 @@ struct TasksView: View {
             guard let due = todo.dueDate else { b.noDate.append(todo); continue }
             if due < today { b.overdue.append(todo) }
             else if due < tomorrow { b.today.append(todo) }
+            else if due < dayAfterTomorrow { b.tomorrow.append(todo) }
             else if due < weekEnd { b.thisWeek.append(todo) }
             else { b.later.append(todo) }
         }
+        b.overdue = prioritySorted(b.overdue)
+        b.today = prioritySorted(b.today)
+        b.tomorrow = prioritySorted(b.tomorrow)
+        b.thisWeek = prioritySorted(b.thisWeek)
+        b.later = prioritySorted(b.later)
+        b.noDate = prioritySorted(b.noDate)
         return b
     }
 

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -671,7 +671,7 @@ private struct TaskRow: View {
             Button(action: onInfoTap) {
                 Image(systemName: "info.circle")
                     .font(.system(size: 18, weight: .regular))
-                    .foregroundStyle(Tokens.warning)
+                    .foregroundStyle(Tokens.mutedSoft)
                     .frame(width: 32, height: 32, alignment: .trailing)
                     .contentShape(Rectangle())
             }
@@ -759,6 +759,16 @@ private struct TaskEditorSheet: View {
 
     private var isEditing: Bool { todo != nil }
 
+    /// Distinct, non-empty tags across all todos, sorted case-insensitively.
+    /// The picker itself folds in the current selection, so a tag the edited
+    /// todo carries (or a just-added new tag) still shows even if it's the
+    /// only todo using it.
+    private var availableTags: [String] {
+        Set(viewModel.todos.compactMap { $0.tag })
+            .filter { !$0.isEmpty }
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
     /// The current editor's maps link as a URL, coercing a bare host to https.
     /// `nil` when the field is empty (so the Open button stays hidden).
     private var editorMapsURL: URL? {
@@ -792,22 +802,35 @@ private struct TaskEditorSheet: View {
                                 .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
                                 .paperBorder(Tokens.border, radius: Radius.md)
                         }
-                        Toggle(isOn: $hasDueDate.animation()) {
-                            Text("Due date").font(.edBodyMedium).foregroundStyle(Tokens.ink)
-                        }
-                        if hasDueDate {
-                            DatePicker("", selection: $dueDate)
-                                .labelsHidden()
-                                .tint(Tokens.accentTasks)
+                        labeled("Due date") {
+                            VStack(spacing: 0) {
+                                HStack {
+                                    Text("Set a due date")
+                                        .font(.edBody)
+                                        .foregroundStyle(Tokens.inkSoft)
+                                    Spacer()
+                                    Toggle("", isOn: $hasDueDate.animation())
+                                        .labelsHidden()
+                                        .tint(Tokens.accentTasks)
+                                }
+                                .padding(Space.md)
+
+                                if hasDueDate {
+                                    Divider().background(Tokens.divider)
+                                    HStack {
+                                        DatePicker("", selection: $dueDate, displayedComponents: [.date, .hourAndMinute])
+                                            .labelsHidden()
+                                            .tint(Tokens.accentTasks)
+                                        Spacer(minLength: 0)
+                                    }
+                                    .padding(Space.md)
+                                }
+                            }
+                            .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
+                            .paperBorder(Tokens.border, radius: Radius.md)
                         }
                         labeled("Tag") {
-                            TextField("e.g. work, personal", text: $tag)
-                                .textInputAutocapitalization(.never)
-                                .font(.edBody)
-                                .foregroundStyle(Tokens.ink)
-                                .padding(Space.md)
-                                .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))
-                                .paperBorder(Tokens.border, radius: Radius.md)
+                            TagChipPicker(selection: $tag, tags: availableTags)
                         }
                         labeled("Priority") {
                             Picker("Priority", selection: $priority) {

--- a/mobile/PersonalDashboard/Views/Today/TodayView.swift
+++ b/mobile/PersonalDashboard/Views/Today/TodayView.swift
@@ -314,6 +314,12 @@ private struct TodayTaskRow: View {
         }
         .padding(.horizontal, Space.lg)
         .padding(.vertical, Space.md)
+        // Thin colored left-edge bar keyed to priority, matching the Tasks screen.
+        .overlay(alignment: .leading) {
+            RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+                .fill(Tokens.priorityColor(for: todo.taskPriority))
+                .frame(width: Space.xs)
+        }
     }
 
     private func isOverdue(_ date: Date) -> Bool {

--- a/mobile/PersonalDashboard/Views/Today/TodayView.swift
+++ b/mobile/PersonalDashboard/Views/Today/TodayView.swift
@@ -63,8 +63,19 @@ struct TodayView: View {
 
     private var tasksCard: some View {
         let open = todosVM.todos.filter { !$0.completed }
+        // Highest priority first (P0 → P1 → P2/none), newest within a priority,
+        // matching the Tasks screen ordering so the preview surfaces P0 rows.
+        let byPriority: ([Todo]) -> [Todo] = { todos in
+            todos.sorted { a, b in
+                let ra = a.taskPriority.sortRank, rb = b.taskPriority.sortRank
+                if ra != rb { return ra < rb }
+                return a.createdAt > b.createdAt
+            }
+        }
         let dueTodayOrSoon = open.filter { isDueTodayOrOverdue($0.dueDate) }
-        let preview = dueTodayOrSoon.isEmpty ? Array(open.prefix(5)) : Array(dueTodayOrSoon.prefix(5))
+        let preview = dueTodayOrSoon.isEmpty
+            ? Array(byPriority(open).prefix(5))
+            : Array(byPriority(dueTodayOrSoon).prefix(5))
 
         return TodayCard(
             section: .tasks,


### PR DESCRIPTION
## Summary
Adds a priority concept to tasks and surfaces it as a colored left-edge bar, plus editor and AI wiring, priority-aware sorting, and a few editor UX fixes.

- Local-only `TaskPriority` (None / P0 / P1 / P2) on todos: additive, migration-safe field (defaulted, omitted from `CodingKeys`, no server/sync changes).
- Colored left-edge bar on task rows (Tasks screen + Today widget), using dedicated distinct red / yellow / green hues (not the alert tokens, which read too similar in light mode).
- Priority set two ways: a segmented picker in the task editor, and the AI capture/chat tools ("make the taxes task p0").
- Tasks screen split restored/extended: Overdue → Today → Tomorrow → This Week → Later → No Date. Within each section, sorted P0 → P1 → P2/none, newest-first within a priority. Today widget preview matches.
- Editor polish: info icon recolored gray to match Lists rows; free-text tag field replaced with tappable tag chips ("pills") from existing tags + an add-new option; due-date field rebuilt to match the Finance / Itinerary carded date pattern.

Closes #263

## Test plan
Device QA completed on iPhone 16 Pro Max across several rounds:
- [x] Existing tasks survive the migration (no data loss); default renders green.
- [x] Editor picker sets P0/P1/P2/None; bar color updates and persists across relaunch.
- [x] Bar renders on both the Tasks screen and Today widget, light and dark mode; red / yellow / green are clearly distinct.
- [x] Tomorrow section appears; sections sort by priority then recency.
- [x] AI chat/capture sets priority on new and existing tasks.
- [x] Tag chips select/clear and add-new works; due-date card matches Finance/Itinerary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)