### PR TITLE
feat(ios): chronological task sort, list ordering, and a visible add affordance

### DIFF
--- a/mobile/PersonalDashboard/Services/TodoService.swift
+++ b/mobile/PersonalDashboard/Services/TodoService.swift
@@ -14,12 +14,13 @@ struct TodoService {
 
     // MARK: - Reads
 
-    /// Return the live, undeleted todos sorted by createdAt descending.
+    /// Return the live, undeleted todos sorted by createdAt ascending
+    /// (oldest first, newest last) so new tasks land at the bottom (#267).
     func list() async throws -> [Todo] {
         let context = store.context
         let descriptor = FetchDescriptor<LocalTodo>(
             predicate: #Predicate { $0.deletedAt == nil },
-            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+            sortBy: [SortDescriptor(\.createdAt, order: .forward)]
         )
         let rows = try context.fetch(descriptor)
         return rows.map { $0.toDTO() }

--- a/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/ListsViewModel.swift
@@ -165,19 +165,34 @@ final class ListsViewModel {
         await update(snapshot)
     }
 
-    func addItem(to list: Checklist, text: String) async {
+    /// Insert a new item at the end of the ACTIVE (non-completed) items — just
+    /// before the first completed item, so it appears below the last active
+    /// item but never below the completed block, which always stays at the
+    /// bottom (#267). Returns the actual insertion index so callers (e.g. the
+    /// new-item sheet applying a URL) can target the new item.
+    @discardableResult
+    func addItem(to list: Checklist, text: String) async -> Int? {
         guard !text.isEmpty,
-              let listIndex = lists.firstIndex(where: { $0.id == list.id }) else { return }
+              let listIndex = lists.firstIndex(where: { $0.id == list.id }) else { return nil }
         var snapshot = lists[listIndex]
-        snapshot.items.insert(ChecklistItem(text: text, checked: false), at: 0)
+        // First completed item marks the boundary; fall back to the end when
+        // nothing is completed.
+        let insertAt = snapshot.items.firstIndex(where: { $0.checked }) ?? snapshot.items.count
+        snapshot.items.insert(ChecklistItem(text: text, checked: false), at: insertAt)
         lists[listIndex] = snapshot
         await update(snapshot)
+        return insertAt
     }
 
     func reorderItems(in list: Checklist, from source: IndexSet, to destination: Int) async {
         guard let listIndex = lists.firstIndex(where: { $0.id == list.id }) else { return }
         var snapshot = lists[listIndex]
         snapshot.items.move(fromOffsets: source, toOffset: destination)
+        // Re-assert completed-at-bottom after a drag: keep completed items pinned
+        // below the active ones, preserving relative order within each group
+        // (filter is stable). This lets the user freely reorder active items but
+        // never leaves a completed item interleaved above an active one.
+        snapshot.items = snapshot.items.filter { !$0.checked } + snapshot.items.filter { $0.checked }
         lists[listIndex] = snapshot
         await update(snapshot)
     }

--- a/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
+++ b/mobile/PersonalDashboard/ViewModels/TodosViewModel.swift
@@ -20,7 +20,8 @@ final class TodosViewModel {
         // never flashes empty. SwiftData's main-context fetch is synchronous.
         let descriptor = FetchDescriptor<LocalTodo>(
             predicate: #Predicate { $0.deletedAt == nil },
-            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+            // Oldest first, newest last — new tasks land at the bottom (#267).
+            sortBy: [SortDescriptor(\.createdAt, order: .forward)]
         )
         let rows = (try? resolvedService.store.context.fetch(descriptor)) ?? []
         self.todos = rows.map { $0.toDTO() }
@@ -45,7 +46,8 @@ final class TodosViewModel {
         do {
             let request = TodoCreateRequest(title: title, description: description, dueDate: dueDate, tag: tag, address: address, googleMapsLink: googleMapsLink, priority: priority)
             let new = try await service.create(request)
-            todos.insert(new, at: 0)
+            // Append so a newly created task appears below the last one (#267).
+            todos.append(new)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/mobile/PersonalDashboard/Views/Components/GhostAddRow.swift
+++ b/mobile/PersonalDashboard/Views/Components/GhostAddRow.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+/// A visible "ghost" add-row that replaces an invisible tap zone (#268).
+///
+/// Uses the app's checkbox grammar: an outline `plus.circle` sitting exactly on
+/// the real checkbox column, plus a muted label ("Add task" / "Add item"). It
+/// reads as a ghosted version of a row, not a centered button. Shared by the
+/// Tasks and Lists surfaces so both feel like one system.
+///
+/// Divider alignment (#268 revision): the hairline is built with the *same*
+/// construction as the "Completed" section separator in TasksView —
+/// `Rectangle().fill(Tokens.border).frame(height: 1).padding(.horizontal, Space.lg)`
+/// from a zero-inset base. Callers therefore apply `.listRowInsets(EdgeInsets())`
+/// (zero) and this view owns all horizontal insets internally, so the divider's
+/// leading x lands flush with the Completed separator rather than at the
+/// priority-bar column.
+///
+/// Leading geometry: the divider starts at `Space.lg` (matches the Completed
+/// hairline and the priority-bar column); the plus circle starts at
+/// `Space.lg + Space.md`, exactly where TaskRow / ItemRow place their checkbox.
+struct GhostAddRow: View {
+    /// Row label — "New Task" on Tasks, "New Item" on Lists.
+    var label: String = "New Task"
+    /// Row height — matches each surface's inline-draft row so swapping
+    /// ghost → draft doesn't shift layout (Tasks: 40, Lists: 44).
+    var minHeight: CGFloat = 40
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 0) {
+                // Section-level hairline, identical construction to the Completed
+                // separator so the two read as one system and align on the left.
+                Rectangle()
+                    .fill(Tokens.border)
+                    .frame(height: 1)
+                    .padding(.horizontal, Space.lg)
+
+                HStack(spacing: Space.md) {
+                    // Outline plus in the same 24×24 frame as the real checkbox,
+                    // so it lines up on the checkbox column. Uses the lightest
+                    // neutral (mutedSoft) + a light weight + a slightly smaller
+                    // glyph so the whole row reads clearly quieter than a real
+                    // item — present and tappable, not "disabled".
+                    Image(systemName: "plus.circle")
+                        .font(.system(size: 18, weight: .light))
+                        .foregroundStyle(Tokens.mutedSoft)
+                        .frame(width: 24, height: 24)
+
+                    Text(label)
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.mutedSoft)
+
+                    Spacer(minLength: 0)
+                }
+                // Leading = Space.lg (divider/base column) + Space.md (checkbox
+                // column) so the circle lands at the real checkbox x (28pt).
+                .padding(.leading, Space.lg + Space.md)
+                .padding(.trailing, Space.lg)
+                .frame(maxHeight: .infinity)
+            }
+            .frame(minHeight: minHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(GhostRowButtonStyle())
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
+/// Subtle press feedback for the ghost add-row: a muted surface wash on press,
+/// no scale/bounce. Keeps the row feeling tappable without drawing attention.
+private struct GhostRowButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .background(configuration.isPressed ? Tokens.surface2 : Color.clear)
+            .contentShape(Rectangle())
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -408,18 +408,18 @@ private struct ListDetailContent: View {
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets(top: 2, leading: Space.lg, bottom: 2, trailing: Space.lg))
                         }
-                        // Add strip — one row-height tap target right after the last item.
-                        // Tapping here starts a new item (or dismisses an active draft).
-                        Color.clear
-                            .frame(height: 44)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                if draftActive { draftFocused = false; hideKeyboard() }
-                                else { startDraft() }
-                            }
-                            .listRowBackground(Tokens.paper)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets())
+                        // Visible ghost add-row (#268): section-level hairline +
+                        // outline plus.circle on the checkbox column, right after the
+                        // last item. Tapping starts a new item (or dismisses an active
+                        // draft). 44pt matches the surface's row height. Zero
+                        // listRowInsets — GhostAddRow owns its own insets.
+                        GhostAddRow(label: "New Item", minHeight: 44) {
+                            if draftActive { draftFocused = false; hideKeyboard() }
+                            else { startDraft() }
+                        }
+                        .listRowBackground(Tokens.paper)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets())
 
                         // Dismiss filler — the rest of the empty space below. Tapping here only
                         // commits/deselects the current inline edit (or draft); it never adds.
@@ -478,8 +478,9 @@ private struct ListDetailContent: View {
             }
             .sheet(isPresented: $creatingItem) {
                 // New-item mode: editable name + link. Creation is deferred to
-                // Save so Cancel leaves no orphan blank item. addItem inserts at
-                // index 0, so a supplied URL is applied to index 0 right after.
+                // Save so Cancel leaves no orphan blank item. addItem appends to
+                // the end (#267) and returns the new item's index, so a supplied
+                // URL is applied to that appended item — not index 0.
                 ItemDetailsSheet(
                     itemName: "",
                     initialURL: "",
@@ -490,9 +491,9 @@ private struct ListDetailContent: View {
                         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
                         guard !trimmedName.isEmpty else { return }
                         Task {
-                            await viewModel.addItem(to: list, text: trimmedName)
-                            if !url.isEmpty {
-                                await viewModel.setItemURL(in: list, at: 0, to: url)
+                            let newIndex = await viewModel.addItem(to: list, text: trimmedName)
+                            if !url.isEmpty, let newIndex {
+                                await viewModel.setItemURL(in: list, at: newIndex, to: url)
                             }
                         }
                     }

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -292,15 +292,25 @@ struct TasksView: View {
         var completed: [Todo] = []
     }
 
-    /// Sort order shared by every open bucket: highest priority first
-    /// (P0 → P1 → P2/none), and within one priority the most recently created
-    /// task on top. Keeps the date-based sections intact while ranking rows
-    /// inside each section by urgency.
-    private func prioritySorted(_ todos: [Todo]) -> [Todo] {
+    /// Sort order shared by every open bucket: soonest due time on top
+    /// ("next event first"), later times below. Tasks without a due date (the
+    /// "No Date" bucket) order among themselves by creation time, oldest first;
+    /// createdAt (ascending) is also the tiebreaker when two tasks share a due
+    /// time. The colored priority bar still renders on each row — it no longer
+    /// affects ordering.
+    private func chronoSorted(_ todos: [Todo]) -> [Todo] {
         todos.sorted { a, b in
-            let ra = a.taskPriority.sortRank, rb = b.taskPriority.sortRank
-            if ra != rb { return ra < rb }
-            return a.createdAt > b.createdAt
+            switch (a.dueDate, b.dueDate) {
+            case let (da?, db?):
+                if da != db { return da < db }
+                return a.createdAt < b.createdAt
+            case (nil, nil):
+                return a.createdAt < b.createdAt
+            case (_?, nil):
+                return true   // a task with a due date sorts before one without
+            case (nil, _?):
+                return false
+            }
         }
     }
 
@@ -323,12 +333,12 @@ struct TasksView: View {
             else if due < weekEnd { b.thisWeek.append(todo) }
             else { b.later.append(todo) }
         }
-        b.overdue = prioritySorted(b.overdue)
-        b.today = prioritySorted(b.today)
-        b.tomorrow = prioritySorted(b.tomorrow)
-        b.thisWeek = prioritySorted(b.thisWeek)
-        b.later = prioritySorted(b.later)
-        b.noDate = prioritySorted(b.noDate)
+        b.overdue = chronoSorted(b.overdue)
+        b.today = chronoSorted(b.today)
+        b.tomorrow = chronoSorted(b.tomorrow)
+        b.thisWeek = chronoSorted(b.thisWeek)
+        b.later = chronoSorted(b.later)
+        b.noDate = chronoSorted(b.noDate)
         return b
     }
 
@@ -377,11 +387,12 @@ struct TasksView: View {
                     .listRowSeparator(.hidden)
                     .listRowInsets(EdgeInsets())
                 } else {
-                    // Clear tap target — 40pt keeps sections tight while staying tappable.
-                    Color.clear
-                        .frame(minHeight: 40)
-                        .contentShape(Rectangle())
-                        .onTapGesture { startDraft(in: bucket) }
+                    // Visible ghost add-row (#268): section-level hairline + outline
+                    // plus.circle on the checkbox column. 40pt matches the draft row
+                    // height so swapping ghost → draft doesn't shift the layout.
+                    // Zero listRowInsets — GhostAddRow owns its own insets so its
+                    // divider aligns with the Completed separator.
+                    GhostAddRow(label: "New Task", minHeight: 40) { startDraft(in: bucket) }
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
                         .listRowInsets(EdgeInsets())


### PR DESCRIPTION
## Summary
- **Tasks (#267 refinement):** each date section now sorts by soonest `dueDate` on top (next event first). The colored priority bar still renders on rows but no longer reorders them; ties break by creation order.
- **Checklists (#267):** new items are inserted at the end of the *active* (non-completed) items instead of at index 0, and completed items always stay at the bottom — enforced consistently across add, toggle, and drag-reorder.
- **Visible add affordance (#268):** the previously-invisible "tap below the last row to add" zone is now a subtle ghost row — a full-width hairline divider + a faded `plus.circle` + a muted "New Task" / "New Item" label, left-aligned in the checkbox column. Tapping it starts the inline add. Shown under each active task section (not Completed/Overdue) and below the last list item.

Closes #267
Closes #268

## Test plan
- [x] Clean `xcodebuild` build (BUILD SUCCEEDED) after `xcodegen generate`.
- [x] Device QA on iPhone across multiple ship cycles: task sort (soonest-first), checklist insertion order + completed-at-bottom, ghost-row look/labels/subtlety in light and dark, divider flush with the Completed separator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)