### PR TITLE
feat(mobile): native macOS app — full feature port

### DIFF
--- a/mobile/PersonalDashboard/AI/TicketExtraction.swift
+++ b/mobile/PersonalDashboard/AI/TicketExtraction.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SwiftData
+#if canImport(UIKit)
 import UIKit
+#else
+import AppKit
+#endif
 
 /// Outcome of running one uploaded ticket through the on-device pipeline (#222).
 /// An item is ALWAYS created (the upload is never lost) — `degraded` flags the
@@ -56,7 +60,7 @@ struct TicketExtraction {
             // Rasterise page 1 for the extraction image (barcode decode reads
             // pages directly from the PDF data below).
             extractionImageData = BarcodeService.renderFirstPage(pdfData: data, targetLongEdge: 2200)?
-                .jpegData(compressionQuality: 0.85)
+                .jpegDataCompat(quality: 0.85)
         } else {
             let compressed = try await Task.detached(priority: .userInitiated) {
                 try storage.compress(imageData: data)
@@ -69,7 +73,7 @@ struct TicketExtraction {
         let decoded: DecodedBarcode?
         if isPDF {
             decoded = BarcodeService.decode(pdfData: data)
-        } else if let image = extractionImageData.flatMap({ UIImage(data: $0) }) {
+        } else if let image = extractionImageData.flatMap({ PlatformImage(data: $0) }) {
             decoded = BarcodeService.decode(image: image)
         } else {
             decoded = nil

--- a/mobile/PersonalDashboard/App/AppRouter.swift
+++ b/mobile/PersonalDashboard/App/AppRouter.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
+#endif
 import Observation
 
 /// Activity timeline deep-link payload. The Activity surface sets this when
@@ -73,12 +75,14 @@ final class AppRouter {
     /// menu tap and the edge-swipe gesture route through here so the
     /// keyboard-dismiss behaviour is consistent.
     func openDrawer() {
+        #if canImport(UIKit)
         UIApplication.shared.sendAction(
             #selector(UIResponder.resignFirstResponder),
             to: nil,
             from: nil,
             for: nil
         )
+        #endif
         withAnimation(.easeOut(duration: 0.2)) {
             drawerOpen = true
         }

--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -71,6 +71,8 @@ private struct MacRootView: View {
             ListsView(router: router)
         case .vocabulary:
             PersonalVocabularyView(router: router)
+        case .activity:
+            ActivityView(router: router)
         default:
             ComingSoonView(section: section)
         }

--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -45,6 +45,18 @@ private struct MacRootView: View {
 
     @State private var selection: AppSection = .tasks
 
+    /// Theme preference, shared with the iOS store via the same UserDefaults
+    /// key (`colorSchemePref`) that `ContentView` uses. Surfaced to `Settings`
+    /// as a binding and applied to the whole window so the picker takes effect.
+    @AppStorage("colorSchemePref") private var schemePrefRaw: String = ColorSchemePref.system.rawValue
+
+    private var schemePref: Binding<ColorSchemePref> {
+        Binding(
+            get: { ColorSchemePref(rawValue: schemePrefRaw) ?? .system },
+            set: { schemePrefRaw = $0.rawValue }
+        )
+    }
+
     var body: some View {
         NavigationSplitView {
             List(sections, selection: $selection) { section in
@@ -58,6 +70,7 @@ private struct MacRootView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Tokens.paper)
         }
+        .preferredColorScheme((ColorSchemePref(rawValue: schemePrefRaw) ?? .system).resolved)
     }
 
     @ViewBuilder
@@ -77,6 +90,8 @@ private struct MacRootView: View {
             PersonalVocabularyView(router: router)
         case .activity:
             ActivityView(router: router)
+        case .settings:
+            SettingsView(router: router, schemePref: schemePref)
         default:
             ComingSoonView(section: section)
         }

--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import SwiftData
+
+/// Entry point for the native macOS build (issue #281).
+///
+/// Deliberately separate from the iOS `PersonalDashboardApp`: only this file is
+/// a member of the macOS target, so there is exactly one `@main` per target and
+/// the iOS app entry (with its `UIApplicationDelegateAdaptor`, background tasks,
+/// and email ingest) is never dragged onto macOS.
+///
+/// The beachhead surfaces a single feature (Tasks) in one window, backed by the
+/// Mac's own local SwiftData store (`SwiftDataStore.shared`). There is no
+/// CloudKit sync on free personal-team signing; cross-device continuity comes
+/// from restoring the iCloud Drive backup the phone writes (a later milestone).
+@main
+struct DexterMacApp: App {
+    @State private var router = AppRouter()
+
+    var body: some Scene {
+        WindowGroup {
+            MacRootView(router: router)
+                // Harmless if unused by Tasks (its view model reads
+                // SwiftDataStore.shared directly); wires the container for any
+                // future @Query-based surface added to this window.
+                .modelContainer(SwiftDataStore.shared.container)
+                .frame(minWidth: 460, minHeight: 520)
+        }
+        .windowResizability(.contentMinSize)
+    }
+}
+
+/// Minimal macOS shell for the Tasks beachhead: a navigation container hosting
+/// the existing `TasksView`, reused unchanged. As more surfaces are ported this
+/// grows into a `NavigationSplitView` with a sidebar; for now it is a
+/// single-feature window.
+private struct MacRootView: View {
+    @Bindable var router: AppRouter
+
+    var body: some View {
+        NavigationStack {
+            TasksView(router: router)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Tokens.paper)
+    }
+}

--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -86,6 +86,8 @@ private struct MacRootView: View {
             ListsView(router: router)
         case .notes:
             NotesView(router: router)
+        case .finance:
+            FinanceView(router: router)
         case .vocabulary:
             PersonalVocabularyView(router: router)
         case .activity:

--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -65,6 +65,12 @@ private struct MacRootView: View {
         switch section {
         case .tasks:
             TasksView(router: router)
+        case .today:
+            TodayView(router: router)
+        case .lists:
+            ListsView(router: router)
+        case .vocabulary:
+            PersonalVocabularyView(router: router)
         default:
             ComingSoonView(section: section)
         }

--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -63,6 +63,8 @@ private struct MacRootView: View {
     @ViewBuilder
     private func detailView(for section: AppSection) -> some View {
         switch section {
+        case .chat:
+            ChatView(router: router)
         case .tasks:
             TasksView(router: router)
         case .today:

--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -8,10 +8,10 @@ import SwiftData
 /// the iOS app entry (with its `UIApplicationDelegateAdaptor`, background tasks,
 /// and email ingest) is never dragged onto macOS.
 ///
-/// The beachhead surfaces a single feature (Tasks) in one window, backed by the
-/// Mac's own local SwiftData store (`SwiftDataStore.shared`). There is no
-/// CloudKit sync on free personal-team signing; cross-device continuity comes
-/// from restoring the iCloud Drive backup the phone writes (a later milestone).
+/// The Mac runs its own local SwiftData store (`SwiftDataStore.shared`). There
+/// is no CloudKit sync on free personal-team signing; cross-device continuity
+/// comes from restoring the iCloud Drive backup the phone writes (a later
+/// milestone, after all features are ported — issue #281).
 @main
 struct DexterMacApp: App {
     @State private var router = AppRouter()
@@ -19,26 +19,73 @@ struct DexterMacApp: App {
     var body: some Scene {
         WindowGroup {
             MacRootView(router: router)
-                // Harmless if unused by Tasks (its view model reads
-                // SwiftDataStore.shared directly); wires the container for any
-                // future @Query-based surface added to this window.
                 .modelContainer(SwiftDataStore.shared.container)
-                .frame(minWidth: 460, minHeight: 520)
+                .frame(minWidth: 900, minHeight: 600)
         }
         .windowResizability(.contentMinSize)
     }
 }
 
-/// Minimal macOS shell for the Tasks beachhead: a navigation container hosting
-/// the existing `TasksView`, reused unchanged. As more surfaces are ported this
-/// grows into a `NavigationSplitView` with a sidebar; for now it is a
-/// single-feature window.
+/// Native macOS shell: a `NavigationSplitView` with a sidebar of sections and a
+/// detail pane that hosts the selected feature. This replaces the iOS
+/// chat-rooted `ZStack` router + floating tab bar + edge-swipe drawer, which are
+/// phone idioms. `AppRouter` still carries per-feature navigation state.
+///
+/// Each feature is wired into `detailView(for:)` as it is ported; sections not
+/// yet ported render a `ComingSoonView` placeholder.
 private struct MacRootView: View {
     @Bindable var router: AppRouter
 
+    /// Sidebar order. Excludes the dead `dashboard` section (issue #30).
+    private let sections: [AppSection] = [
+        .chat, .today, .tasks, .notes, .lists,
+        .activity, .itineraries, .finance, .vocabulary,
+        .settings, .helpCenter,
+    ]
+
+    @State private var selection: AppSection = .tasks
+
     var body: some View {
-        NavigationStack {
+        NavigationSplitView {
+            List(sections, selection: $selection) { section in
+                Label(section.displayName, systemImage: section.icon)
+                    .tag(section)
+            }
+            .navigationTitle("Dexter")
+            .frame(minWidth: 210)
+        } detail: {
+            detailView(for: selection)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Tokens.paper)
+        }
+    }
+
+    @ViewBuilder
+    private func detailView(for section: AppSection) -> some View {
+        switch section {
+        case .tasks:
             TasksView(router: router)
+        default:
+            ComingSoonView(section: section)
+        }
+    }
+}
+
+/// Placeholder for a section not yet ported to macOS.
+private struct ComingSoonView: View {
+    let section: AppSection
+
+    var body: some View {
+        VStack(spacing: Space.md) {
+            Image(systemName: section.icon)
+                .font(.system(size: 40, weight: .light))
+                .foregroundStyle(Tokens.muted)
+            Text(section.displayName)
+                .font(.edTitle)
+                .foregroundStyle(Tokens.ink)
+            Text("Coming to macOS")
+                .font(.edBody)
+                .foregroundStyle(Tokens.muted)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Tokens.paper)

--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -69,6 +69,8 @@ private struct MacRootView: View {
             TodayView(router: router)
         case .lists:
             ListsView(router: router)
+        case .notes:
+            NotesView(router: router)
         case .vocabulary:
             PersonalVocabularyView(router: router)
         case .activity:

--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -86,6 +86,8 @@ private struct MacRootView: View {
             ListsView(router: router)
         case .notes:
             NotesView(router: router)
+        case .itineraries:
+            TripsView(router: router)
         case .finance:
             FinanceView(router: router)
         case .vocabulary:

--- a/mobile/PersonalDashboard/Design/Buttons.swift
+++ b/mobile/PersonalDashboard/Design/Buttons.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 enum ButtonKind {
     case primary
@@ -182,7 +181,7 @@ struct GlassButtonStyle: ButtonStyle {
             .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
             .animation(.easeOut(duration: 0.1), value: configuration.isPressed)
             .onChange(of: configuration.isPressed) { _, pressed in
-                if pressed { UIImpactFeedbackGenerator(style: .light).impactOccurred() }
+                if pressed { Haptics.light() }
             }
     }
 }

--- a/mobile/PersonalDashboard/Design/Haptics.swift
+++ b/mobile/PersonalDashboard/Design/Haptics.swift
@@ -1,4 +1,6 @@
+#if canImport(UIKit)
 import UIKit
+#endif
 
 /// Lightweight haptic helpers used by row-level destructive actions
 /// (swipe-to-delete) so the same feel is reused across surfaces.
@@ -6,22 +8,29 @@ import UIKit
 /// Generators are short-lived intentionally: iOS does not require us to
 /// hold onto them for one-shot fires, and creating one per call keeps
 /// the call sites local.
+///
+/// On macOS there is no `UIFeedbackGenerator`; the helpers compile to
+/// no-ops so shared call sites (e.g. `SwipeActions`) stay platform-agnostic.
 enum Haptics {
     /// A medium-warning thump suitable for a destructive commit
     /// (delete row, drop row). Mirrors the Mail / Reminders feel.
     static func destructive() {
+        #if canImport(UIKit)
         let generator = UINotificationFeedbackGenerator()
         generator.prepare()
         generator.notificationOccurred(.warning)
+        #endif
     }
 
     /// A short, soft impact for affirmative button presses (e.g. the
     /// itinerary FAB). Re-uses a one-shot `UIImpactFeedbackGenerator` so
     /// the call site can fire-and-forget.
     static func light() {
+        #if canImport(UIKit)
         let generator = UIImpactFeedbackGenerator(style: .light)
         generator.prepare()
         generator.impactOccurred()
+        #endif
     }
 
     /// A low-key selection tick used to signal threshold crossings during
@@ -29,8 +38,10 @@ enum Haptics {
     /// boundary). Quieter than `destructive()` so it doesn't compete with
     /// the warning thump that fires on the actual commit.
     static func tick() {
+        #if canImport(UIKit)
         let generator = UISelectionFeedbackGenerator()
         generator.prepare()
         generator.selectionChanged()
+        #endif
     }
 }

--- a/mobile/PersonalDashboard/Design/Keyboard.swift
+++ b/mobile/PersonalDashboard/Design/Keyboard.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
+#endif
 
 // MARK: - Keyboard dismiss helpers
 
@@ -28,12 +30,15 @@ extension View {
     /// routes through those commit paths without the parent needing per-row focus
     /// state. Wraps the same `sendAction` idiom used inline elsewhere.
     func hideKeyboard() {
+        #if canImport(UIKit)
         UIApplication.shared.sendAction(
             #selector(UIResponder.resignFirstResponder),
             to: nil,
             from: nil,
             for: nil
         )
+        #endif
+        // macOS has no software keyboard; nothing to dismiss.
     }
 }
 
@@ -47,12 +52,14 @@ private struct DismissKeyboardOnTapModifier: ViewModifier {
                 Color.clear
                     .contentShape(Rectangle())
                     .onTapGesture {
+                        #if canImport(UIKit)
                         UIApplication.shared.sendAction(
                             #selector(UIResponder.resignFirstResponder),
                             to: nil,
                             from: nil,
                             for: nil
                         )
+                        #endif
                     }
             )
     }

--- a/mobile/PersonalDashboard/Design/ListAppearance.swift
+++ b/mobile/PersonalDashboard/Design/ListAppearance.swift
@@ -1,5 +1,22 @@
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+/// Whether an SF Symbol name renders on this platform. UIKit on iOS, AppKit on
+/// macOS; both back SF Symbols, so the guard against unknown/AI-supplied names
+/// works identically on both.
+private func sfSymbolExists(_ name: String) -> Bool {
+    #if canImport(UIKit)
+    return UIImage(systemName: name) != nil
+    #elseif canImport(AppKit)
+    return NSImage(systemSymbolName: name, accessibilityDescription: nil) != nil
+    #else
+    return true
+    #endif
+}
 
 /// Single source of truth for a list's visual identity (#253): the curated SF
 /// Symbol set, the palette, the default fallback, and the local keyword→icon
@@ -98,14 +115,14 @@ enum ListAppearance {
     /// symbol name that doesn't exist on the device (blank-tile prevention).
     static func resolvedIconName(_ stored: String?) -> String {
         guard let stored, !stored.isEmpty,
-              UIImage(systemName: stored) != nil else { return defaultIcon }
+              sfSymbolExists(stored) else { return defaultIcon }
         return stored
     }
 
     /// Whether a symbol name renders on this device.
     static func isValidSymbol(_ name: String?) -> Bool {
         guard let name, !name.isEmpty else { return false }
-        return UIImage(systemName: name) != nil
+        return sfSymbolExists(name)
     }
 
     // MARK: - Keyword → appearance mapper

--- a/mobile/PersonalDashboard/Design/PlatformImage.swift
+++ b/mobile/PersonalDashboard/Design/PlatformImage.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#else
+import AppKit
+#endif
+
+/// Module-wide platform image alias + small bridges, so shared code that has to
+/// touch a concrete bitmap type (barcode render/decode, ticket ingest) keeps one
+/// call shape across iOS and macOS instead of `#if` islands at every use.
+///
+/// Added for the native macOS target (issue #281). This is the general-purpose
+/// sibling of Finance's `ReceiptPlatformImage`; both resolve to the same
+/// underlying `UIImage` / `NSImage`, so the two aliases are interchangeable.
+#if canImport(UIKit)
+typealias PlatformImage = UIImage
+#else
+typealias PlatformImage = NSImage
+#endif
+
+extension Image {
+    /// Build a SwiftUI `Image` from the platform-native bitmap, cross-platform.
+    init(platformImage: PlatformImage) {
+        #if canImport(UIKit)
+        self.init(uiImage: platformImage)
+        #else
+        self.init(nsImage: platformImage)
+        #endif
+    }
+}
+
+extension PlatformImage {
+    /// The backing `CGImage`, cross-platform. `UIImage.cgImage` on iOS; the
+    /// `cgImage(forProposedRect:…)` accessor on macOS (`NSImage` has no direct
+    /// `cgImage` property). Nil for vector-only / undecodable images.
+    var cgImageCompat: CGImage? {
+        #if canImport(UIKit)
+        return cgImage
+        #else
+        return cgImage(forProposedRect: nil, context: nil, hints: nil)
+        #endif
+    }
+
+    /// JPEG-encode at `quality` (0…1), cross-platform. `UIImage.jpegData` on
+    /// iOS; an `NSBitmapImageRep` round-trip on macOS.
+    func jpegDataCompat(quality: CGFloat) -> Data? {
+        #if canImport(UIKit)
+        return jpegData(compressionQuality: quality)
+        #else
+        guard let cg = cgImageCompat else { return nil }
+        let rep = NSBitmapImageRep(cgImage: cg)
+        return rep.representation(using: .jpeg, properties: [.compressionFactor: quality])
+        #endif
+    }
+}

--- a/mobile/PersonalDashboard/Design/PlatformModifiers.swift
+++ b/mobile/PersonalDashboard/Design/PlatformModifiers.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// Cross-platform shims for SwiftUI text/navigation modifiers that exist only
+/// on iOS. Each applies the real modifier on iOS and is a no-op on macOS, so
+/// shared views keep one fluent chain instead of `#if` islands mid-builder.
+///
+/// Added for the native macOS target (issue #281). As more surfaces are
+/// ported, route their iOS-only cosmetic modifiers through here.
+extension View {
+    /// `.textInputAutocapitalization(.never)` on iOS; no-op on macOS
+    /// (the modifier is absent from the macOS SwiftUI surface).
+    @ViewBuilder
+    func noAutocapitalization() -> some View {
+        #if os(iOS)
+        self.textInputAutocapitalization(.never)
+        #else
+        self
+        #endif
+    }
+
+    /// URL keyboard on iOS; no-op on macOS (hardware keyboard, no keyboard type).
+    @ViewBuilder
+    func urlKeyboard() -> some View {
+        #if os(iOS)
+        self.keyboardType(.URL)
+        #else
+        self
+        #endif
+    }
+
+    /// Inline nav-bar title on iOS; no-op on macOS, where the title renders in
+    /// the window titlebar and there is no display-mode concept.
+    @ViewBuilder
+    func inlineNavigationTitle() -> some View {
+        #if os(iOS)
+        self.navigationBarTitleDisplayMode(.inline)
+        #else
+        self
+        #endif
+    }
+
+    /// `.listSectionSpacing(_:)` on iOS; no-op on macOS (the modifier is
+    /// unavailable there — macOS Lists space sections differently).
+    @ViewBuilder
+    func listSectionSpacingCompat(_ spacing: CGFloat) -> some View {
+        #if os(iOS)
+        self.listSectionSpacing(spacing)
+        #else
+        self
+        #endif
+    }
+}

--- a/mobile/PersonalDashboard/Design/PlatformModifiers.swift
+++ b/mobile/PersonalDashboard/Design/PlatformModifiers.swift
@@ -50,3 +50,17 @@ extension View {
         #endif
     }
 }
+
+extension ToolbarItemPlacement {
+    /// Trailing "Done"-style toolbar slot: `.topBarTrailing` on iOS (the
+    /// navigation-bar trailing position), `.automatic` on macOS where there is
+    /// no top bar and `.topBarTrailing` does not exist. iOS placement is
+    /// unchanged. Added for the native macOS target (issue #281).
+    static var trailingBar: ToolbarItemPlacement {
+        #if os(iOS)
+        .topBarTrailing
+        #else
+        .automatic
+        #endif
+    }
+}

--- a/mobile/PersonalDashboard/Design/PlatformModifiers.swift
+++ b/mobile/PersonalDashboard/Design/PlatformModifiers.swift
@@ -28,6 +28,17 @@ extension View {
         #endif
     }
 
+    /// Decimal-pad keyboard on iOS; no-op on macOS (hardware keyboard, no
+    /// keyboard type). Used by amount fields in the Finance surface (#281).
+    @ViewBuilder
+    func decimalKeyboard() -> some View {
+        #if os(iOS)
+        self.keyboardType(.decimalPad)
+        #else
+        self
+        #endif
+    }
+
     /// Inline nav-bar title on iOS; no-op on macOS, where the title renders in
     /// the window titlebar and there is no display-mode concept.
     @ViewBuilder

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
+#endif
 
 /// Swipe-left-to-delete with circular red trash + gray fade card,
 /// keyed to a UIKit-bridged horizontal-only pan recognizer so the
@@ -24,10 +26,22 @@ import UIKit
 /// into the row.
 extension View {
     func swipeToDeleteTrash(perform action: @escaping () -> Void) -> some View {
-        modifier(SwipeToDeleteWithTint(onDelete: action))
+        #if canImport(UIKit)
+        return modifier(SwipeToDeleteWithTint(onDelete: action))
+        #else
+        // macOS: the custom UIKit pan bridge below doesn't exist. Rows live
+        // inside a `List`, so the native trailing swipe-to-delete gives the
+        // same affordance with a real destructive full-swipe.
+        return self.swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive, action: action) {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        #endif
     }
 }
 
+#if canImport(UIKit)
 private struct SwipeToDeleteWithTint: ViewModifier {
     let onDelete: () -> Void
 
@@ -367,3 +381,4 @@ private struct HorizontalPanCapture<Content: View>: UIViewRepresentable {
         var host: UIHostingController<AnyView>?
     }
 }
+#endif

--- a/mobile/PersonalDashboard/Design/Tokens.swift
+++ b/mobile/PersonalDashboard/Design/Tokens.swift
@@ -1,5 +1,9 @@
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 // MARK: - Section identity
 
@@ -66,10 +70,21 @@ extension Color {
     }
 
     /// Light/dark pair. Resolved at render time via the system color scheme.
+    /// Backed by a platform dynamic color so a single `Color` re-resolves when
+    /// the appearance flips, on both UIKit (iOS) and AppKit (macOS).
     static func paper(_ light: UInt32, _ dark: UInt32) -> Color {
-        Color(UIColor { trait in
+        #if canImport(UIKit)
+        return Color(UIColor { trait in
             UIColor(Color(hex: trait.userInterfaceStyle == .dark ? dark : light))
         })
+        #elseif canImport(AppKit)
+        return Color(nsColor: NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            return NSColor(Color(hex: isDark ? dark : light))
+        })
+        #else
+        return Color(hex: light)
+        #endif
     }
 }
 

--- a/mobile/PersonalDashboard/InfoMac.plist
+++ b/mobile/PersonalDashboard/InfoMac.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ATSApplicationFontsPath</key>
+	<string>Fonts</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Dexter</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+</dict>
+</plist>

--- a/mobile/PersonalDashboard/InfoMac.plist
+++ b/mobile/PersonalDashboard/InfoMac.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ANTHROPIC_API_KEY</key>
+	<string>$(ANTHROPIC_API_KEY)</string>
 	<key>ATSApplicationFontsPath</key>
 	<string>Fonts</string>
 	<key>CFBundleDevelopmentRegion</key>

--- a/mobile/PersonalDashboard/Services/BarcodeService.swift
+++ b/mobile/PersonalDashboard/Services/BarcodeService.swift
@@ -1,8 +1,13 @@
 import Foundation
-import UIKit
 import Vision
 import CoreImage
 import PDFKit
+#if canImport(UIKit)
+import UIKit
+#else
+import AppKit
+import CoreGraphics
+#endif
 
 /// Normalised symbology id stored on `LocalItineraryItem.barcodeSymbology`.
 /// We persist a small stable token (not the raw `VNBarcodeSymbology.rawValue`,
@@ -49,6 +54,13 @@ struct DecodedBarcode {
 ///  - `render(...)`: regenerate a crisp barcode image from a stored payload in
 ///    its original symbology, scaled with nearest-neighbour so the modules stay
 ///    hard-edged (a smoothed barcode fails scanners).
+///
+/// Cross-platform (issue #281): the shared work (Vision decode, CoreImage
+/// generation, PDF page geometry) uses first-party frameworks that exist on both
+/// iOS and macOS. Only the concrete bitmap wrap/rasterise differs by platform,
+/// and the returned `PlatformImage` resolves to `UIImage` on iOS / `NSImage` on
+/// macOS, so every call site is source-identical. The iOS pixel path is byte
+/// unchanged from #222.
 enum BarcodeService {
 
     // MARK: - Decode
@@ -56,9 +68,15 @@ enum BarcodeService {
     /// Detect the single most prominent barcode in `image`. Returns `nil` when
     /// no barcode is found. When several are present we prefer the one with the
     /// largest bounding-box area (the primary ticket code, not a tiny promo QR).
-    static func decode(image: UIImage) -> DecodedBarcode? {
-        guard let cgImage = image.cgImage else { return nil }
+    static func decode(image: PlatformImage) -> DecodedBarcode? {
+        guard let cgImage = image.cgImageCompat else { return nil }
+        #if canImport(UIKit)
         return decode(cgImage: cgImage, orientation: cgOrientation(from: image.imageOrientation))
+        #else
+        // `NSImage` carries no EXIF orientation the way `UIImage` does; the
+        // `cgImageCompat` bitmap is already upright.
+        return decode(cgImage: cgImage, orientation: .up)
+        #endif
     }
 
     /// Decode across a PDF's pages, returning the first page's most prominent
@@ -70,7 +88,7 @@ enum BarcodeService {
         for index in 0..<pages {
             guard let page = doc.page(at: index) else { continue }
             let image = render(pdfPage: page, targetLongEdge: 2400)
-            if let cg = image?.cgImage, let hit = decode(cgImage: cg, orientation: .up) {
+            if let cg = image?.cgImageCompat, let hit = decode(cgImage: cg, orientation: .up) {
                 return hit
             }
         }
@@ -118,7 +136,7 @@ enum BarcodeService {
     /// (nearest-neighbour) scaling. Returns `nil` for `.other`/unsupported
     /// symbologies or on any generation failure — the caller then falls back to
     /// the original attachment.
-    static func render(payload: String, symbology: BarcodeSymbology, targetLongEdge: CGFloat = 900) -> UIImage? {
+    static func render(payload: String, symbology: BarcodeSymbology, targetLongEdge: CGFloat = 900) -> PlatformImage? {
         guard !payload.isEmpty else { return nil }
         // Boarding-pass payloads are Latin-1; fall back to UTF-8 for QR URLs.
         let messageData = payload.data(using: .isoLatin1) ?? payload.data(using: .utf8)
@@ -154,11 +172,12 @@ enum BarcodeService {
         return upscale(cgImage: nativeCG, targetLongEdge: targetLongEdge)
     }
 
+    #if canImport(UIKit)
     /// Draw a small generated code into a larger bitmap with nearest-neighbour
     /// sampling (no blur). Preserves aspect ratio (PDF417 is very wide). We draw
     /// via `UIImage.draw(in:)` rather than `CGContext.draw` so the code renders
     /// upright — a manual CG flip would MIRROR the code (fatal for QR/PDF417).
-    private static func upscale(cgImage: CGImage, targetLongEdge: CGFloat) -> UIImage {
+    private static func upscale(cgImage: CGImage, targetLongEdge: CGFloat) -> PlatformImage {
         let w = CGFloat(cgImage.width)
         let h = CGFloat(cgImage.height)
         let scale = max(targetLongEdge / max(w, h), 1)
@@ -175,14 +194,30 @@ enum BarcodeService {
             UIImage(cgImage: cgImage).draw(in: CGRect(origin: .zero, size: size))
         }
     }
+    #else
+    /// macOS upscale (issue #281). The `CIContext`-produced `CGImage` is already
+    /// upright, so we wrap it in an `NSImage` at the target point size WITHOUT
+    /// any coordinate manipulation — that sidesteps the vertical-flip/mirror
+    /// hazard the iOS comment warns about (a mirrored PDF417 fails scanners).
+    /// Crisp upscaling is handled at display time by SwiftUI's
+    /// `.interpolation(.none)` (nearest-neighbour), matching the iOS result.
+    private static func upscale(cgImage: CGImage, targetLongEdge: CGFloat) -> PlatformImage {
+        let w = CGFloat(cgImage.width)
+        let h = CGFloat(cgImage.height)
+        let scale = max(targetLongEdge / max(w, h), 1)
+        let size = NSSize(width: w * scale, height: h * scale)
+        return NSImage(cgImage: cgImage, size: size)
+    }
+    #endif
 
     // MARK: - PDF rasterisation
 
-    /// Render a single PDF page to a UIImage whose longest edge is about
+    #if canImport(UIKit)
+    /// Render a single PDF page to an image whose longest edge is about
     /// `targetLongEdge` points. Used for barcode decoding (needs detail) and
     /// for the one-shot extraction image (so we never depend on the PDF beta
     /// header). White-backed so a transparent page doesn't decode as black.
-    static func render(pdfPage page: PDFPage, targetLongEdge: CGFloat) -> UIImage? {
+    static func render(pdfPage page: PDFPage, targetLongEdge: CGFloat) -> PlatformImage? {
         let pageRect = page.bounds(for: .mediaBox)
         guard pageRect.width > 0, pageRect.height > 0 else { return nil }
         let scale = max(targetLongEdge / max(pageRect.width, pageRect.height), 1)
@@ -203,10 +238,45 @@ enum BarcodeService {
             page.draw(with: .mediaBox, to: cg)
         }
     }
+    #else
+    /// macOS PDF rasterisation (issue #281). A raw `CGContext` bitmap has a
+    /// bottom-left origin (unlike the iOS renderer's top-left context), and PDF
+    /// user space is ALSO bottom-left, so we only scale + translate the origin —
+    /// no y-flip — and the produced `CGImage` reads out upright. White-backed
+    /// for the same decode-safety reason as iOS.
+    static func render(pdfPage page: PDFPage, targetLongEdge: CGFloat) -> PlatformImage? {
+        let pageRect = page.bounds(for: .mediaBox)
+        guard pageRect.width > 0, pageRect.height > 0 else { return nil }
+        let scale = max(targetLongEdge / max(pageRect.width, pageRect.height), 1)
+        let pixelW = Int((pageRect.width * scale).rounded())
+        let pixelH = Int((pageRect.height * scale).rounded())
+        guard pixelW > 0, pixelH > 0,
+              let ctx = CGContext(
+                data: nil,
+                width: pixelW,
+                height: pixelH,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue
+              )
+        else { return nil }
+
+        ctx.interpolationQuality = .high
+        ctx.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: pixelW, height: pixelH))
+        ctx.scaleBy(x: scale, y: scale)
+        ctx.translateBy(x: -pageRect.origin.x, y: -pageRect.origin.y)
+        page.draw(with: .mediaBox, to: ctx)
+
+        guard let cg = ctx.makeImage() else { return nil }
+        return NSImage(cgImage: cg, size: NSSize(width: pixelW, height: pixelH))
+    }
+    #endif
 
     /// Convenience: render the first page of a PDF's data. Nil when the data
     /// isn't a readable PDF.
-    static func renderFirstPage(pdfData: Data, targetLongEdge: CGFloat = 2000) -> UIImage? {
+    static func renderFirstPage(pdfData: Data, targetLongEdge: CGFloat = 2000) -> PlatformImage? {
         guard let doc = PDFDocument(data: pdfData), let page = doc.page(at: 0) else { return nil }
         return render(pdfPage: page, targetLongEdge: targetLongEdge)
     }
@@ -216,8 +286,8 @@ enum BarcodeService {
     /// Crop `image` to a Vision-normalised bounding box (bottom-left origin),
     /// with a little padding so the quiet zone around the code is preserved.
     /// Returns the original image if the crop can't be computed.
-    static func crop(image: UIImage, toNormalized box: CGRect, padding: CGFloat = 0.06) -> UIImage {
-        guard let cg = image.cgImage else { return image }
+    static func crop(image: PlatformImage, toNormalized box: CGRect, padding: CGFloat = 0.06) -> PlatformImage {
+        guard let cg = image.cgImageCompat else { return image }
         let w = CGFloat(cg.width)
         let h = CGFloat(cg.height)
         // Vision origin is bottom-left; CGImage crop origin is top-left.
@@ -231,9 +301,14 @@ enum BarcodeService {
             height: clamped.height * h
         )
         guard let cropped = cg.cropping(to: rect) else { return image }
+        #if canImport(UIKit)
         return UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)
+        #else
+        return NSImage(cgImage: cropped, size: NSSize(width: cropped.width, height: cropped.height))
+        #endif
     }
 
+    #if canImport(UIKit)
     private static func cgOrientation(from ui: UIImage.Orientation) -> CGImagePropertyOrientation {
         switch ui {
         case .up:            return .up
@@ -247,4 +322,5 @@ enum BarcodeService {
         @unknown default:    return .up
         }
     }
+    #endif
 }

--- a/mobile/PersonalDashboard/Services/ReceiptStorage.swift
+++ b/mobile/PersonalDashboard/Services/ReceiptStorage.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(UIKit)
 import UIKit
+#endif
 
 /// Errors thrown by ReceiptStorage. Surface to the user when a save / delete
 /// can't complete (rare: disk full, sandbox sealed, etc.).
@@ -67,6 +69,7 @@ final class ReceiptStorage {
     /// row render immediately rather than after compression finishes (#200
     /// follow-up). It reads only immutable value-typed constants and touches
     /// no actor-isolated state, so it's safe to call from any executor.
+    #if canImport(UIKit)
     nonisolated func compress(imageData: Data) throws -> Data {
         guard let image = UIImage(data: imageData) else {
             throw ReceiptStorageError.imageEncodingFailed
@@ -89,6 +92,7 @@ final class ReceiptStorage {
         }
         return firstPass
     }
+    #endif
 
     /// Persist a pre-compressed JPEG (typically the output of `compress(imageData:)`).
     /// Returned path is relative.
@@ -98,12 +102,15 @@ final class ReceiptStorage {
 
     /// Legacy convenience: compress + save in one shot. Kept for callers that
     /// don't need the compressed bytes (e.g. failure paths that just need
-    /// the receipt on disk and don't call Vision).
+    /// the receipt on disk and don't call Vision). Depends on `compress`, so
+    /// iOS-only (image encoding is UIKit-backed) — issue #281.
+    #if canImport(UIKit)
     func save(imageData: Data, fileExtension: String) throws -> String {
         _ = fileExtension // Kept for API parity; output is always .jpg.
         let compressed = try compress(imageData: imageData)
         return try persist(data: compressed, ext: "jpg")
     }
+    #endif
 
     /// Save raw PDF data unchanged. Returned path is relative.
     func save(pdfData: Data) throws -> String {
@@ -208,6 +215,7 @@ final class ReceiptStorage {
 
 // MARK: - UIImage downsize helper
 
+#if canImport(UIKit)
 private extension UIImage {
     /// Resize so the longest edge is at most `longestEdge` points, preserving
     /// aspect ratio. Returns nil if the source is degenerate.
@@ -227,3 +235,4 @@ private extension UIImage {
         }
     }
 }
+#endif

--- a/mobile/PersonalDashboard/Services/ReceiptStorage.swift
+++ b/mobile/PersonalDashboard/Services/ReceiptStorage.swift
@@ -1,6 +1,14 @@
 import Foundation
 #if canImport(UIKit)
 import UIKit
+#else
+// macOS: the receipt encode/downsize path is built on ImageIO +
+// CoreGraphics (portable, no UIKit). `UniformTypeIdentifiers` supplies the
+// JPEG type identifier for the ImageIO destination. Added for the native
+// macOS target (issue #281).
+import ImageIO
+import CoreGraphics
+import UniformTypeIdentifiers
 #endif
 
 /// Errors thrown by ReceiptStorage. Surface to the user when a save / delete
@@ -92,6 +100,33 @@ final class ReceiptStorage {
         }
         return firstPass
     }
+    #else
+    /// macOS counterpart to the UIKit `compress`. Same contract (downsize to
+    /// `targetMaxEdge`, JPEG-encode, tighten quality / dimensions until under
+    /// `targetMaxBytes`), built on ImageIO so it needs no AppKit `NSImage`
+    /// round-trip and bakes in EXIF orientation. `nonisolated` for the same
+    /// off-main-actor reason as iOS. Issue #281.
+    nonisolated func compress(imageData: Data) throws -> Data {
+        guard let firstPass = Self.downsampledJPEG(
+            from: imageData, longestEdge: targetMaxEdge, quality: jpegQuality
+        ) else {
+            throw ReceiptStorageError.imageEncodingFailed
+        }
+        if firstPass.count <= targetMaxBytes {
+            return firstPass
+        }
+        if let secondPass = Self.downsampledJPEG(
+            from: imageData, longestEdge: targetMaxEdge, quality: fallbackJpegQuality
+        ), secondPass.count <= targetMaxBytes {
+            return secondPass
+        }
+        if let thirdPass = Self.downsampledJPEG(
+            from: imageData, longestEdge: 1024, quality: fallbackJpegQuality
+        ) {
+            return thirdPass
+        }
+        return firstPass
+    }
     #endif
 
     /// Persist a pre-compressed JPEG (typically the output of `compress(imageData:)`).
@@ -105,6 +140,12 @@ final class ReceiptStorage {
     /// the receipt on disk and don't call Vision). Depends on `compress`, so
     /// iOS-only (image encoding is UIKit-backed) — issue #281.
     #if canImport(UIKit)
+    func save(imageData: Data, fileExtension: String) throws -> String {
+        _ = fileExtension // Kept for API parity; output is always .jpg.
+        let compressed = try compress(imageData: imageData)
+        return try persist(data: compressed, ext: "jpg")
+    }
+    #else
     func save(imageData: Data, fileExtension: String) throws -> String {
         _ = fileExtension // Kept for API parity; output is always .jpg.
         let compressed = try compress(imageData: imageData)
@@ -233,6 +274,44 @@ private extension UIImage {
         return renderer.image { _ in
             draw(in: CGRect(origin: .zero, size: newSize))
         }
+    }
+}
+#else
+
+// MARK: - macOS ImageIO downsample + JPEG encode (issue #281)
+
+private extension ReceiptStorage {
+    /// Decode `data`, downsize so the longest edge is at most `longestEdge`
+    /// pixels (never upscales, matching the iOS `downsized` behaviour), bake in
+    /// EXIF orientation, and re-encode as JPEG at `quality`. Pure ImageIO +
+    /// CoreGraphics, so it runs off the main actor and needs no AppKit.
+    nonisolated static func downsampledJPEG(
+        from data: Data, longestEdge: CGFloat, quality: CGFloat
+    ) -> Data? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let thumbOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            // Apply the source's EXIF orientation to the pixels so a portrait
+            // photo isn't stored sideways.
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: Int(longestEdge.rounded()),
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(
+            source, 0, thumbOptions as CFDictionary
+        ) else { return nil }
+
+        let output = NSMutableData()
+        let type = UTType.jpeg.identifier as CFString
+        guard let destination = CGImageDestinationCreateWithData(
+            output, type, 1, nil
+        ) else { return nil }
+        let props: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: quality
+        ]
+        CGImageDestinationAddImage(destination, cgImage, props as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
     }
 }
 #endif

--- a/mobile/PersonalDashboard/Services/TicketStorage.swift
+++ b/mobile/PersonalDashboard/Services/TicketStorage.swift
@@ -1,5 +1,15 @@
 import Foundation
+#if canImport(UIKit)
 import UIKit
+#else
+// macOS: the ticket encode/downsize path is built on ImageIO +
+// CoreGraphics (portable, no UIKit), mirroring `ReceiptStorage`'s macOS branch.
+// `UniformTypeIdentifiers` supplies the JPEG type identifier for the ImageIO
+// destination. Added for the native macOS target (issue #281).
+import ImageIO
+import CoreGraphics
+import UniformTypeIdentifiers
+#endif
 
 /// Errors thrown by TicketStorage. Surface to the user when a save / delete
 /// can't complete (rare: disk full, sandbox sealed, etc.).
@@ -26,6 +36,11 @@ enum TicketStorageError: LocalizedError {
 /// a longest edge that keeps the base64 payload well under Anthropic's 5 MB
 /// per-image limit, so the SAME compressed bytes are safe for both the on-disk
 /// save AND the barcode-decode / extraction passes.
+///
+/// Cross-platform (issue #281): iOS keeps the UIKit `UIImage` compression path
+/// byte-for-byte; macOS uses the exact ImageIO + CoreGraphics approach already
+/// proven in `ReceiptStorage` (decode → EXIF-transform → downsample →
+/// JPEG-encode, off the main actor, no AppKit round-trip).
 @MainActor
 final class TicketStorage {
     static let shared = TicketStorage()
@@ -53,6 +68,7 @@ final class TicketStorage {
     /// to `targetMaxEdge` first. `nonisolated` so callers can run it off the
     /// main actor via `Task.detached` (the decode + re-encode is the expensive
     /// step) — it touches only immutable value constants.
+    #if canImport(UIKit)
     nonisolated func compress(imageData: Data) throws -> Data {
         guard let image = UIImage(data: imageData) else {
             throw TicketStorageError.imageEncodingFailed
@@ -72,6 +88,32 @@ final class TicketStorage {
         }
         return firstPass
     }
+    #else
+    /// macOS counterpart to the UIKit `compress`. Same contract (downsize to
+    /// `targetMaxEdge`, JPEG-encode, tighten quality / dimensions until under
+    /// `targetMaxBytes`), built on ImageIO so it needs no AppKit `NSImage`
+    /// round-trip and bakes in EXIF orientation. `nonisolated` for the same
+    /// off-main-actor reason as iOS. Issue #281.
+    nonisolated func compress(imageData: Data) throws -> Data {
+        guard let firstPass = Self.downsampledJPEG(
+            from: imageData, longestEdge: targetMaxEdge, quality: jpegQuality
+        ) else {
+            throw TicketStorageError.imageEncodingFailed
+        }
+        if firstPass.count <= targetMaxBytes { return firstPass }
+        if let secondPass = Self.downsampledJPEG(
+            from: imageData, longestEdge: targetMaxEdge, quality: fallbackJpegQuality
+        ), secondPass.count <= targetMaxBytes {
+            return secondPass
+        }
+        if let thirdPass = Self.downsampledJPEG(
+            from: imageData, longestEdge: 1400, quality: fallbackJpegQuality
+        ) {
+            return thirdPass
+        }
+        return firstPass
+    }
+    #endif
 
     /// Persist a pre-compressed JPEG (typically the output of `compress`).
     /// Returned path is relative.
@@ -161,6 +203,7 @@ final class TicketStorage {
 
 // MARK: - UIImage downsize helper
 
+#if canImport(UIKit)
 private extension UIImage {
     /// Resize so the longest edge is at most `longestEdge` points, preserving
     /// aspect ratio. Returns self when already small enough; nil only for a
@@ -182,3 +225,43 @@ private extension UIImage {
         }
     }
 }
+#else
+
+// MARK: - macOS ImageIO downsample + JPEG encode (issue #281)
+
+private extension TicketStorage {
+    /// Decode `data`, downsize so the longest edge is at most `longestEdge`
+    /// pixels (never upscales, matching the iOS `downsizedForTicket` behaviour),
+    /// bake in EXIF orientation, and re-encode as JPEG at `quality`. Pure
+    /// ImageIO + CoreGraphics, so it runs off the main actor and needs no
+    /// AppKit. Mirrors `ReceiptStorage.downsampledJPEG`.
+    nonisolated static func downsampledJPEG(
+        from data: Data, longestEdge: CGFloat, quality: CGFloat
+    ) -> Data? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let thumbOptions: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            // Apply the source's EXIF orientation to the pixels so a portrait
+            // photo isn't stored sideways.
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: Int(longestEdge.rounded()),
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(
+            source, 0, thumbOptions as CFDictionary
+        ) else { return nil }
+
+        let output = NSMutableData()
+        let type = UTType.jpeg.identifier as CFString
+        guard let destination = CGImageDestinationCreateWithData(
+            output, type, 1, nil
+        ) else { return nil }
+        let props: [CFString: Any] = [
+            kCGImageDestinationLossyCompressionQuality: quality
+        ]
+        CGImageDestinationAddImage(destination, cgImage, props as CFDictionary)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
+    }
+}
+#endif

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -1,17 +1,25 @@
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
+#endif
 
 struct ChatView: View {
     @State private var viewModel = ChatViewModel()
+    #if os(iOS)
     /// The speech transcriber is owned by the app-level `VoiceCaptureViewModel`
     /// and shared via the environment (issue #150). The inline mic button here
     /// and the global press-and-hold overlay therefore drive the SAME single
     /// transcriber instance, which is what keeps the re-entry guard meaningful
     /// (two instances could each install a tap and crash the audio engine).
+    ///
+    /// iOS-only: voice capture is AVFoundation/Speech-coupled and is gated off
+    /// on macOS (issue #281), where Chat is text-only.
     @Environment(VoiceCaptureViewModel.self) private var voiceVM
     private var transcriber: SpeechTranscriber { voiceVM.transcriber }
+    #endif
     @State private var pendingViewMore: Bool = false
     @State private var keyboardVisible: Bool = false
+    #if os(iOS)
     /// Whatever the user had typed at the moment they tapped the mic.
     /// While recording we replace the input field with `baseline + transcript`
     /// so partials feel live; tapping mic-stop with an empty transcript
@@ -43,6 +51,7 @@ struct ChatView: View {
     /// in the requested 1.5–2s window: long enough to ride out a natural
     /// mid-sentence pause, short enough to feel responsive.
     private let silenceFinalizeDelay: TimeInterval = 1.8
+    #endif
 
     /// Owned here so we can auto-focus the input bar when the user lands on
     /// chat (issue #48 — tapping the chat icon should pop the keyboard
@@ -63,13 +72,9 @@ struct ChatView: View {
                 .ignoresSafeArea()
                 // Tap on empty paper background dismisses the keyboard so
                 // the floating tab bar comes back into view (issue #48).
+                // `hideKeyboard()` is a no-op on macOS (no software keyboard).
                 .onTapGesture {
-                    UIApplication.shared.sendAction(
-                        #selector(UIResponder.resignFirstResponder),
-                        to: nil,
-                        from: nil,
-                        for: nil
-                    )
+                    hideKeyboard()
                 }
 
             VStack(spacing: 0) {
@@ -95,15 +100,11 @@ struct ChatView: View {
                 }
                 .simultaneousGesture(
                     TapGesture().onEnded {
-                        UIApplication.shared.sendAction(
-                            #selector(UIResponder.resignFirstResponder),
-                            to: nil,
-                            from: nil,
-                            for: nil
-                        )
+                        hideKeyboard()
                     }
                 )
 
+                #if os(iOS)
                 if transcriber.isRecording {
                     ListeningIndicator(onStop: stopListening)
                         .padding(.horizontal, Space.lg)
@@ -137,13 +138,14 @@ struct ChatView: View {
                     .onTapGesture { transcriber.errorMessage = nil }
                     .transition(.opacity.combined(with: .move(edge: .bottom)))
                 }
+                #endif
 
                 ChatInputBar(
                     text: $viewModel.draftInput,
                     isSending: viewModel.isSending,
                     onSend: send,
-                    onMic: { Task { await toggleMic() } },
-                    isMicActive: transcriber.isRecording,
+                    onMic: micHandler,
+                    isMicActive: micActive,
                     focused: $inputFocused
                 )
                 .padding(.horizontal, Space.lg)
@@ -157,7 +159,9 @@ struct ChatView: View {
             }
             // Animate the listening banner and inline mic-error in/out so they
             // don't pop (their transitions are declared at each call site).
+            #if os(iOS)
             .animation(.easeOut(duration: 0.2), value: transcriber.isRecording)
+            #endif
         }
         .background(Tokens.paper)
         .onAppear {
@@ -179,6 +183,7 @@ struct ChatView: View {
                 }
             }
         }
+        #if os(iOS)
         .onChange(of: transcriber.transcript) { _, newTranscript in
             // Mirror live partials into the existing TextField so the user
             // sees the transcription appear in real time. Append to the
@@ -244,6 +249,7 @@ struct ChatView: View {
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
             withAnimation(.easeOut(duration: 0.18)) { keyboardVisible = false }
         }
+        #endif
         .alert("Something went wrong",
                isPresented: Binding(
                    get: { viewModel.errorMessage != nil },
@@ -341,7 +347,28 @@ struct ChatView: View {
         }
     }
 
+    /// Mic tap handler passed to `ChatInputBar`. On macOS there is no voice
+    /// capture (issue #281), so this is `nil` and `ChatInputBar` renders no
+    /// mic button. On iOS it toggles the shared transcriber.
+    private var micHandler: (() -> Void)? {
+        #if os(iOS)
+        return { Task { await toggleMic() } }
+        #else
+        return nil
+        #endif
+    }
+
+    /// Whether the mic is actively recording. Always `false` on macOS.
+    private var micActive: Bool {
+        #if os(iOS)
+        return transcriber.isRecording
+        #else
+        return false
+        #endif
+    }
+
     private func send() {
+        #if os(iOS)
         // Flush any in-flight transcription first so the final partial
         // lands in `draftInput` before the message ships.
         if transcriber.isRecording {
@@ -352,9 +379,11 @@ struct ChatView: View {
         // session can't land in `draftInput` after the message has shipped
         // (issue #151).
         endInlineMicSession()
+        #endif
         Task { await viewModel.send() }
     }
 
+    #if os(iOS)
     private func toggleMic() async {
         if transcriber.isRecording {
             stopListening()
@@ -445,6 +474,7 @@ struct ChatView: View {
         silenceTimer?.invalidate()
         silenceTimer = nil
     }
+    #endif
 
     private var hasLiveAssistantTurn: Bool {
         viewModel.turns.last?.isStreaming == true
@@ -471,6 +501,10 @@ struct ChatView: View {
 /// input-bar stop button so the user has an obvious cancel target right where
 /// their eyes are). Uses the restrained design vocabulary: surface fill,
 /// paper border, danger-tinted dot to echo the input-bar stop affordance.
+///
+/// iOS-only: relies on `WaveformBars` and the voice transcriber, both gated
+/// off on macOS (issue #281).
+#if os(iOS)
 private struct ListeningIndicator: View {
     let onStop: () -> Void
 
@@ -517,6 +551,7 @@ private struct ListeningIndicator: View {
         .accessibilityAddTraits(.isButton)
     }
 }
+#endif
 
 /// Three short bars that bob continuously to suggest live audio. Decorative
 /// only — height is time-driven, not bound to actual mic levels (the

--- a/mobile/PersonalDashboard/Views/Components/MarkdownEditor.swift
+++ b/mobile/PersonalDashboard/Views/Components/MarkdownEditor.swift
@@ -1,5 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
 import UIKit
+#endif
 
 // MARK: - MarkdownEditor
 //
@@ -13,6 +15,7 @@ import UIKit
 // UITextView gives us `selectedRange`, key-input behavior, and an obvious
 // place to attach the input accessory view.
 
+#if os(iOS)
 struct MarkdownEditor: UIViewRepresentable {
     @Binding var text: String
     @FocusState.Binding var isFocused: Bool
@@ -589,3 +592,40 @@ private struct EditorListMarker {
         }
     }
 }
+#else
+
+// MARK: - macOS MarkdownEditor
+//
+// Native SwiftUI editor for the Mac port (issue #281). macOS has no software
+// keyboard, so the iOS `inputAccessoryView` format toolbar has no analog; and
+// with a full hardware keyboard, typing markdown directly is the natural path.
+// This uses SwiftUI's native `TextEditor` (real focus, scrolling, selection
+// handled by AppKit) with a placeholder overlay, matching the iOS init API so
+// `NotesView` uses it unchanged. The preview tab renders via `MarkdownView`.
+struct MarkdownEditor: View {
+    @Binding var text: String
+    @FocusState.Binding var isFocused: Bool
+    var minHeight: CGFloat = 320
+    var placeholder: String = ""
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            if text.isEmpty {
+                Text(placeholder)
+                    .font(.edBody)
+                    .foregroundStyle(Tokens.muted)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 10)
+                    .allowsHitTesting(false)
+            }
+            TextEditor(text: $text)
+                .focused($isFocused)
+                .font(.edBody)
+                .foregroundStyle(Tokens.ink)
+                .scrollContentBackground(.hidden)
+                .padding(.horizontal, 2)
+                .frame(minHeight: minHeight)
+        }
+    }
+}
+#endif

--- a/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
+++ b/mobile/PersonalDashboard/Views/Finance/AddExpenseSheet.swift
@@ -1,7 +1,44 @@
 import SwiftUI
 import SwiftData
 import PDFKit
+#if canImport(UIKit)
 import UIKit
+#else
+import AppKit
+#endif
+
+/// Cross-platform receipt image alias + loaders (issue #281). The receipt
+/// viewers are backed by UIKit on iOS and AppKit on macOS; both take the
+/// platform-native image type, so a single alias keeps their call sites
+/// identical.
+#if canImport(UIKit)
+typealias ReceiptPlatformImage = UIImage
+#else
+typealias ReceiptPlatformImage = NSImage
+#endif
+
+/// Load a receipt image file into the platform-native image type. Returns nil
+/// when the file is missing or not a decodable image (e.g. a PDF).
+func loadReceiptPlatformImage(_ url: URL) -> ReceiptPlatformImage? {
+    #if canImport(UIKit)
+    return UIImage(contentsOfFile: url.path)
+    #else
+    return NSImage(contentsOfFile: url.path)
+    #endif
+}
+
+extension Image {
+    /// Build a SwiftUI `Image` from a receipt file on disk, cross-platform.
+    /// Fails (returns nil) when the file can't be decoded as an image.
+    init?(receiptFileURL url: URL) {
+        guard let platformImage = loadReceiptPlatformImage(url) else { return nil }
+        #if canImport(UIKit)
+        self.init(uiImage: platformImage)
+        #else
+        self.init(nsImage: platformImage)
+        #endif
+    }
+}
 
 /// Editor target for the AddExpense / EditExpense sheet.
 ///
@@ -221,7 +258,7 @@ struct AddExpenseSheet: View {
                 }
             }
             .navigationTitle(navigationTitleText)
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -349,7 +386,7 @@ struct AddExpenseSheet: View {
             Text("Amount").eyebrow()
             HStack(spacing: Space.sm) {
                 TextField("0.00", text: $amountText)
-                    .keyboardType(.decimalPad)
+                    .decimalKeyboard()
                     .font(.edDisplay)
                     .foregroundStyle(Tokens.ink)
                     .focused($amountFocused)
@@ -1297,7 +1334,7 @@ struct PersonPickerSheet: View {
                 .background(Tokens.paper)
             }
             .navigationTitle("Person")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -1427,7 +1464,7 @@ struct EventPickerSheet: View {
                 .background(Tokens.paper)
             }
             .navigationTitle("Event")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -1556,8 +1593,8 @@ struct ReceiptThumbnailImage: View {
                let url = ReceiptStorage.shared.load(relativePath: path) {
                 if isPDF(path) {
                     pdfPlaceholder
-                } else if let image = UIImage(contentsOfFile: url.path) {
-                    Image(uiImage: image)
+                } else if let image = Image(receiptFileURL: url) {
+                    image
                         .resizable()
                         .scaledToFill()
                 } else {
@@ -1616,7 +1653,7 @@ struct ReceiptFullViewer: View {
                 content
             }
             .navigationTitle("Receipt")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
@@ -1632,7 +1669,7 @@ struct ReceiptFullViewer: View {
             if relativePath.lowercased().hasSuffix(".pdf") {
                 PDFKitView(url: url)
                     .ignoresSafeArea(edges: .bottom)
-            } else if let image = UIImage(contentsOfFile: url.path) {
+            } else if let image = loadReceiptPlatformImage(url) {
                 ZoomableImageView(image: image)
                     .ignoresSafeArea(edges: .bottom)
             } else {
@@ -1650,8 +1687,9 @@ struct ReceiptFullViewer: View {
     }
 }
 
-// MARK: - Zoomable image (UIScrollView-backed)
+// MARK: - Zoomable image (scroll-view-backed)
 
+#if os(iOS)
 /// A `UIScrollView` wrapping a `UIImageView`, exposing native pinch-to-zoom,
 /// pan-while-zoomed, and double-tap-to-toggle. `viewForZooming` is what makes
 /// the scroll view drive the zoom; the image is centred in `layoutSubviews`
@@ -1775,12 +1813,51 @@ private final class CenteringScrollView: UIScrollView {
         imageView.frame = frame
     }
 }
+#else
+/// macOS receipt image viewer (issue #281). An `NSScrollView` with
+/// `allowsMagnification` gives trackpad pinch-to-zoom and drag-to-pan for
+/// free; the document `NSImageView` is sized to the image's natural size and
+/// scaled proportionally. No hand-rolled gesture math, matching the iOS
+/// scroll-view approach.
+private struct ZoomableImageView: NSViewRepresentable {
+    let image: NSImage
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.allowsMagnification = true
+        scrollView.minMagnification = 1.0
+        scrollView.maxMagnification = 5.0
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+
+        let imageView = NSImageView()
+        imageView.image = image
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.imageAlignment = .alignCenter
+        imageView.frame = NSRect(origin: .zero, size: image.size)
+        scrollView.documentView = imageView
+
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        // Keep the document view sized to the current image; the image is
+        // fixed for the viewer's life, so nothing to reconcile.
+        (nsView.documentView as? NSImageView)?.image = image
+    }
+}
+#endif
 
 // MARK: - PDF (PDFKit-backed)
 
 /// A `PDFView` with `autoScales = true`, which gives native pinch-zoom,
 /// page scrolling, and a fit-to-width initial layout. Loaded from the
-/// on-disk receipt URL.
+/// on-disk receipt URL. `PDFView` is UIKit-backed on iOS and AppKit-backed
+/// on macOS, so the representable splits by platform but shares the same
+/// configuration (issue #281).
+#if os(iOS)
 private struct PDFKitView: UIViewRepresentable {
     let url: URL
 
@@ -1800,3 +1877,24 @@ private struct PDFKitView: UIViewRepresentable {
         }
     }
 }
+#else
+private struct PDFKitView: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> PDFView {
+        let pdfView = PDFView()
+        pdfView.autoScales = true
+        pdfView.displayMode = .singlePageContinuous
+        pdfView.displayDirection = .vertical
+        pdfView.backgroundColor = .clear
+        pdfView.document = PDFDocument(url: url)
+        return pdfView
+    }
+
+    func updateNSView(_ nsView: PDFView, context: Context) {
+        if nsView.document == nil {
+            nsView.document = PDFDocument(url: url)
+        }
+    }
+}
+#endif

--- a/mobile/PersonalDashboard/Views/Finance/FinanceFilterBar.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceFilterBar.swift
@@ -394,7 +394,7 @@ private struct CustomDateRangeSheet: View {
                 .padding(Space.lg)
             }
             .navigationTitle("Date range")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -633,7 +633,7 @@ private struct MoreFiltersSheet: View {
                 .background(Tokens.paper)
             }
             .navigationTitle("Filters")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Clear") {

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import SwiftData
+#if canImport(UIKit)
 import UIKit
+#endif
 
 /// Source channel for the "+" capture menu. Drives both the picker
 /// presentation flags and the downstream `ExpenseSource` we tag the
@@ -111,6 +113,11 @@ struct FinanceView: View {
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
         }
+        // Camera capture is iOS-only: `.fullScreenCover` and
+        // UIImagePickerController don't exist on macOS. The menu item that
+        // presents this (below) is likewise gated, so `showingCamera` never
+        // flips on macOS. Photo-library / PDF / statement / manual all stay.
+        #if os(iOS)
         .fullScreenCover(isPresented: $showingCamera) {
             CameraPicker { data in
                 showingCamera = false
@@ -118,6 +125,7 @@ struct FinanceView: View {
             }
             .ignoresSafeArea()
         }
+        #endif
         .photoLibraryPicker(isPresented: $showingPhotoLibrary) { data in
             handleCaptureData(data, source: .photoLibrary)
         }
@@ -173,7 +181,9 @@ struct FinanceView: View {
             // .camera path is hidden in the simulator (and other no-camera
             // hardware) — the UIImagePickerController would silently fall
             // back to .photoLibrary, which makes the two top items
-            // confusingly redundant.
+            // confusingly redundant. Also entirely gated off on macOS, which
+            // has no UIImagePickerController camera capture (issue #281).
+            #if os(iOS)
             if UIImagePickerController.isSourceTypeAvailable(.camera) {
                 Button {
                     startScan(.camera)
@@ -181,6 +191,7 @@ struct FinanceView: View {
                     Label("Scan receipt", systemImage: "camera")
                 }
             }
+            #endif
             Button {
                 startScan(.photoLibrary)
             } label: {
@@ -593,7 +604,7 @@ struct FinanceView: View {
                 .font(.edBody)
                 .foregroundStyle(Tokens.ink)
                 .autocorrectionDisabled(true)
-                .textInputAutocapitalization(.never)
+                .noAutocapitalization()
             if !searchText.isEmpty {
                 Button {
                     searchText = ""

--- a/mobile/PersonalDashboard/Views/Finance/RecurringExpenseEditorSheet.swift
+++ b/mobile/PersonalDashboard/Views/Finance/RecurringExpenseEditorSheet.swift
@@ -65,7 +65,7 @@ struct RecurringExpenseEditorSheet: View {
                 }
             }
             .navigationTitle(isEditing ? "Edit recurring" : "New recurring")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -90,7 +90,7 @@ struct RecurringExpenseEditorSheet: View {
             Text("Monthly amount").eyebrow()
             HStack(spacing: Space.sm) {
                 TextField("0.00", text: $amountText)
-                    .keyboardType(.decimalPad)
+                    .decimalKeyboard()
                     .font(.edDisplay)
                     .foregroundStyle(Tokens.ink)
                     .focused($amountFocused)

--- a/mobile/PersonalDashboard/Views/Finance/RecurringExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/RecurringExpensesView.swift
@@ -38,7 +38,7 @@ struct RecurringExpensesView: View {
                 content
             }
             .navigationTitle("Recurring")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -810,9 +810,9 @@ private struct ItemDetailsSheet: View {
                             Text("Link (URL)").eyebrow()
                             HStack(spacing: Space.sm) {
                                 TextField("Paste a link", text: $urlText)
-                                    .textInputAutocapitalization(.never)
+                                    .noAutocapitalization()
                                     .autocorrectionDisabled(true)
-                                    .keyboardType(.URL)
+                                    .urlKeyboard()
                                     .font(.edBody)
                                     .foregroundStyle(Tokens.ink)
                                     .padding(Space.md)
@@ -852,7 +852,7 @@ private struct ItemDetailsSheet: View {
                 .scrollDismissesKeyboard(.interactively)
             }
             .navigationTitle(nameEditable ? "New item" : "Item details")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }.foregroundStyle(Tokens.muted)
@@ -941,7 +941,7 @@ private struct NewListSheet: View {
             }
             .animation(.easeOut(duration: 0.2), value: inferred.colorHex)
             .navigationTitle("New list")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }.foregroundStyle(Tokens.muted)
@@ -1052,7 +1052,7 @@ private struct ListPropertiesSheet: View {
                 .scrollDismissesKeyboard(.interactively)
             }
             .navigationTitle("List appearance")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }.foregroundStyle(Tokens.muted)

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -435,7 +435,7 @@ private struct NewFolderSheet: View {
                 .padding(Space.lg)
             }
             .navigationTitle("New folder")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }.foregroundStyle(Tokens.muted)

--- a/mobile/PersonalDashboard/Views/Settings/BackupSettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/BackupSettingsView.swift
@@ -45,7 +45,7 @@ struct BackupSettingsView: View {
                 content
             }
             .navigationTitle("Backup")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }

--- a/mobile/PersonalDashboard/Views/Settings/DataExportImportView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/DataExportImportView.swift
@@ -1,7 +1,12 @@
 import SwiftUI
 import SwiftData
-import UIKit
 import UniformTypeIdentifiers
+#if canImport(UIKit)
+import UIKit
+#endif
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// Sheet that hosts export + import in a single surface. Two rows on the
 /// landing page; tapping one drives the corresponding flow.
@@ -35,7 +40,7 @@ struct DataExportImportView: View {
                 content
             }
             .navigationTitle(navigationTitle)
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     if showsBackButton {
@@ -331,12 +336,19 @@ struct DataExportImportView: View {
         let service = DataExportService(modelContext: modelContext)
         do {
             let url = try service.export()
+            #if os(iOS)
             phase = .shareReady(url)
             await presentShareSheet(for: url)
             // Hand back to idle once the share sheet dismisses. The tmp
             // file stays on disk for the OS to clean up (sharing copies
             // it into Files / Mail / etc).
             phase = .idle
+            #else
+            // macOS has no share sheet; let the user pick a save location and
+            // copy the exported archive there (issue #281).
+            phase = .idle
+            saveExportedArchive(at: url)
+            #endif
         } catch {
             phase = .idle
             errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
@@ -379,6 +391,7 @@ struct DataExportImportView: View {
         }
     }
 
+    #if os(iOS)
     @MainActor
     private func presentShareSheet(for url: URL) async {
         guard let topController = topMostViewController() else { return }
@@ -414,6 +427,32 @@ struct DataExportImportView: View {
         while let presented = top.presentedViewController { top = presented }
         return top
     }
+    #endif
+
+    #if os(macOS)
+    /// macOS export: present an `NSSavePanel` and copy the freshly built
+    /// archive to the chosen location. There is no share sheet on macOS, so the
+    /// user saves the `.zip` directly (issue #281).
+    @MainActor
+    private func saveExportedArchive(at url: URL) {
+        let panel = NSSavePanel()
+        panel.title = "Save Dexter export"
+        panel.nameFieldStringValue = url.lastPathComponent
+        panel.allowedContentTypes = [.zip]
+        panel.canCreateDirectories = true
+        panel.isExtensionHidden = false
+
+        guard panel.runModal() == .OK, let destination = panel.url else { return }
+        do {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.copyItem(at: url, to: destination)
+        } catch {
+            errorMessage = "Couldn't save export: \(error.localizedDescription)"
+        }
+    }
+    #endif
 
     // MARK: - Helpers
 
@@ -528,8 +567,10 @@ private struct PreviewRow: View {
     }
 }
 
+#if os(iOS)
 private extension UIWindowScene {
     var keyWindow: UIWindow? {
         windows.first { $0.isKeyWindow } ?? windows.first
     }
 }
+#endif

--- a/mobile/PersonalDashboard/Views/Settings/ParsedFilesView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/ParsedFilesView.swift
@@ -49,9 +49,9 @@ struct ParsedFilesView: View {
                 .scrollDismissesKeyboard(.interactively)
             }
             .navigationTitle("Parsed files")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .trailingBar) {
                     Button("Done") { dismiss() }
                 }
             }
@@ -98,7 +98,7 @@ struct ParsedFilesView: View {
                 .font(.edBody)
                 .foregroundStyle(Tokens.ink)
                 .autocorrectionDisabled(true)
-                .textInputAutocapitalization(.never)
+                .noAutocapitalization()
             if !searchText.isEmpty {
                 Button {
                     searchText = ""
@@ -507,9 +507,9 @@ private struct StatementDetailView: View {
                 }
             }
             .navigationTitle("Statement import")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .trailingBar) {
                     Button("Done") { dismiss() }
                 }
             }
@@ -603,9 +603,9 @@ private struct ParsedEmailDetailView: View {
                 }
             }
             .navigationTitle("Email detail")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .trailingBar) {
                     Button("Done") { dismiss() }
                 }
             }
@@ -614,7 +614,12 @@ private struct ParsedEmailDetailView: View {
 
     private var undoButton: some View {
         Button(role: .destructive) {
+            // Undo is backed by the iOS-only email-ingest service. This button
+            // can't appear on macOS anyway (no email logs are ever written
+            // there), but the call must compile out (issue #281).
+            #if os(iOS)
             _ = EmailIngestService().undo(logUUID: entry.clientUUID)
+            #endif
             undone = true
         } label: {
             HStack(spacing: Space.sm) {

--- a/mobile/PersonalDashboard/Views/Settings/PersonalVocabularyView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/PersonalVocabularyView.swift
@@ -216,7 +216,7 @@ private struct KeywordEditorSheet: View {
                 }
             }
             .navigationTitle(isEditing ? "Edit term" : "New term")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }

--- a/mobile/PersonalDashboard/Views/Settings/ResetDataView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/ResetDataView.swift
@@ -84,7 +84,7 @@ struct ResetDataView: View {
                 }
             }
             .navigationTitle("Reset data")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     if phase == .confirm {
@@ -232,7 +232,7 @@ struct ResetDataView: View {
                         .foregroundStyle(Tokens.inkSoft)
 
                     TextField("reset", text: $confirmText)
-                        .textInputAutocapitalization(.never)
+                        .noAutocapitalization()
                         .autocorrectionDisabled()
                         .font(.edBody)
                         .foregroundStyle(Tokens.ink)

--- a/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
@@ -6,7 +6,11 @@ struct SettingsView: View {
 
     @State private var showingResetData: Bool = false
     @State private var showingDataTransfer: Bool = false
+    // Receipts inbox is iOS-only (backed by BackgroundTasks email ingest), so
+    // this flag and its row/sheet are compiled out on macOS (issue #281).
+    #if os(iOS)
     @State private var showingEmailInbox: Bool = false
+    #endif
     @State private var showingParsedFiles: Bool = false
     @State private var showingBackup: Bool = false
 
@@ -29,9 +33,11 @@ struct SettingsView: View {
         .sheet(isPresented: $showingDataTransfer) {
             DataExportImportView()
         }
+        #if os(iOS)
         .sheet(isPresented: $showingEmailInbox) {
             EmailInboxView()
         }
+        #endif
         .sheet(isPresented: $showingParsedFiles) {
             ParsedFilesView()
         }
@@ -116,6 +122,9 @@ struct SettingsView: View {
     private var automationSection: some View {
         SettingsSection(title: "Automation") {
             VStack(spacing: 0) {
+                // Receipts inbox is iOS-only (BackgroundTasks email ingest);
+                // macOS shows only the parsed-files history row (issue #281).
+                #if os(iOS)
                 Button {
                     showingEmailInbox = true
                 } label: {
@@ -130,6 +139,7 @@ struct SettingsView: View {
                     .fill(Tokens.divider)
                     .frame(height: 0.5)
                     .padding(.leading, Space.lg)
+                #endif
 
                 Button {
                     showingParsedFiles = true

--- a/mobile/PersonalDashboard/Views/Shell/BottomTabBar.swift
+++ b/mobile/PersonalDashboard/Views/Shell/BottomTabBar.swift
@@ -1,19 +1,8 @@
 import SwiftUI
 import UIKit
 
-/// Layout metrics for the bottom tab bar so surfaces can reserve space
-/// above their content (especially sticky-bottom UI like the chat input).
-///
-/// `height` is the visual footprint occupied above the home-indicator safe
-/// area: pill height + the bottom gap between the pill and the safe-area
-/// inset. The chat circle's lift above the pill is intentionally NOT
-/// included — surfaces reserve space for the pill body, and the lifted
-/// circle is allowed to overlap the surface above (it's a floating
-/// element, not a strip of chrome).
-enum BottomTabBarMetrics {
-    /// Total height reserved above the bottom safe area (pill + bottom gap).
-    static let height: CGFloat = 74
-}
+// `BottomTabBarMetrics` moved to BottomTabBarMetrics.swift (UIKit-free) so
+// surfaces can reserve space without depending on this iOS-only view.
 
 /// Floating-pill bottom tab bar (Navigation v3, issue #48).
 ///

--- a/mobile/PersonalDashboard/Views/Shell/BottomTabBarMetrics.swift
+++ b/mobile/PersonalDashboard/Views/Shell/BottomTabBarMetrics.swift
@@ -1,0 +1,19 @@
+import CoreGraphics
+
+/// Layout metrics for the bottom tab bar so surfaces can reserve space
+/// above their content (especially sticky-bottom UI like the chat input).
+///
+/// `height` is the visual footprint occupied above the home-indicator safe
+/// area: pill height + the bottom gap between the pill and the safe-area
+/// inset. The chat circle's lift above the pill is intentionally NOT
+/// included — surfaces reserve space for the pill body, and the lifted
+/// circle is allowed to overlap the surface above (it's a floating
+/// element, not a strip of chrome).
+///
+/// Lives in its own UIKit-free file so surfaces that only need the metric
+/// (e.g. `TasksView`) can depend on it without dragging in the tab-bar view
+/// itself, which is iOS-only chrome (keyboard notifications, haptics).
+enum BottomTabBarMetrics {
+    /// Total height reserved above the bottom safe area (pill + bottom gap).
+    static let height: CGFloat = 74
+}

--- a/mobile/PersonalDashboard/Views/Tasks/TagChipPicker.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TagChipPicker.swift
@@ -134,7 +134,7 @@ struct TagChipPicker: View {
     private var addNewChip: some View {
         if isAddingNew {
             TextField("New tag", text: $newTagText)
-                .textInputAutocapitalization(.never)
+                .noAutocapitalization()
                 .autocorrectionDisabled(true)
                 .font(.edBody)
                 .foregroundStyle(Tokens.ink)

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -60,7 +60,7 @@ struct TasksView: View {
                             .listRowInsets(EdgeInsets())
                     }
                     .listStyle(.plain)
-                    .listSectionSpacing(0)
+                    .listSectionSpacingCompat(0)
                     .scrollContentBackground(.hidden)
                     .background(Tokens.paper)
                     .refreshable { await viewModel.load() }
@@ -890,9 +890,9 @@ private struct TaskEditorSheet: View {
                         labeled("Google Maps link") {
                             HStack(spacing: Space.sm) {
                                 TextField("Paste a Google Maps link", text: $googleMapsLink)
-                                    .textInputAutocapitalization(.never)
+                                    .noAutocapitalization()
                                     .autocorrectionDisabled(true)
-                                    .keyboardType(.URL)
+                                    .urlKeyboard()
                                     .font(.edBody)
                                     .foregroundStyle(Tokens.ink)
                                     .padding(Space.md)
@@ -923,7 +923,7 @@ private struct TaskEditorSheet: View {
                 .scrollDismissesKeyboard(.interactively)
             }
             .navigationTitle(isEditing ? "Edit task" : "New task")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }.foregroundStyle(Tokens.muted)

--- a/mobile/PersonalDashboard/Views/Trips/TicketCardView.swift
+++ b/mobile/PersonalDashboard/Views/Trips/TicketCardView.swift
@@ -615,7 +615,7 @@ struct StayBookingDetailSheet: View {
                 }
             }
             .navigationTitle("Stay")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
@@ -623,9 +623,14 @@ struct StayBookingDetailSheet: View {
                 }
             }
         }
+        // The scan surface is a gate/turnstile idiom that needs the camera-era
+        // brightness + idle-timer control; iOS-only, and `.fullScreenCover` is
+        // unavailable on macOS regardless (issue #281).
+        #if os(iOS)
         .fullScreenCover(isPresented: $showingScan) {
             TicketScanView(item: item)
         }
+        #endif
         .sheet(isPresented: $showingOriginal) {
             TicketOriginalViewer(attachmentPath: item.attachmentPath)
         }
@@ -633,12 +638,15 @@ struct StayBookingDetailSheet: View {
 
     private var actions: some View {
         VStack(spacing: Space.sm) {
+            // "Scan ticket" opens the iOS-only present-to-scan surface.
+            #if os(iOS)
             if item.hasBarcode {
                 actionRow(icon: "barcode.viewfinder", title: "Scan ticket") {
                     Haptics.light()
                     showingScan = true
                 }
             }
+            #endif
             if !item.attachmentPath.isEmpty {
                 actionRow(icon: "doc.text.magnifyingglass", title: "View original ticket") {
                     Haptics.light()
@@ -786,13 +794,13 @@ struct BarcodeImageView: View {
     /// centers it on the stub; the editor thumbnail keeps the default leading.
     var alignment: Alignment = .leading
 
-    @State private var rendered: UIImage?
+    @State private var rendered: PlatformImage?
     @State private var didAttempt = false
 
     var body: some View {
         Group {
             if let rendered {
-                Image(uiImage: rendered)
+                Image(platformImage: rendered)
                     .resizable()
                     .interpolation(.none)
                     .aspectRatio(contentMode: .fit)
@@ -828,7 +836,7 @@ struct BarcodeImageView: View {
         let symbol = BarcodeSymbology(rawValue: symbology) ?? .other
         // Regenerate off the main actor; CoreImage + UIGraphicsImageRenderer are
         // safe off-main and this keeps scrolling smooth.
-        let image = await Task.detached(priority: .userInitiated) { () -> UIImage? in
+        let image = await Task.detached(priority: .userInitiated) { () -> PlatformImage? in
             if let regenerated = BarcodeService.render(payload: payloadCopy, symbology: symbol, targetLongEdge: 900) {
                 return regenerated
             }
@@ -847,17 +855,17 @@ struct BarcodeImageView: View {
 
     /// Load the original attachment and crop to its barcode's bounding box when
     /// detectable, so the fallback shows the code rather than the whole ticket.
-    private func loadAttachmentBarcodeCrop() async -> UIImage? {
+    private func loadAttachmentBarcodeCrop() async -> PlatformImage? {
         guard !attachmentPath.isEmpty,
               let url = TicketStorage.shared.load(relativePath: attachmentPath) else { return nil }
         let isPDF = TicketStorage.isPDF(attachmentPath)
-        return await Task.detached(priority: .userInitiated) { () -> UIImage? in
-            let base: UIImage?
+        return await Task.detached(priority: .userInitiated) { () -> PlatformImage? in
+            let base: PlatformImage?
             if isPDF {
                 let data = (try? Data(contentsOf: url))
                 base = data.flatMap { BarcodeService.renderFirstPage(pdfData: $0) }
             } else {
-                base = UIImage(contentsOfFile: url.path)
+                base = loadReceiptPlatformImage(url)
             }
             guard let base else { return nil }
             if let decoded = BarcodeService.decode(image: base) {

--- a/mobile/PersonalDashboard/Views/Trips/TicketScanView.swift
+++ b/mobile/PersonalDashboard/Views/Trips/TicketScanView.swift
@@ -1,3 +1,4 @@
+#if os(iOS)
 import SwiftUI
 import PDFKit
 import UIKit
@@ -16,6 +17,12 @@ import UIKit
 /// When the item has no decodable barcode but does have an attachment, the
 /// barcode panel shows the original (auto-cropped to the code when we can still
 /// detect it — see `BarcodeImageView`).
+///
+/// iOS-only (issue #281): it depends on `UIScreen.brightness` and the idle
+/// timer, which don't exist on macOS. Gate off the whole file; the shared
+/// viewers it used (`TicketOriginalViewer`, `TicketAttachmentThumbnail`) now
+/// live in the cross-platform `TicketViewers.swift`. This surface is NOT a
+/// member of the macOS target and its call sites are `#if os(iOS)`-guarded.
 struct TicketScanView: View {
     let item: LocalItineraryItem
 
@@ -225,169 +232,4 @@ struct TicketScanView: View {
         }
     }
 }
-
-// MARK: - Original file viewer
-
-/// Full-screen viewer for the stored original ticket file, backed by
-/// `TicketStorage`. Mirrors the Finance `ReceiptFullViewer` pattern but reads
-/// from the tickets directory. UIKit-backed for smooth native zoom.
-struct TicketOriginalViewer: View {
-    let attachmentPath: String
-
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        NavigationStack {
-            ZStack {
-                Tokens.paper.ignoresSafeArea()
-                content
-            }
-            .navigationTitle("Original ticket")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }
-                        .foregroundStyle(Tokens.ink)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var content: some View {
-        if let url = TicketStorage.shared.load(relativePath: attachmentPath) {
-            if TicketStorage.isPDF(attachmentPath) {
-                TicketPDFView(url: url)
-                    .ignoresSafeArea(edges: .bottom)
-            } else if let image = UIImage(contentsOfFile: url.path) {
-                TicketZoomableImageView(image: image)
-                    .ignoresSafeArea(edges: .bottom)
-            } else {
-                unavailable
-            }
-        } else {
-            unavailable
-        }
-    }
-
-    private var unavailable: some View {
-        Text("The ticket file is no longer available.")
-            .font(.edBody)
-            .foregroundStyle(Tokens.muted)
-    }
-}
-
-// MARK: - Attachment thumbnail
-
-/// Small inline preview of a stored ticket file: the image for a photo/scan,
-/// a doc icon for a PDF, a placeholder when the file is gone. Used by the item
-/// editor's ticket section. Mirrors Finance's `ReceiptThumbnailImage` but reads
-/// from `TicketStorage`.
-struct TicketAttachmentThumbnail: View {
-    let relativePath: String
-
-    var body: some View {
-        Group {
-            if let url = TicketStorage.shared.load(relativePath: relativePath) {
-                if TicketStorage.isPDF(relativePath) {
-                    icon("doc.text.fill", tint: Tokens.accent(for: .itineraries))
-                } else if let image = UIImage(contentsOfFile: url.path) {
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFill()
-                } else {
-                    icon("photo", tint: Tokens.muted)
-                }
-            } else {
-                icon("photo", tint: Tokens.muted)
-            }
-        }
-        .background(Tokens.surface2)
-    }
-
-    private func icon(_ name: String, tint: Color) -> some View {
-        Image(systemName: name)
-            .font(.system(size: 22, weight: .regular))
-            .foregroundStyle(tint)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-}
-
-// MARK: - PDF viewer
-
-/// Thin `PDFView` wrapper with native pinch-zoom + page scrolling. Named
-/// distinctly from Finance's `PDFKitView` (which is file-private) to avoid a
-/// collision while keeping tickets self-contained.
-private struct TicketPDFView: UIViewRepresentable {
-    let url: URL
-
-    func makeUIView(context: Context) -> PDFView {
-        let view = PDFView()
-        view.autoScales = true
-        view.displayMode = .singlePageContinuous
-        view.displayDirection = .vertical
-        view.backgroundColor = .clear
-        view.document = PDFDocument(url: url)
-        return view
-    }
-
-    func updateUIView(_ uiView: PDFView, context: Context) {
-        if uiView.document?.documentURL != url {
-            uiView.document = PDFDocument(url: url)
-        }
-    }
-}
-
-// MARK: - Zoomable image
-
-/// `UIScrollView` + `UIImageView` giving native pinch-to-zoom, pan, and
-/// double-tap-to-toggle. A compact re-implementation (Finance's equivalent is
-/// file-private).
-private struct TicketZoomableImageView: UIViewRepresentable {
-    let image: UIImage
-
-    func makeUIView(context: Context) -> UIScrollView {
-        let scrollView = UIScrollView()
-        scrollView.delegate = context.coordinator
-        scrollView.backgroundColor = .clear
-        scrollView.showsHorizontalScrollIndicator = false
-        scrollView.showsVerticalScrollIndicator = false
-        scrollView.contentInsetAdjustmentBehavior = .never
-        scrollView.minimumZoomScale = 1.0
-        scrollView.maximumZoomScale = 5.0
-
-        let imageView = UIImageView(image: image)
-        imageView.contentMode = .scaleAspectFit
-        imageView.frame = scrollView.bounds
-        imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        scrollView.addSubview(imageView)
-        context.coordinator.imageView = imageView
-
-        let doubleTap = UITapGestureRecognizer(
-            target: context.coordinator,
-            action: #selector(Coordinator.handleDoubleTap(_:))
-        )
-        doubleTap.numberOfTapsRequired = 2
-        scrollView.addGestureRecognizer(doubleTap)
-        return scrollView
-    }
-
-    func updateUIView(_ uiView: UIScrollView, context: Context) {}
-
-    func makeCoordinator() -> Coordinator { Coordinator() }
-
-    final class Coordinator: NSObject, UIScrollViewDelegate {
-        weak var imageView: UIImageView?
-
-        func viewForZooming(in scrollView: UIScrollView) -> UIView? { imageView }
-
-        @objc func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
-            guard let scrollView = recognizer.view as? UIScrollView else { return }
-            if scrollView.zoomScale > scrollView.minimumZoomScale + 0.01 {
-                scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
-            } else {
-                scrollView.setZoomScale(min(scrollView.maximumZoomScale, 2.5), animated: true)
-            }
-        }
-    }
-}
+#endif

--- a/mobile/PersonalDashboard/Views/Trips/TicketViewers.swift
+++ b/mobile/PersonalDashboard/Views/Trips/TicketViewers.swift
@@ -1,0 +1,238 @@
+import SwiftUI
+import PDFKit
+#if canImport(UIKit)
+import UIKit
+#else
+import AppKit
+#endif
+
+/// Ticket viewers that must work on BOTH iOS and macOS (issue #281), relocated
+/// here out of the iOS-only `TicketScanView.swift` (which is gated behind a
+/// camera/brightness hardware path). These are reachable on macOS from the
+/// non-camera flows: viewing an imported / emailed-in ticket's original file,
+/// and the item editor's ticket thumbnail.
+///
+/// iOS behaviour is unchanged: on iOS every `#if canImport(UIKit)` branch below
+/// compiles to the exact UIKit implementation these views had before the move
+/// (a `PDFView`/`UIScrollView` representable pair). macOS gets equivalent AppKit
+/// representables so the "View original" surface and the thumbnail both render.
+
+// MARK: - Original file viewer
+
+/// Full-screen viewer for the stored original ticket file, backed by
+/// `TicketStorage`. Mirrors the Finance receipt viewer but reads from the
+/// tickets directory. Native zoom on both platforms.
+struct TicketOriginalViewer: View {
+    let attachmentPath: String
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Tokens.paper.ignoresSafeArea()
+                content
+            }
+            .navigationTitle("Original ticket")
+            .inlineNavigationTitle()
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Tokens.ink)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let url = TicketStorage.shared.load(relativePath: attachmentPath) {
+            if TicketStorage.isPDF(attachmentPath) {
+                TicketPDFView(url: url)
+                    .ignoresSafeArea(edges: .bottom)
+            } else if let image = loadReceiptPlatformImage(url) {
+                TicketZoomableImageView(image: image)
+                    .ignoresSafeArea(edges: .bottom)
+            } else {
+                unavailable
+            }
+        } else {
+            unavailable
+        }
+    }
+
+    private var unavailable: some View {
+        Text("The ticket file is no longer available.")
+            .font(.edBody)
+            .foregroundStyle(Tokens.muted)
+    }
+}
+
+// MARK: - Attachment thumbnail
+
+/// Small inline preview of a stored ticket file: the image for a photo/scan,
+/// a doc icon for a PDF, a placeholder when the file is gone. Used by the item
+/// editor's ticket section.
+struct TicketAttachmentThumbnail: View {
+    let relativePath: String
+
+    var body: some View {
+        Group {
+            if let url = TicketStorage.shared.load(relativePath: relativePath) {
+                if TicketStorage.isPDF(relativePath) {
+                    icon("doc.text.fill", tint: Tokens.accent(for: .itineraries))
+                } else if let image = Image(receiptFileURL: url) {
+                    image
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    icon("photo", tint: Tokens.muted)
+                }
+            } else {
+                icon("photo", tint: Tokens.muted)
+            }
+        }
+        .background(Tokens.surface2)
+    }
+
+    private func icon(_ name: String, tint: Color) -> some View {
+        Image(systemName: name)
+            .font(.system(size: 22, weight: .regular))
+            .foregroundStyle(tint)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - PDF viewer
+
+#if canImport(UIKit)
+/// Thin `PDFView` wrapper with native pinch-zoom + page scrolling. Named
+/// distinctly from Finance's `PDFKitView` (which is file-private) to avoid a
+/// collision while keeping tickets self-contained.
+private struct TicketPDFView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> PDFView {
+        let view = PDFView()
+        view.autoScales = true
+        view.displayMode = .singlePageContinuous
+        view.displayDirection = .vertical
+        view.backgroundColor = .clear
+        view.document = PDFDocument(url: url)
+        return view
+    }
+
+    func updateUIView(_ uiView: PDFView, context: Context) {
+        if uiView.document?.documentURL != url {
+            uiView.document = PDFDocument(url: url)
+        }
+    }
+}
+#else
+/// macOS `PDFView` (AppKit-backed) wrapper. PDFKit is cross-platform; only the
+/// SwiftUI representable protocol differs.
+private struct TicketPDFView: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> PDFView {
+        let view = PDFView()
+        view.autoScales = true
+        view.displayMode = .singlePageContinuous
+        view.displayDirection = .vertical
+        view.backgroundColor = .clear
+        view.document = PDFDocument(url: url)
+        return view
+    }
+
+    func updateNSView(_ nsView: PDFView, context: Context) {
+        if nsView.document?.documentURL != url {
+            nsView.document = PDFDocument(url: url)
+        }
+    }
+}
+#endif
+
+// MARK: - Zoomable image
+
+#if canImport(UIKit)
+/// `UIScrollView` + `UIImageView` giving native pinch-to-zoom, pan, and
+/// double-tap-to-toggle. A compact re-implementation (Finance's equivalent is
+/// file-private).
+private struct TicketZoomableImageView: UIViewRepresentable {
+    let image: UIImage
+
+    func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.delegate = context.coordinator
+        scrollView.backgroundColor = .clear
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.minimumZoomScale = 1.0
+        scrollView.maximumZoomScale = 5.0
+
+        let imageView = UIImageView(image: image)
+        imageView.contentMode = .scaleAspectFit
+        imageView.frame = scrollView.bounds
+        imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        scrollView.addSubview(imageView)
+        context.coordinator.imageView = imageView
+
+        let doubleTap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleDoubleTap(_:))
+        )
+        doubleTap.numberOfTapsRequired = 2
+        scrollView.addGestureRecognizer(doubleTap)
+        return scrollView
+    }
+
+    func updateUIView(_ uiView: UIScrollView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator: NSObject, UIScrollViewDelegate {
+        weak var imageView: UIImageView?
+
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? { imageView }
+
+        @objc func handleDoubleTap(_ recognizer: UITapGestureRecognizer) {
+            guard let scrollView = recognizer.view as? UIScrollView else { return }
+            if scrollView.zoomScale > scrollView.minimumZoomScale + 0.01 {
+                scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
+            } else {
+                scrollView.setZoomScale(min(scrollView.maximumZoomScale, 2.5), animated: true)
+            }
+        }
+    }
+}
+#else
+/// macOS zoomable image: an `NSScrollView` hosting an `NSImageView` gives native
+/// magnification (pinch / scroll-to-zoom) and pan, the AppKit analogue of the
+/// iOS `UIScrollView` viewer.
+private struct TicketZoomableImageView: NSViewRepresentable {
+    let image: NSImage
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = false
+        scrollView.allowsMagnification = true
+        scrollView.minMagnification = 1.0
+        scrollView.maxMagnification = 5.0
+
+        let imageView = NSImageView()
+        imageView.image = image
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.imageAlignment = .alignCenter
+        scrollView.documentView = imageView
+        return scrollView
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        (nsView.documentView as? NSImageView)?.image = image
+        nsView.documentView?.frame = nsView.contentView.bounds
+    }
+}
+#endif

--- a/mobile/PersonalDashboard/Views/Trips/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Trips/TripDetailView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import SwiftData
+#if canImport(UIKit)
 import UIKit
+#endif
 
 /// Vertical timeline for a single `LocalTrip` (issue #108).
 ///
@@ -155,6 +157,10 @@ struct TripDetailView: View {
         }
         // Ticket upload pickers (#222). Camera is a full-screen cover (UIKit's
         // camera UI is itself full-screen); photo/PDF are system pickers.
+        // Camera capture is iOS-only: `.fullScreenCover` + UIImagePickerController
+        // don't exist on macOS, and the menu item that flips `showingTicketCamera`
+        // is likewise gated (issue #281). Photo/PDF import stay cross-platform.
+        #if os(iOS)
         .fullScreenCover(isPresented: $showingTicketCamera) {
             CameraPicker { data in
                 showingTicketCamera = false
@@ -162,6 +168,7 @@ struct TripDetailView: View {
             }
             .ignoresSafeArea()
         }
+        #endif
         .photoLibraryPicker(isPresented: $showingPhotoLibrary) { data in
             switch photoPickPurpose {
             case .ticket:  handleTicketData(data, isPDF: false)
@@ -176,31 +183,32 @@ struct TripDetailView: View {
             }
         }
         // Full-screen scan surface for a ticket card tap (or right after a
-        // successful upload).
+        // successful upload). iOS-only (present-to-scan hardware idiom); on
+        // macOS `scanTarget` is never set for scanning and the cover is absent
+        // (issue #281).
+        #if os(iOS)
         .fullScreenCover(item: $scanTarget) { target in
             if let item = items.first(where: { $0.clientUUID == target.id }) {
                 TicketScanView(item: item)
             }
         }
-        // Full-screen detail surface for a booked stay: the tinted stay card
-        // plus its actions (scan / view original / edit). Presented as a
-        // full-screen cover to match TicketScanView; the sheet's own "Done"
-        // button closes it. Shown from either the check-in or the check-out
-        // row — both resolve to the same item.
+        #endif
+        // Detail surface for a booked stay: the tinted stay card plus its
+        // actions (scan / view original / edit). iOS presents it full-screen to
+        // match TicketScanView; macOS has no `.fullScreenCover`, so it presents
+        // the same content as a `.sheet` instead — the view is presentation-only
+        // and its "Done" button closes either form (issue #281). Shown from
+        // either the check-in or the check-out row — both resolve to the same
+        // item.
+        #if os(iOS)
         .fullScreenCover(item: $stayDetailTarget) { target in
-            if let item = items.first(where: { $0.clientUUID == target.id }) {
-                StayBookingDetailSheet(item: item) {
-                    // Route Edit to the existing editor. Dismiss this surface
-                    // first, then present the editor on the next runloop so the
-                    // two presentations don't fight.
-                    let uuid = item.clientUUID
-                    stayDetailTarget = nil
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                        editingItem = .existing(uuid)
-                    }
-                }
-            }
+            stayBookingDetail(for: target)
         }
+        #else
+        .sheet(item: $stayDetailTarget) { target in
+            stayBookingDetail(for: target)
+        }
+        #endif
         .alert(
             "Couldn't save the ticket",
             isPresented: Binding(
@@ -216,6 +224,7 @@ struct TripDetailView: View {
         // shared pickers above (#261); receipt results flow into the review
         // sheet (which already carries this trip's context), a statement PDF
         // batch-imports every line, linked to the trip.
+        #if os(iOS)
         .fullScreenCover(isPresented: $showingExpenseCamera) {
             CameraPicker { data in
                 showingExpenseCamera = false
@@ -223,6 +232,7 @@ struct TripDetailView: View {
             }
             .ignoresSafeArea()
         }
+        #endif
         .alert(
             "Import complete",
             isPresented: Binding(
@@ -449,7 +459,9 @@ struct TripDetailView: View {
             Divider()
             // Camera is hidden on hardware without one (simulator), where
             // UIImagePickerController would silently fall back to the
-            // library and make two menu items redundant.
+            // library and make two menu items redundant. iOS-only: neither
+            // UIImagePickerController nor the camera cover exist on macOS (#281).
+            #if os(iOS)
             if UIImagePickerController.isSourceTypeAvailable(.camera) {
                 Button {
                     showingTicketCamera = true
@@ -457,6 +469,7 @@ struct TripDetailView: View {
                     Label("Scan a ticket", systemImage: "camera")
                 }
             }
+            #endif
             Button {
                 photoPickPurpose = .ticket
                 showingPhotoLibrary = true
@@ -483,6 +496,8 @@ struct TripDetailView: View {
         Menu {
             // Camera is hidden on hardware without one (simulator), where
             // UIImagePickerController would silently fall back to the library.
+            // iOS-only (no UIImagePickerController / camera cover on macOS — #281).
+            #if os(iOS)
             if UIImagePickerController.isSourceTypeAvailable(.camera) {
                 Button {
                     showingExpenseCamera = true
@@ -490,6 +505,7 @@ struct TripDetailView: View {
                     Label("Scan receipt", systemImage: "camera")
                 }
             }
+            #endif
             Button {
                 photoPickPurpose = .expense
                 showingPhotoLibrary = true
@@ -520,6 +536,25 @@ struct TripDetailView: View {
         }
         .disabled(isProcessingExpenseUpload)
         .accessibilityLabel("Add trip expense")
+    }
+
+    /// Shared builder for the booked-stay detail surface, presented as a
+    /// full-screen cover on iOS and a sheet on macOS (issue #281). Kept in one
+    /// place so both presentations carry identical content + Edit routing.
+    @ViewBuilder
+    private func stayBookingDetail(for target: StayDetailTarget) -> some View {
+        if let item = items.first(where: { $0.clientUUID == target.id }) {
+            StayBookingDetailSheet(item: item) {
+                // Route Edit to the existing editor. Dismiss this surface
+                // first, then present the editor on the next runloop so the
+                // two presentations don't fight.
+                let uuid = item.clientUUID
+                stayDetailTarget = nil
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                    editingItem = .existing(uuid)
+                }
+            }
+        }
     }
 
     /// The shared circular "+" glyph both FABs wear.
@@ -1342,7 +1377,7 @@ struct ItineraryItemEditorSheet: View {
                 }
             }
             .navigationTitle(isEditing ? "Edit item" : "New item")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
@@ -1734,9 +1769,9 @@ struct ItineraryItemEditorSheet: View {
                 TextField("Paste a Google Maps link", text: $googleMapsLink)
                     .font(.edBody)
                     .foregroundStyle(Tokens.ink)
-                    .textInputAutocapitalization(.never)
+                    .noAutocapitalization()
                     .autocorrectionDisabled(true)
-                    .keyboardType(.URL)
+                    .urlKeyboard()
                     .submitLabel(.done)
                     .padding(Space.md)
                     .background(Tokens.surface, in: RoundedRectangle(cornerRadius: Radius.md))

--- a/mobile/PersonalDashboard/Views/Trips/TripExpensesView.swift
+++ b/mobile/PersonalDashboard/Views/Trips/TripExpensesView.swift
@@ -626,7 +626,7 @@ private struct TripExpenseFilterSheet: View {
             }
             .background(Tokens.paper)
             .navigationTitle("Filter")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }

--- a/mobile/PersonalDashboard/Views/Trips/TripsView.swift
+++ b/mobile/PersonalDashboard/Views/Trips/TripsView.swift
@@ -407,7 +407,7 @@ private struct TripEditorSheet: View {
                 }
             }
             .navigationTitle(isEditing ? "Edit trip" : "New trip")
-            .navigationBarTitleDisplayMode(.inline)
+            .inlineNavigationTitle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -214,6 +214,26 @@ targets:
       - path: PersonalDashboard/AI/AnthropicClient+ExtractExpense.swift
       - path: PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
       - path: PersonalDashboard/AI/PDFChunker.swift
+      # Trips / itineraries surface (issue #281 — final feature). The
+      # present-to-scan surface (TicketScanView.swift: UIScreen.brightness +
+      # idle timer + camera) is iOS-only and stays OUT of this target; its call
+      # sites are `#if os(iOS)`-guarded and the stay-detail cover falls back to a
+      # `.sheet` on macOS. The reachable viewers (TicketOriginalViewer /
+      # TicketAttachmentThumbnail) were relocated to the cross-platform
+      # TicketViewers.swift. TicketStorage / BarcodeService / TicketExtraction
+      # are shimmed cross-platform (UIKit `#if`, ImageIO/CoreGraphics on macOS).
+      # BCBPParser + AddressGeocoder are already portable Foundation/CoreLocation.
+      - path: PersonalDashboard/Services/BCBPParser.swift
+      - path: PersonalDashboard/Services/AddressGeocoder.swift
+      - path: PersonalDashboard/Services/TicketStorage.swift
+      - path: PersonalDashboard/Services/BarcodeService.swift
+      - path: PersonalDashboard/AI/TicketExtraction.swift
+      - path: PersonalDashboard/Views/Trips/TripsView.swift
+      - path: PersonalDashboard/Views/Trips/TripDetailView.swift
+      - path: PersonalDashboard/Views/Trips/TripExpensesView.swift
+      - path: PersonalDashboard/Views/Trips/TripCalendarPopover.swift
+      - path: PersonalDashboard/Views/Trips/TicketCardView.swift
+      - path: PersonalDashboard/Views/Trips/TicketViewers.swift
       - path: PersonalDashboard/Resources/Fonts
         type: folder
         buildPhase: resources

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -3,6 +3,7 @@ options:
   bundleIdPrefix: com.akshaysharma
   deploymentTarget:
     iOS: "17.0"
+    macOS: "14.0"
   developmentLanguage: en
   createIntermediateGroups: true
 
@@ -15,6 +16,8 @@ targets:
         excludes:
           - "Resources/Preview Content/**"
           - "Resources/Fonts/**"
+          - "App/DexterMacApp.swift"   # macOS @main; belongs only to DexterMac target
+          - "InfoMac.plist"            # generated Info.plist for the macOS target
       - path: PersonalDashboard/Resources/Preview Content
         type: folder
       - path: PersonalDashboard/Resources/Fonts
@@ -108,6 +111,60 @@ targets:
         MARKETING_VERSION: "0.1.0"
         CURRENT_PROJECT_VERSION: "1"
 
+  # Native macOS app (issue #281). Shares the portable model/design/service
+  # layer with the iOS target via an explicit curated source list — only files
+  # that compile on macOS (UIKit shimmed behind `#if canImport(UIKit)`) are
+  # included. The first feature is Tasks; the list grows as surfaces are ported.
+  DexterMac:
+    type: application
+    platform: macOS
+    sources:
+      - path: PersonalDashboard/Models
+      - path: PersonalDashboard/Cache/SwiftDataStore.swift
+      - path: PersonalDashboard/Cache/StoreChange.swift
+      - path: PersonalDashboard/Design
+        excludes:
+          - "ListAppearance.swift"   # UIImage(systemName:), Lists-only, not needed by Tasks
+      - path: PersonalDashboard/App/AppRouter.swift
+      - path: PersonalDashboard/App/DexterMacApp.swift
+      - path: PersonalDashboard/ViewModels/TodosViewModel.swift
+      - path: PersonalDashboard/Services/TodoService.swift
+      - path: PersonalDashboard/Services/MapsLinkResolver.swift
+      - path: PersonalDashboard/Services/APIError.swift
+      - path: PersonalDashboard/Views/Tasks
+      - path: PersonalDashboard/Views/Components/GhostAddRow.swift
+      - path: PersonalDashboard/Views/Shell/TopBar.swift
+      - path: PersonalDashboard/Views/Shell/BottomTabBarMetrics.swift
+      - path: PersonalDashboard/Resources/Fonts
+        type: folder
+        buildPhase: resources
+      - path: PersonalDashboard/Resources/Assets.xcassets
+        buildPhase: resources
+    info:
+      path: PersonalDashboard/InfoMac.plist
+      properties:
+        CFBundleDisplayName: Dexter
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        LSMinimumSystemVersion: "14.0"
+        ITSAppUsesNonExemptEncryption: false
+        # Custom fonts ship as a Fonts/ folder reference; register them for
+        # AppKit/SwiftUI. `.custom()` falls back to system font if this fails.
+        ATSApplicationFontsPath: Fonts
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.akshaysharma.personaldashboard.mac
+        DEVELOPMENT_TEAM: "PJFPUSSNUW"
+        CODE_SIGN_STYLE: Automatic
+        SWIFT_VERSION: "5.0"
+        ENABLE_PREVIEWS: YES
+        MARKETING_VERSION: "0.1.0"
+        CURRENT_PROJECT_VERSION: "1"
+        # Dev-only build run from Xcode. Sandbox off keeps file access simple
+        # for the later iCloud-backup-restore milestone; revisit before any
+        # signed distribution.
+        ENABLE_APP_SANDBOX: NO
+
   PersonalDashboardUITests:
     type: bundle.ui-testing
     platform: iOS
@@ -158,3 +215,9 @@ schemes:
       targets:
         - PersonalDashboardTests
         - PersonalDashboardUITests
+  DexterMac:
+    build:
+      targets:
+        DexterMac: all
+    run:
+      config: Debug

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -172,6 +172,26 @@ targets:
       - path: PersonalDashboard/Services/EventService.swift
       - path: PersonalDashboard/Services/RecurringExpenseService.swift
       - path: PersonalDashboard/Services/RecurringExpenseNotifications.swift
+      # Settings (issue #281). The email-inbox surface (EmailInboxView) and its
+      # BackgroundTasks/IMAP ingest stack (EmailIngestService, IMAPClient,
+      # EmailIngestCoordinator) stay OUT of this target — iOS-only. The email
+      # LOG model + outcome enum live in Models/ (already in target) so the
+      # parsed-files history compiles; it just shows zero email rows on macOS.
+      - path: PersonalDashboard/App/ColorSchemePref.swift
+      - path: PersonalDashboard/Views/Settings/SettingsView.swift
+      - path: PersonalDashboard/Views/Settings/ResetDataView.swift
+      - path: PersonalDashboard/Views/Settings/BackupSettingsView.swift
+      - path: PersonalDashboard/Views/Settings/ParsedFilesView.swift
+      - path: PersonalDashboard/Views/Settings/DataExportImportView.swift
+      - path: PersonalDashboard/Services/BackupService.swift
+      - path: PersonalDashboard/Services/BackupSettings.swift
+      - path: PersonalDashboard/Services/DataExportService.swift
+      - path: PersonalDashboard/Services/DataImportService.swift
+      - path: PersonalDashboard/Services/ReceiptStorage.swift
+      - path: PersonalDashboard/Services/MiniZip.swift
+      - path: PersonalDashboard/Services/DataArchive.swift
+      - path: PersonalDashboard/Views/Finance/ExpenseRow.swift
+      - path: PersonalDashboard/Views/Finance/PersonEventBadge.swift
       - path: PersonalDashboard/Resources/Fonts
         type: folder
         buildPhase: resources

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -137,11 +137,14 @@ targets:
       - path: PersonalDashboard/Views/Tasks
       - path: PersonalDashboard/Views/Lists/ListsView.swift
       - path: PersonalDashboard/Views/Today/TodayView.swift
+      - path: PersonalDashboard/Views/Notes/NotesView.swift
+      - path: PersonalDashboard/Views/Components/MarkdownEditor.swift
       - path: PersonalDashboard/Views/Activity/ActivityView.swift
       - path: PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
       - path: PersonalDashboard/Views/Settings/PersonalVocabularyView.swift
       - path: PersonalDashboard/Views/Components/GhostAddRow.swift
       - path: PersonalDashboard/Views/Components/DeleteRowButton.swift
+      - path: PersonalDashboard/Views/Components/SectionEyebrow.swift
       - path: PersonalDashboard/Views/Components/MarkdownView.swift
       - path: PersonalDashboard/Views/Shell/TopBar.swift
       - path: PersonalDashboard/Views/Shell/BottomTabBarMetrics.swift

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -192,6 +192,28 @@ targets:
       - path: PersonalDashboard/Services/DataArchive.swift
       - path: PersonalDashboard/Views/Finance/ExpenseRow.swift
       - path: PersonalDashboard/Views/Finance/PersonEventBadge.swift
+      # Finance surface (issue #281). The camera capture path
+      # (CameraPicker.swift, UIImagePickerController) is iOS-only and stays OUT
+      # of this target; FinanceView gates its menu item + fullScreenCover with
+      # `#if os(iOS)`. Photo-library (PhotosUI), PDF + statement import
+      # (.fileImporter), manual entry, and recurring expenses all work on
+      # macOS. Receipt viewers in AddExpenseSheet are AppKit variants behind
+      # `#if os(iOS)/#else`. BarcodeService / APIClient are NOT pulled by the
+      # Finance chain (Trips-only) so they stay out.
+      - path: PersonalDashboard/Views/Finance/FinanceView.swift
+      - path: PersonalDashboard/Views/Finance/AddExpenseSheet.swift
+      - path: PersonalDashboard/Views/Finance/FinanceFilterBar.swift
+      - path: PersonalDashboard/Views/Finance/FinanceProcessingRow.swift
+      - path: PersonalDashboard/Views/Finance/PrefilledExpense.swift
+      - path: PersonalDashboard/Views/Finance/PhotoLibraryPicker.swift
+      - path: PersonalDashboard/Views/Finance/PDFPicker.swift
+      - path: PersonalDashboard/Views/Finance/RecurringExpensesView.swift
+      - path: PersonalDashboard/Views/Finance/RecurringExpenseEditorSheet.swift
+      - path: PersonalDashboard/AI/StatementImporter.swift
+      - path: PersonalDashboard/AI/ExpenseDedupe.swift
+      - path: PersonalDashboard/AI/AnthropicClient+ExtractExpense.swift
+      - path: PersonalDashboard/AI/AnthropicClient+ExtractStatement.swift
+      - path: PersonalDashboard/AI/PDFChunker.swift
       - path: PersonalDashboard/Resources/Fonts
         type: folder
         buildPhase: resources

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -133,9 +133,12 @@ targets:
       - path: PersonalDashboard/ViewModels/ListsViewModel.swift
       - path: PersonalDashboard/Services/NoteService.swift
       - path: PersonalDashboard/Services/ChecklistService.swift
+      - path: PersonalDashboard/Services/FinanceSettings.swift
       - path: PersonalDashboard/Views/Tasks
       - path: PersonalDashboard/Views/Lists/ListsView.swift
       - path: PersonalDashboard/Views/Today/TodayView.swift
+      - path: PersonalDashboard/Views/Activity/ActivityView.swift
+      - path: PersonalDashboard/Views/Finance/FinanceDashboardBand.swift
       - path: PersonalDashboard/Views/Settings/PersonalVocabularyView.swift
       - path: PersonalDashboard/Views/Components/GhostAddRow.swift
       - path: PersonalDashboard/Views/Components/DeleteRowButton.swift

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -123,16 +123,23 @@ targets:
       - path: PersonalDashboard/Cache/SwiftDataStore.swift
       - path: PersonalDashboard/Cache/StoreChange.swift
       - path: PersonalDashboard/Design
-        excludes:
-          - "ListAppearance.swift"   # UIImage(systemName:), Lists-only, not needed by Tasks
       - path: PersonalDashboard/App/AppRouter.swift
       - path: PersonalDashboard/App/DexterMacApp.swift
       - path: PersonalDashboard/ViewModels/TodosViewModel.swift
       - path: PersonalDashboard/Services/TodoService.swift
       - path: PersonalDashboard/Services/MapsLinkResolver.swift
       - path: PersonalDashboard/Services/APIError.swift
+      - path: PersonalDashboard/ViewModels/NotesViewModel.swift
+      - path: PersonalDashboard/ViewModels/ListsViewModel.swift
+      - path: PersonalDashboard/Services/NoteService.swift
+      - path: PersonalDashboard/Services/ChecklistService.swift
       - path: PersonalDashboard/Views/Tasks
+      - path: PersonalDashboard/Views/Lists/ListsView.swift
+      - path: PersonalDashboard/Views/Today/TodayView.swift
+      - path: PersonalDashboard/Views/Settings/PersonalVocabularyView.swift
       - path: PersonalDashboard/Views/Components/GhostAddRow.swift
+      - path: PersonalDashboard/Views/Components/DeleteRowButton.swift
+      - path: PersonalDashboard/Views/Components/MarkdownView.swift
       - path: PersonalDashboard/Views/Shell/TopBar.swift
       - path: PersonalDashboard/Views/Shell/BottomTabBarMetrics.swift
       - path: PersonalDashboard/Resources/Fonts

--- a/mobile/project.yml
+++ b/mobile/project.yml
@@ -148,6 +148,30 @@ targets:
       - path: PersonalDashboard/Views/Components/MarkdownView.swift
       - path: PersonalDashboard/Views/Shell/TopBar.swift
       - path: PersonalDashboard/Views/Shell/BottomTabBarMetrics.swift
+      # Chat (issue #281). Text chat only — the voice capture path
+      # (VoiceCaptureViewModel / SpeechTranscriber / overlay / InkOrb /
+      # WaveformBars) is AVFoundation/Speech-coupled and gated off with
+      # `#if os(iOS)` inside ChatView, so those files stay out of this target.
+      - path: PersonalDashboard/App/AppConfig.swift
+      - path: PersonalDashboard/Views/Chat/ChatView.swift
+      - path: PersonalDashboard/Views/Chat/ChatInputBar.swift
+      - path: PersonalDashboard/Views/Chat/ChatComponents.swift
+      - path: PersonalDashboard/Views/Chat/ChatResultCard.swift
+      - path: PersonalDashboard/ViewModels/ChatViewModel.swift
+      - path: PersonalDashboard/AI/ChatStream.swift
+      - path: PersonalDashboard/AI/AnthropicClient.swift
+      - path: PersonalDashboard/AI/AssistantContextBuilder.swift
+      - path: PersonalDashboard/AI/ChatDraft.swift
+      - path: PersonalDashboard/AI/ChatActionResult.swift
+      - path: PersonalDashboard/AI/ToolDefinitions.swift
+      - path: PersonalDashboard/AI/ExecuteDraftAction.swift
+      - path: PersonalDashboard/Services/AIStreamingService.swift
+      - path: PersonalDashboard/Services/FXService.swift
+      - path: PersonalDashboard/Services/ExpenseService.swift
+      - path: PersonalDashboard/Services/PersonService.swift
+      - path: PersonalDashboard/Services/EventService.swift
+      - path: PersonalDashboard/Services/RecurringExpenseService.swift
+      - path: PersonalDashboard/Services/RecurringExpenseNotifications.swift
       - path: PersonalDashboard/Resources/Fonts
         type: folder
         buildPhase: resources
@@ -161,6 +185,11 @@ targets:
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         LSMinimumSystemVersion: "14.0"
         ITSAppUsesNonExemptEncryption: false
+        # Anthropic Messages API key for on-device Chat (issue #281). Mirrors
+        # the iOS target: env var wins for `xcodebuild ANTHROPIC_API_KEY=…`,
+        # else this $(ANTHROPIC_API_KEY) build setting. Empty in a plain Xcode
+        # build, in which case Chat degrades gracefully ("not configured").
+        ANTHROPIC_API_KEY: $(ANTHROPIC_API_KEY)
         # Custom fonts ship as a Fonts/ folder reference; register them for
         # AppKit/SwiftUI. `.custom()` falls back to system font if this fails.
         ATSApplicationFontsPath: Fonts


### PR DESCRIPTION
## Summary

Builds a **native macOS SwiftUI app** (`DexterMac` target, path 2 — not Mac Catalyst) and ports **all 10 feature sections** to it: Tasks, Today, Lists, Notes, Vocabulary, Activity, Chat, Settings, Finance, Trips. (Help center remains a static placeholder.)

- Shared model / AI / service / design layers are reused as-is; the iOS app is unchanged and keeps building clean after every feature.
- UIKit-coupled shared code is either shimmed behind `#if canImport(UIKit)` or given a real AppKit/ImageIO implementation (receipt/ticket image pipeline, barcode rendering, PDF/image viewers).
- Native `NavigationSplitView` sidebar shell replaces the iOS chat-rooted ZStack + tab bar + drawer.
- The Mac runs its own local SwiftData store (no CloudKit on free signing). The backup/export/import layer now compiles on macOS, setting up the iCloud-restore bridge as the next milestone.

## Hardware gated off on macOS (kept on iOS)
Voice capture, camera receipt scan, camera ticket scan (+ screen-brightness/idle-timer). All non-hardware paths kept: typing, photo-library, file/PDF/statement import.

## Test plan
- [x] `xcodegen generate` + macOS (`DexterMac`) build: BUILD SUCCEEDED after every feature.
- [x] iOS (`PersonalDashboard`) build: BUILD SUCCEEDED throughout (no regression).
- [x] Each section launched + rendered natively; QA screenshots on #281.
- [ ] Device pass (macOS): interactive CRUD on tap/gesture controls; barcode/PDF scannability for imported tickets. (synthetic events can't drive these; build-verified only.)

QA evidence (screenshots per section): see the comments on #281.

Part of #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)