### PR TITLE
fix(macos): native chrome polish — toolbar title, anchored FAB, Chat sidebar

### DIFF
--- a/mobile/PersonalDashboard/Design/MacChrome.swift
+++ b/mobile/PersonalDashboard/Design/MacChrome.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// Native macOS window chrome, shared across every ported section view
+/// (issue #283).
+///
+/// The iOS build renders an in-view `TopBar` (hamburger + title + AS pip)
+/// because the phone shell is a chat-rooted `ZStack` router with a floating
+/// tab bar and an edge-swipe drawer — the title and profile affordance have
+/// nowhere else to live. On macOS the shell is a `NavigationSplitView`: the
+/// sidebar is always present, so the hamburger is meaningless and the title +
+/// profile belong in the native window toolbar, not stacked inside the content.
+///
+/// These helpers keep the port DRY. Each section view drops its `TopBar`
+/// behind `#if os(iOS)` and applies `.macSectionChrome(_:)`, which is a no-op
+/// on iOS and installs the native title + toolbar on macOS. iOS rendering is
+/// unchanged.
+
+#if os(macOS)
+/// The "AS" profile coin, lifted verbatim from `TopBar` so the macOS toolbar
+/// carries the same affordance the iOS top bar does. A paper coin, not a
+/// colored badge. Sized a touch smaller than the iOS pip to sit cleanly in
+/// the ~28pt window toolbar.
+struct MacProfilePip: View {
+    var body: some View {
+        Text("AS")
+            .font(.edFootnote)
+            .foregroundStyle(Tokens.ink)
+            .frame(width: 24, height: 24)
+            .background(Tokens.paper2, in: Circle())
+            .overlay(Circle().stroke(Tokens.border, lineWidth: 0.5))
+            .accessibilityLabel("Akshay")
+    }
+}
+#endif
+
+extension View {
+    /// Native macOS section chrome: sets the window title and pins the AS
+    /// profile pip to the toolbar's primary-action slot. No-op on iOS, where
+    /// the in-view `TopBar` owns the title + pip (issue #283).
+    @ViewBuilder
+    func macSectionChrome(_ title: String) -> some View {
+        macSectionChrome(title) { EmptyView() }
+    }
+
+    /// Variant that also injects a secondary trailing toolbar control (e.g.
+    /// the Notes folder-add button) ahead of the profile pip. On iOS the
+    /// `trailing` content is discarded — its iOS home is the in-view chrome —
+    /// so iOS rendering is unchanged (issue #283).
+    @ViewBuilder
+    func macSectionChrome<Trailing: View>(
+        _ title: String,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
+        #if os(macOS)
+        self
+            .navigationTitle(title)
+            .toolbar {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    trailing()
+                    MacProfilePip()
+                }
+            }
+        #else
+        self
+        #endif
+    }
+
+    /// Background fill for a section canvas. On iOS ignores every safe-area
+    /// edge (full-bleed under the status bar / home indicator). On macOS keeps
+    /// the top title-bar inset so the split view reserves the title-bar region
+    /// and the sidebar keeps its top inset — ignoring the top there collapses
+    /// the inset and slides content under the traffic lights (issue #283). The
+    /// bottom edge is still released so the paper reaches the window edge.
+    @ViewBuilder
+    func canvasIgnoresSafeArea() -> some View {
+        #if os(macOS)
+        self.ignoresSafeArea(.container, edges: .bottom)
+        #else
+        self.ignoresSafeArea()
+        #endif
+    }
+}

--- a/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
+++ b/mobile/PersonalDashboard/Views/Activity/ActivityView.swift
@@ -86,15 +86,19 @@ struct ActivityView: View {
 
     var body: some View {
         ZStack {
-            Tokens.paper.ignoresSafeArea()
+            Tokens.paper.canvasIgnoresSafeArea()
 
             VStack(spacing: 0) {
+                // iOS in-view top bar; macOS uses the native window toolbar
+                // via `.macSectionChrome` below (issue #283).
+                #if os(iOS)
                 TopBar(
                     title: "Activity",
                     onMenu: {
                         withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true }
                     }
                 )
+                #endif
 
                 Text("Everything you have captured, newest first.")
                     .font(.edSubheadline)
@@ -167,6 +171,7 @@ struct ActivityView: View {
             }
         }
         .activeSection(.activity)
+        .macSectionChrome("Activity")
     }
 
     // MARK: - Combine + filter + paginate

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -67,6 +67,81 @@ struct ChatView: View {
     ]
 
     var body: some View {
+        #if os(macOS)
+        macBody
+        #else
+        iosBody
+        #endif
+    }
+
+    #if os(macOS)
+    /// Native macOS layout, kept entirely separate from `iosBody` so the iOS
+    /// `ZStack(alignment: .bottom)` + keyboard/voice code is untouched (#283).
+    ///
+    /// Root cause of the sidebar-scroll bug: Chat's detail has focusable
+    /// controls (the example-chip buttons in the empty state, the input
+    /// TextField) but — unlike the List-based sections — had no scroll view of
+    /// its own. macOS's scroll-to-reveal-first-responder then bubbled to the
+    /// nearest enclosing scroll view, which was the NavigationSplitView SIDEBAR
+    /// `List`, sliding it up under the traffic lights and lighting the toolbar's
+    /// scrolled-material band. Giving the detail its own `ScrollView` (below,
+    /// for the empty state; `conversation` already has one) absorbs the reveal
+    /// locally, so the sidebar stays put. The input docks via `.safeAreaInset`.
+    private var macBody: some View {
+        ZStack {
+            Tokens.paper
+                .canvasIgnoresSafeArea()
+
+            if viewModel.turns.isEmpty {
+                // Wrap the empty state in the detail's OWN ScrollView. macOS
+                // scroll-to-reveal-first-responder (triggered by the focusable
+                // example-chip buttons / the input field) bubbles to the
+                // nearest enclosing scroll view; without one in the detail it
+                // reached the sidebar List and slid it up under the traffic
+                // lights (issue #283). A local ScrollView absorbs the reveal.
+                // GeometryReader lets the state fill the viewport so it stays
+                // vertically centered like on iOS.
+                GeometryReader { proxy in
+                    ScrollView {
+                        emptyState
+                            .frame(minHeight: proxy.size.height)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+            } else {
+                conversation
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            ChatInputBar(
+                text: $viewModel.draftInput,
+                isSending: viewModel.isSending,
+                onSend: send,
+                onMic: micHandler,
+                isMicActive: micActive,
+                focused: $inputFocused
+            )
+            .padding(.horizontal, Space.lg)
+            .padding(.top, Space.sm)
+            .padding(.bottom, Space.lg)
+        }
+        .background(Tokens.paper)
+        .macSectionChrome("Chat")
+        .alert("Something went wrong",
+               isPresented: Binding(
+                   get: { viewModel.errorMessage != nil },
+                   set: { if !$0 { viewModel.errorMessage = nil } }
+               )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+    }
+    #endif
+
+    #if os(iOS)
+    private var iosBody: some View {
         ZStack(alignment: .bottom) {
             Tokens.paper
                 // Full-bleed on iOS; keeps the top title-bar inset on macOS so
@@ -288,6 +363,7 @@ struct ChatView: View {
             Text(viewModel.errorMessage ?? "")
         }
     }
+    #endif
 
     // MARK: - Empty state
 

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -181,6 +181,14 @@ struct ChatView: View {
         .background(Tokens.paper)
         .macSectionChrome("Chat")
         .onAppear {
+            // Auto-focusing the input on landing is a phone idiom ("pop the
+            // keyboard so the surface is ready to type", issue #48). On macOS
+            // it steals first-responder the moment Chat opens, which (a) makes
+            // the first click on another sidebar row merely resign focus
+            // instead of switching sections — leaving Chat highlighted — and
+            // (b) drives a focus-into-a-bottom-field relayout that rides the
+            // sidebar up under the traffic lights. So it stays iOS-only (#283).
+            #if os(iOS)
             // Land in keyboard-up state on first appearance. The small
             // delay gives SwiftUI time to lay the view tree out before
             // we ask the TextField to take first responder.
@@ -189,8 +197,10 @@ struct ChatView: View {
                     inputFocused = true
                 }
             }
+            #endif
         }
         .onChange(of: router.currentSection) { _, newSection in
+            #if os(iOS)
             // Tapping the chat circle from any other surface should drop
             // the user straight into typing (issue #48).
             if newSection == .chat {
@@ -198,6 +208,7 @@ struct ChatView: View {
                     inputFocused = true
                 }
             }
+            #endif
         }
         #if os(iOS)
         .onChange(of: transcriber.transcript) { _, newTranscript in

--- a/mobile/PersonalDashboard/Views/Chat/ChatView.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatView.swift
@@ -69,7 +69,10 @@ struct ChatView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             Tokens.paper
-                .ignoresSafeArea()
+                // Full-bleed on iOS; keeps the top title-bar inset on macOS so
+                // the split view reserves the title-bar region and the sidebar
+                // keeps its top inset (issue #283).
+                .canvasIgnoresSafeArea()
                 // Tap on empty paper background dismisses the keyboard so
                 // the floating tab bar comes back into view (issue #48).
                 // `hideKeyboard()` is a no-op on macOS (no software keyboard).
@@ -85,12 +88,16 @@ struct ChatView: View {
                 // keyboard. The ChatInputBar is intentionally outside this
                 // gesture so tapping the text field still focuses it.
                 VStack(spacing: 0) {
+                    // iOS renders the in-view top bar; macOS uses the native
+                    // window toolbar via `.macSectionChrome` below (issue #283).
+                    #if os(iOS)
                     TopBar(
                         title: viewModel.turns.isEmpty ? nil : "Chat",
                         onMenu: {
                             router.openDrawer()
                         }
                     )
+                    #endif
 
                     if viewModel.turns.isEmpty {
                         emptyState
@@ -155,7 +162,15 @@ struct ChatView: View {
                 // hides and the keyboard pushes the input up directly. The
                 // gap above the tab bar is intentionally small so the input
                 // sits visually close to the floating pill.
+                //
+                // macOS has no tab bar and no software keyboard, so the input
+                // bar sits a modest inset above the window's bottom edge
+                // instead of reserving the 74pt tab-bar strip (issue #283).
+                #if os(macOS)
+                .padding(.bottom, Space.lg)
+                #else
                 .padding(.bottom, keyboardVisible ? Space.md : BottomTabBarMetrics.height)
+                #endif
             }
             // Animate the listening banner and inline mic-error in/out so they
             // don't pop (their transitions are declared at each call site).
@@ -164,6 +179,7 @@ struct ChatView: View {
             #endif
         }
         .background(Tokens.paper)
+        .macSectionChrome("Chat")
         .onAppear {
             // Land in keyboard-up state on first appearance. The small
             // delay gives SwiftUI time to lay the view tree out before

--- a/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
+++ b/mobile/PersonalDashboard/Views/Finance/FinanceView.swift
@@ -82,21 +82,26 @@ struct FinanceView: View {
 
     var body: some View {
         ZStack {
-            Tokens.paper.ignoresSafeArea()
+            Tokens.paper.canvasIgnoresSafeArea()
 
             VStack(spacing: 0) {
+                // iOS in-view top bar; macOS uses the native window toolbar
+                // via `.macSectionChrome` below (issue #283).
+                #if os(iOS)
                 TopBar(
                     title: "Finance",
                     onMenu: {
                         withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true }
                     }
                 )
+                #endif
                 content
             }
 
             captureMenuButton
         }
         .activeSection(.finance)
+        .macSectionChrome("Finance")
         .task {
             // Warm the chosen display currency's FX factor so month/day/
             // category totals render in it on first paint (#220). SGD is a
@@ -224,7 +229,7 @@ struct FinanceView: View {
         }
         .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
         .padding(.trailing, 22)
-        .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+        .padding(.bottom, BottomTabBarMetrics.fabBottomInset)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
         .accessibilityLabel("Add expense")
     }

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -14,7 +14,7 @@ struct ListsView: View {
 
     var body: some View {
         ZStack {
-            Tokens.paper.ignoresSafeArea()
+            Tokens.paper.canvasIgnoresSafeArea()
 
             VStack(spacing: 0) {
                 if let id = selectedListId, let list = viewModel.lists.first(where: { $0.id == id }) {
@@ -39,10 +39,14 @@ struct ListsView: View {
                             ListPropertiesSheet(viewModel: viewModel, list: list)
                         }
                 } else {
+                    // iOS in-view top bar; macOS uses the native window
+                    // toolbar via `.macSectionChrome` below (issue #283).
+                    #if os(iOS)
                     TopBar(
                         title: "Lists",
                         onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                     )
+                    #endif
                     rootList
                 }
             }
@@ -55,11 +59,12 @@ struct ListsView: View {
                 }
                 .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
                 .padding(.trailing, 22)
-                .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+                .padding(.bottom, BottomTabBarMetrics.fabBottomInset)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             }
         }
         .activeSection(.lists)
+        .macSectionChrome("Lists")
         // Live-refresh when the voice-capture or chat path writes a list / item.
         .onReceive(NotificationCenter.default.publisher(for: .localStoreDidChange)) { _ in
             Task { await viewModel.load() }
@@ -464,7 +469,7 @@ private struct ListDetailContent: View {
                         }
                         .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
                         .padding(.trailing, 22)
-                        .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+                        .padding(.bottom, BottomTabBarMetrics.fabBottomInset)
                         .opacity(draftActive ? 0 : 1)
                         .animation(.easeOut(duration: 0.15), value: draftActive)
                     }

--- a/mobile/PersonalDashboard/Views/Notes/NotesView.swift
+++ b/mobile/PersonalDashboard/Views/Notes/NotesView.swift
@@ -15,7 +15,7 @@ struct NotesView: View {
 
     var body: some View {
         ZStack {
-            Tokens.paper.ignoresSafeArea()
+            Tokens.paper.canvasIgnoresSafeArea()
 
             VStack(spacing: 0) {
                 if let id = selectedNoteId, let note = viewModel.notes.first(where: { $0.id == id }) {
@@ -43,15 +43,20 @@ struct NotesView: View {
                     )
                     folderNotesList(folder)
                 } else {
+                    // iOS: in-view top bar, and the create-folder affordance
+                    // overlays the top-right of the list area so it doesn't
+                    // take layout space — Folders/Unfiled start at the same
+                    // vertical level as Lists/Tasks.
+                    //
+                    // macOS: no top bar; the folder-add is a native toolbar
+                    // button (see `.macSectionChrome` below) and the list sits
+                    // flush under the window title bar, so the overlay hack —
+                    // which mis-aligned the UNFILED header — is dropped (#283).
+                    #if os(iOS)
                     TopBar(
                         title: "Notes",
                         onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                     )
-                    // Create-folder affordance overlays the top-right of the
-                    // list area so it doesn't take layout space — the
-                    // Folders/Unfiled sections start at the same vertical
-                    // level as Lists/Tasks. The button sits between the top
-                    // bar (with the AS pip) and the first row of content.
                     rootList
                         .overlay(alignment: .topTrailing) {
                             Button {
@@ -66,6 +71,9 @@ struct NotesView: View {
                             .accessibilityLabel("New folder")
                             .padding(.trailing, Space.sm)
                         }
+                    #else
+                    rootList
+                    #endif
                 }
             }
 
@@ -77,11 +85,24 @@ struct NotesView: View {
                 }
                 .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
                 .padding(.trailing, 22)
-                .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+                .padding(.bottom, BottomTabBarMetrics.fabBottomInset)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             }
         }
         .activeSection(.notes)
+        .macSectionChrome("Notes") {
+            // Native folder-add lives in the toolbar on macOS. Only at the
+            // root list (no note / folder open), mirroring the iOS overlay's
+            // visibility (issue #283).
+            if selectedNoteId == nil && selectedFolder == nil {
+                Button {
+                    showingNewFolder = true
+                } label: {
+                    Image(systemName: "folder.badge.plus")
+                }
+                .accessibilityLabel("New folder")
+            }
+        }
         // Live-refresh when the voice-capture or chat path writes a note.
         .onReceive(NotificationCenter.default.publisher(for: .localStoreDidChange)) { _ in
             Task { await viewModel.load() }

--- a/mobile/PersonalDashboard/Views/Settings/PersonalVocabularyView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/PersonalVocabularyView.swift
@@ -31,13 +31,17 @@ struct PersonalVocabularyView: View {
 
     var body: some View {
         ZStack {
-            Tokens.paper.ignoresSafeArea()
+            Tokens.paper.canvasIgnoresSafeArea()
 
             VStack(spacing: 0) {
+                // iOS in-view top bar; macOS uses the native window toolbar
+                // via `.macSectionChrome` below (issue #283).
+                #if os(iOS)
                 TopBar(
                     title: "Vocabulary",
                     onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                 )
+                #endif
                 content
             }
 
@@ -49,11 +53,12 @@ struct PersonalVocabularyView: View {
             }
             .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
             .padding(.trailing, 22)
-            .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+            .padding(.bottom, BottomTabBarMetrics.fabBottomInset)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             .accessibilityLabel("Add term")
         }
         .activeSection(.vocabulary)
+        .macSectionChrome("Vocabulary")
         .sheet(item: $editing) { target in
             KeywordEditorSheet(target: target)
                 .presentationDetents([.medium, .large])

--- a/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
+++ b/mobile/PersonalDashboard/Views/Settings/SettingsView.swift
@@ -23,10 +23,11 @@ struct SettingsView: View {
 
     var body: some View {
         ZStack {
-            Tokens.paper.ignoresSafeArea()
+            Tokens.paper.canvasIgnoresSafeArea()
             rootContent
         }
         .activeSection(.settings)
+        .macSectionChrome("Settings")
         .sheet(isPresented: $showingResetData) {
             ResetDataView()
         }
@@ -50,10 +51,14 @@ struct SettingsView: View {
 
     private var rootContent: some View {
         VStack(spacing: 0) {
+            // iOS in-view top bar; macOS uses the native window toolbar
+            // via `.macSectionChrome` on the body (issue #283).
+            #if os(iOS)
             TopBar(
                 title: "Settings",
                 onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
             )
+            #endif
 
             ScrollView {
                 VStack(alignment: .leading, spacing: Space.xl) {

--- a/mobile/PersonalDashboard/Views/Shell/BottomTabBarMetrics.swift
+++ b/mobile/PersonalDashboard/Views/Shell/BottomTabBarMetrics.swift
@@ -16,4 +16,17 @@ import CoreGraphics
 enum BottomTabBarMetrics {
     /// Total height reserved above the bottom safe area (pill + bottom gap).
     static let height: CGFloat = 74
+
+    /// Bottom inset for a floating "+" FAB. On iOS the FAB clears the floating
+    /// tab bar (pill height + a small gap) and is allowed to overlap the
+    /// surface above. On macOS there is no tab bar, so the FAB anchors flush to
+    /// the true bottom corner with a modest inset (issue #283). Callers keep
+    /// their own trailing padding; only the bottom differs per platform.
+    static var fabBottomInset: CGFloat {
+        #if os(macOS)
+        Space.xl
+        #else
+        height + Space.sm
+        #endif
+    }
 }

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -17,15 +17,19 @@ struct TasksView: View {
 
     var body: some View {
         ZStack {
-            Tokens.paper.ignoresSafeArea()
+            Tokens.paper.canvasIgnoresSafeArea()
 
             VStack(spacing: 0) {
+                // iOS in-view top bar; macOS uses the native window toolbar
+                // via `.macSectionChrome` below (issue #283).
+                #if os(iOS)
                 TopBar(
                     title: "Tasks",
                     onMenu: {
                         withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true }
                     }
                 )
+                #endif
 
                 // Using `List` (not `ScrollView { LazyVStack }`) so each row
                 // can opt into native `.swipeActions`. The list is dressed
@@ -85,7 +89,7 @@ struct TasksView: View {
             }
             .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
             .padding(.trailing, 22)
-            .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+            .padding(.bottom, BottomTabBarMetrics.fabBottomInset)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             // Hide the FAB while an inline draft is active — the user is already
             // adding a task inline, so the FAB is redundant and visually distracting.
@@ -94,6 +98,7 @@ struct TasksView: View {
             .animation(.easeOut(duration: 0.15), value: draftBucket)
         }
         .activeSection(.tasks)
+        .macSectionChrome("Tasks")
         // Live-refresh when the voice-capture or chat path writes a task.
         .onReceive(NotificationCenter.default.publisher(for: .localStoreDidChange)) { _ in
             Task { await viewModel.load() }

--- a/mobile/PersonalDashboard/Views/Today/TodayView.swift
+++ b/mobile/PersonalDashboard/Views/Today/TodayView.swift
@@ -9,13 +9,17 @@ struct TodayView: View {
 
     var body: some View {
         ZStack {
-            Tokens.paper.ignoresSafeArea()
+            Tokens.paper.canvasIgnoresSafeArea()
 
             VStack(spacing: 0) {
+                // iOS in-view top bar; macOS uses the native window toolbar
+                // via `.macSectionChrome` below (issue #283).
+                #if os(iOS)
                 TopBar(
                     title: nil,
                     onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                 )
+                #endif
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: Space.xl) {
@@ -32,6 +36,7 @@ struct TodayView: View {
             }
         }
         .activeSection(.today)
+        .macSectionChrome("Today")
         .task { await loadAll() }
     }
 

--- a/mobile/PersonalDashboard/Views/Trips/TripDetailView.swift
+++ b/mobile/PersonalDashboard/Views/Trips/TripDetailView.swift
@@ -443,7 +443,7 @@ struct TripDetailView: View {
             }
         }
         .padding(.trailing, Space.lg)
-        .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+        .padding(.bottom, BottomTabBarMetrics.fabBottomInset)
         .allowsHitTesting(true)
     }
 

--- a/mobile/PersonalDashboard/Views/Trips/TripsView.swift
+++ b/mobile/PersonalDashboard/Views/Trips/TripsView.swift
@@ -28,7 +28,7 @@ struct TripsView: View {
 
     var body: some View {
         ZStack {
-            Tokens.paper.ignoresSafeArea()
+            Tokens.paper.canvasIgnoresSafeArea()
 
             VStack(spacing: 0) {
                 if let id = selectedTripUUID, let trip = trips.first(where: { $0.clientUUID == id }) {
@@ -41,10 +41,14 @@ struct TripsView: View {
                     )
                     TripDetailView(trip: trip)
                 } else {
+                    // iOS in-view top bar; macOS uses the native window toolbar
+                    // via `.macSectionChrome` below (issue #283).
+                    #if os(iOS)
                     TopBar(
                         title: "Trips",
                         onMenu: { withAnimation(.easeOut(duration: 0.2)) { router.drawerOpen = true } }
                     )
+                    #endif
                     rootContent
                 }
             }
@@ -57,12 +61,13 @@ struct TripsView: View {
                 }
                 .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
                 .padding(.trailing, 22)
-                .padding(.bottom, BottomTabBarMetrics.height + Space.sm)
+                .padding(.bottom, BottomTabBarMetrics.fabBottomInset)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                 .accessibilityLabel("New trip")
             }
         }
         .activeSection(.itineraries)
+        .macSectionChrome("Trips")
         .onAppear {
             consumeFocus()
             syncBackHandler()


### PR DESCRIPTION
## Summary
Reworks the native macOS (`DexterMac`) chrome from the ported iOS layout to native idioms (Reminders-inspired), and fixes the visual bugs that came with the wholesale port. iOS is untouched (everything gated behind `#if os(macOS)` / `#else`); both targets build clean.

- Section title + "AS" profile pip moved into the native window toolbar; in-view hamburger header removed on macOS.
- Cream "+" anchored to the true bottom-right (dropped the 74pt iOS tab-bar reserve).
- Notes folder-add moved to a native toolbar button; UNFILED header and rows now align to the content column.
- Chat: auto-focus-on-open gated to iOS (was stealing first-responder and leaving the sidebar row stuck highlighted).
- Chat: sidebar no longer scrolls under the traffic lights — the detail's focusable controls now sit in their own ScrollView (macOS scroll-to-reveal-first-responder was bubbling to the sidebar List), with the input docked via safeAreaInset.

## Test plan
- `xcodebuild` DexterMac (macOS) and PersonalDashboard (iOS): both **BUILD SUCCEEDED**.
- Screenshot QA across sections (Chat, Notes, Tasks) confirming native toolbar, inset sidebar, anchored FAB, aligned Notes. Evidence on the ticket.
- Pending: hands-on pass on interactive tap controls (complete/edit/delete, add sheets), which macOS SwiftUI won't let automation drive.

Closes #283