### PR TITLE
feat(macos): Reminders-style UI polish — rows, chat input, toolbar buttons, sidebar, headers

### DIFF
--- a/mobile/PersonalDashboard/App/DexterMacApp.swift
+++ b/mobile/PersonalDashboard/App/DexterMacApp.swift
@@ -39,7 +39,7 @@ private struct MacRootView: View {
     /// Sidebar order. Excludes the dead `dashboard` section (issue #30).
     private let sections: [AppSection] = [
         .chat, .today, .tasks, .notes, .lists,
-        .activity, .itineraries, .finance, .vocabulary,
+        .itineraries, .finance, .vocabulary, .activity,
         .settings, .helpCenter,
     ]
 

--- a/mobile/PersonalDashboard/Design/MacChrome.swift
+++ b/mobile/PersonalDashboard/Design/MacChrome.swift
@@ -55,11 +55,13 @@ extension View {
         #if os(macOS)
         self
             .navigationTitle(title)
+            // Two DISTINCT toolbar items, not one group: a group renders the
+            // secondary control and the AS coin inside a single bordered pill,
+            // so they read as merged (issue #285). Separate items get macOS's
+            // standard inter-item spacing and their own chrome.
             .toolbar {
-                ToolbarItemGroup(placement: .primaryAction) {
-                    trailing()
-                    MacProfilePip()
-                }
+                ToolbarItem(placement: .primaryAction) { trailing() }
+                ToolbarItem(placement: .primaryAction) { MacProfilePip() }
             }
             // Consistent transparent title-bar across every section (issue
             // #285). Some sections lit the toolbar's scrolled-material band (a
@@ -167,7 +169,11 @@ private struct MacRowHover: ViewModifier {
         content
             .background(
                 RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-                    .fill(hovering ? Tokens.paper2 : Color.clear)
+                    // A whisper-subtle tint, not the solid `paper2` surface —
+                    // `paper2` reads as a heavy dark box on a row (issue #285).
+                    // `ink` at low opacity gives Reminders' barely-there hover:
+                    // a faint light wash in dark mode, a faint grey in light.
+                    .fill(hovering ? Tokens.ink.opacity(0.06) : Color.clear)
                     .padding(.horizontal, Space.xs)
             )
             .onHover { hovering = $0 }

--- a/mobile/PersonalDashboard/Design/MacChrome.swift
+++ b/mobile/PersonalDashboard/Design/MacChrome.swift
@@ -16,18 +16,19 @@ import SwiftUI
 /// unchanged.
 
 #if os(macOS)
-/// The "AS" profile coin, lifted verbatim from `TopBar` so the macOS toolbar
-/// carries the same affordance the iOS top bar does. A paper coin, not a
-/// colored badge. Sized a touch smaller than the iOS pip to sit cleanly in
-/// the ~28pt window toolbar.
+/// The "AS" profile coin in the macOS window toolbar, echoing the iOS top-bar
+/// affordance. A single solid ink round with paper "AS" text — no surrounding
+/// oval or button chrome (issue #285). Sized to sit cleanly in the toolbar
+/// while reading as a proper account bubble (à la Reminders), not a faint
+/// badge.
 struct MacProfilePip: View {
     var body: some View {
         Text("AS")
-            .font(.edFootnote)
-            .foregroundStyle(Tokens.ink)
-            .frame(width: 24, height: 24)
-            .background(Tokens.paper2, in: Circle())
-            .overlay(Circle().stroke(Tokens.border, lineWidth: 0.5))
+            .font(.system(size: 12, weight: .semibold))
+            .tracking(0.3)
+            .foregroundStyle(Tokens.paper)
+            .frame(width: 30, height: 30)
+            .background(Tokens.ink, in: Circle())
             .accessibilityLabel("Akshay")
     }
 }
@@ -60,6 +61,13 @@ extension View {
                     MacProfilePip()
                 }
             }
+            // Consistent transparent title-bar across every section (issue
+            // #285). Some sections lit the toolbar's scrolled-material band (a
+            // grey stripe under the traffic lights) while others stayed clear,
+            // depending on whether their content scrolled under the title bar.
+            // Hiding the window-toolbar background everywhere makes the paper
+            // canvas read straight up to the window edge in all sections.
+            .toolbarBackground(.hidden, for: .windowToolbar)
         #else
         self
         #endif
@@ -79,4 +87,113 @@ extension View {
         self.ignoresSafeArea()
         #endif
     }
+
+    // MARK: - Reminders-like row + control polish (issue #285)
+
+    /// Disables the `List`'s built-in row selection on macOS so a click no
+    /// longer paints the hard full-bleed grey selection bar. Rows keep their
+    /// own tap gestures and buttons; only the system selection chrome goes
+    /// away. No-op on iOS, where List rows here are never selection-driven.
+    @ViewBuilder
+    func macTamedListSelection() -> some View {
+        #if os(macOS)
+        self.selectionDisabled(true)
+        #else
+        self
+        #endif
+    }
+
+    /// Subtle, inset, rounded hover background for a `List` row on macOS — the
+    /// soft Reminders-style highlight that replaces the system selection bar
+    /// (paired with `macTamedListSelection()`). Owns its own hover state.
+    /// No-op on iOS (touch has no hover; the iOS row render path is unchanged).
+    @ViewBuilder
+    func macRowHover() -> some View {
+        #if os(macOS)
+        modifier(MacRowHover())
+        #else
+        self
+        #endif
+    }
+
+    /// Quiet, rounded background for an in-view header icon button on macOS,
+    /// replacing the hard square default-bordered button chrome with a soft
+    /// inset surface that lifts on hover (issue #285). Pair with
+    /// `macPlainButtonStyle()`. No-op on iOS.
+    @ViewBuilder
+    func macHeaderIconChrome() -> some View {
+        #if os(macOS)
+        modifier(MacHeaderIconChrome())
+        #else
+        self
+        #endif
+    }
+
+    /// `.buttonStyle(.plain)` on macOS only — strips the default bordered
+    /// button chrome from in-view header controls. No-op on iOS so the phone
+    /// button rendering is untouched.
+    @ViewBuilder
+    func macPlainButtonStyle() -> some View {
+        #if os(macOS)
+        self.buttonStyle(.plain)
+        #else
+        self
+        #endif
+    }
+
+    /// `.textFieldStyle(.plain)` on macOS only, so a `TextField` inside a
+    /// custom rounded surface doesn't draw its own default bordered box
+    /// (the box-in-a-box on the chat input, issue #285). No-op on iOS, where
+    /// the field already renders borderless.
+    @ViewBuilder
+    func plainFieldStyleOnMac() -> some View {
+        #if os(macOS)
+        self.textFieldStyle(.plain)
+        #else
+        self
+        #endif
+    }
 }
+
+#if os(macOS)
+/// Inset rounded hover highlight for a macOS List row. Sits behind the row
+/// content (the row's own leading priority bar / glyphs stay on top) and is
+/// inset from the row edges so the highlight reads as a soft rounded pill, the
+/// way Reminders renders row hover — not a full-bleed bar.
+private struct MacRowHover: ViewModifier {
+    @State private var hovering = false
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                    .fill(hovering ? Tokens.paper2 : Color.clear)
+                    .padding(.horizontal, Space.xs)
+            )
+            .onHover { hovering = $0 }
+            .animation(.easeOut(duration: 0.12), value: hovering)
+    }
+}
+
+/// Quiet rounded chrome for a header icon button on macOS: a soft inset
+/// surface with a hairline, lifting to `paper2` on hover. Replaces the hard
+/// square default-bordered macOS button background.
+private struct MacHeaderIconChrome: ViewModifier {
+    @State private var hovering = false
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                    .fill(hovering ? Tokens.paper2 : Tokens.surface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                            .stroke(Tokens.border, lineWidth: 0.5)
+                    )
+                    .padding(Space.xs)
+            )
+            .onHover { hovering = $0 }
+            .animation(.easeOut(duration: 0.12), value: hovering)
+    }
+}
+#endif

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -2,6 +2,9 @@ import SwiftUI
 #if canImport(UIKit)
 import UIKit
 #endif
+#if canImport(AppKit)
+import AppKit
+#endif
 
 /// Swipe-left-to-delete with circular red trash + gray fade card,
 /// keyed to a UIKit-bridged horizontal-only pan recognizer so the
@@ -68,114 +71,61 @@ extension View {
 }
 
 #if os(macOS)
-/// The macOS custom swipe implementation. Built on a plain `DragGesture` (so it
-/// responds to a mouse click-drag, unlike a trackpad-scroll gesture) that only
-/// engages when the drag is horizontal-dominant, leaving vertical drags to the
-/// parent `ScrollView`.
+/// The macOS row-delete affordance.
+///
+/// A literal trackpad swipe was tried twice and abandoned. A SwiftUI
+/// `DragGesture` fires only on a mouse click-drag (not the two-finger trackpad
+/// swipe users make) AND intercepts real clicks during gesture arbitration, so
+/// the completion toggle and tap-to-edit stopped firing. An AppKit
+/// `scrollWheel` bridge that hosted each row in a nested `NSHostingView`
+/// crashed the app outright (AttributeGraph precondition failure in
+/// `NSHostingView.layout()` — nesting a hosting view inside the SwiftUI
+/// `LazyVStack` is not viable).
+///
+/// This version is pure SwiftUI and leaves the click layer completely
+/// untouched: a trailing red trash button fades in on row hover (positioned
+/// clear of the info button), plus a right-click context-menu delete. Reliable
+/// on both mouse and trackpad (issue #285).
 private struct MacSwipeToDelete: ViewModifier {
     let onDelete: () -> Void
-
-    @State private var offset: CGFloat = 0
-    @State private var isOpen: Bool = false
-    @GestureState private var isDragging: Bool = false
-
-    /// How far the row slides to fully reveal the trash button.
-    private let revealedWidth: CGFloat = 68
-    /// Drag magnitude past which releasing commits the delete outright.
-    private let commitThreshold: CGFloat = 150
-    /// The iOS system delete tint, matched here for visual parity.
+    @State private var hovering = false
     private let trashColor = Color(.sRGB, red: 1.0, green: 0.231, blue: 0.188, opacity: 1.0)
-    private let animation: Animation = .snappy(duration: 0.24, extraBounce: 0.04)
 
     func body(content: Content) -> some View {
-        let dragMag = -offset
-        let progress = min(1.0, max(0.0, dragMag / revealedWidth))
-
-        ZStack(alignment: .trailing) {
-            // Row content slides left; its hit region moves with the offset,
-            // exposing the trash button behind it at the trailing edge.
-            content
-                .offset(x: offset)
-                .gesture(dragGesture)
-
-            // Red trash affordance: full row height, inset slightly, moderate
-            // corner radius (Reminders-style). Only hittable once the swipe is
-            // open so it never blocks the row while closed.
-            Button(action: commit) {
-                Image(systemName: "trash")
-                    .font(.system(size: 16, weight: .regular))
-                    .foregroundStyle(.white)
-                    .frame(width: revealedWidth)
-                    .frame(maxHeight: .infinity)
-                    .background(
-                        RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-                            .fill(trashColor)
-                    )
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .padding(.vertical, 2)
-            .opacity(progress)
-            .allowsHitTesting(isOpen)
-            .accessibilityLabel("Delete")
-        }
-    }
-
-    private var dragGesture: some Gesture {
-        DragGesture(minimumDistance: 8)
-            .updating($isDragging) { _, state, _ in state = true }
-            .onChanged { value in
-                // Engage only horizontal-dominant drags; let vertical drags
-                // fall through to the scroll view.
-                guard abs(value.translation.width) > abs(value.translation.height) else { return }
-                let base: CGFloat = isOpen ? -revealedWidth : 0
-                offset = rubberBanded(base + value.translation.width)
-            }
-            .onEnded { value in
-                guard abs(value.translation.width) > abs(value.translation.height) else {
-                    // Non-horizontal release: settle back to the current state.
-                    withAnimation(animation) { offset = isOpen ? -revealedWidth : 0 }
-                    return
+        content
+            // Trailing red trash, revealed on row hover. Padded in from the
+            // trailing edge so it lands to the LEFT of the row's info button,
+            // never over it. Only hittable while shown, so it can't block the
+            // rest of the row (or steal the checkbox's click) when hidden.
+            .overlay(alignment: .trailing) {
+                Button(action: onDelete) {
+                    Image(systemName: "trash")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 30, height: 24)
+                        .background(
+                            RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+                                .fill(trashColor)
+                        )
+                        .contentShape(Rectangle())
                 }
-                let base: CGFloat = isOpen ? -revealedWidth : 0
-                let endMag = -(base + value.translation.width)
-                if endMag > commitThreshold {
-                    commit()
-                } else if endMag > revealedWidth * 0.5 {
-                    open()
-                } else {
-                    close()
+                .buttonStyle(.plain)
+                .padding(.trailing, 44)
+                .opacity(hovering ? 1 : 0)
+                .allowsHitTesting(hovering)
+                .accessibilityLabel("Delete")
+            }
+            .onHover { hovering = $0 }
+            .animation(.easeOut(duration: 0.12), value: hovering)
+            // Right-click delete, always available (mouse or trackpad).
+            .contextMenu {
+                Button(role: .destructive, action: onDelete) {
+                    Label("Delete", systemImage: "trash")
                 }
             }
-    }
-
-    /// Light asymptotic resistance past the reveal width so the row keeps
-    /// tracking the cursor toward the commit threshold without sliding off.
-    private func rubberBanded(_ raw: CGFloat) -> CGFloat {
-        if raw >= 0 { return 0 }
-        let mag = -raw
-        if mag <= revealedWidth { return raw }
-        let overshoot = mag - revealedWidth
-        let damped = overshoot / (1.0 + overshoot * 0.008)
-        return -(revealedWidth + damped)
-    }
-
-    private func open() {
-        isOpen = true
-        withAnimation(animation) { offset = -revealedWidth }
-    }
-
-    private func close() {
-        isOpen = false
-        withAnimation(animation) { offset = 0 }
-    }
-
-    private func commit() {
-        Haptics.destructive()
-        isOpen = false
-        onDelete()
     }
 }
+
 #endif
 
 #if canImport(UIKit)

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -32,9 +32,13 @@ extension View {
         // macOS: the custom UIKit pan bridge below doesn't exist. Rows live
         // inside a `List`, so the native trailing swipe-to-delete gives the
         // same affordance with a real destructive full-swipe.
+        // Text-only "Delete", not a Label: on macOS a Label in a swipe action
+        // wraps its icon above the text and renders an oversized, cramped pill
+        // on tall rows. A plain "Delete" gives the clean, full-height red button
+        // Reminders uses (issue #285).
         return self.swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive, action: action) {
-                Label("Delete", systemImage: "trash")
+                Text("Delete")
             }
         }
         #endif

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -44,7 +44,139 @@ extension View {
         }
         #endif
     }
+
+    /// macOS-only, Reminders-style custom swipe-to-delete for rows that live in
+    /// a `ScrollView { LazyVStack }` rather than a `List` (issue #285). The
+    /// Tasks and Lists-detail surfaces were moved off `List` on macOS to kill
+    /// the system edit highlight and to get a swipe affordance that matches
+    /// Reminders, neither of which `List` allows. iOS is untouched — it keeps
+    /// the UIKit-bridged `swipeToDeleteTrash` pan (this is a no-op there).
+    ///
+    /// A horizontal mouse/trackpad drag slides the row content left to reveal a
+    /// red trash button at the trailing edge. Dragging past a threshold and
+    /// releasing, or clicking the revealed button, deletes the row; a small drag
+    /// snaps back closed. Vertical-dominant drags are ignored so they pass
+    /// through to the scroll view.
+    @ViewBuilder
+    func macSwipeToDelete(perform action: @escaping () -> Void) -> some View {
+        #if os(macOS)
+        modifier(MacSwipeToDelete(onDelete: action))
+        #else
+        self
+        #endif
+    }
 }
+
+#if os(macOS)
+/// The macOS custom swipe implementation. Built on a plain `DragGesture` (so it
+/// responds to a mouse click-drag, unlike a trackpad-scroll gesture) that only
+/// engages when the drag is horizontal-dominant, leaving vertical drags to the
+/// parent `ScrollView`.
+private struct MacSwipeToDelete: ViewModifier {
+    let onDelete: () -> Void
+
+    @State private var offset: CGFloat = 0
+    @State private var isOpen: Bool = false
+    @GestureState private var isDragging: Bool = false
+
+    /// How far the row slides to fully reveal the trash button.
+    private let revealedWidth: CGFloat = 68
+    /// Drag magnitude past which releasing commits the delete outright.
+    private let commitThreshold: CGFloat = 150
+    /// The iOS system delete tint, matched here for visual parity.
+    private let trashColor = Color(.sRGB, red: 1.0, green: 0.231, blue: 0.188, opacity: 1.0)
+    private let animation: Animation = .snappy(duration: 0.24, extraBounce: 0.04)
+
+    func body(content: Content) -> some View {
+        let dragMag = -offset
+        let progress = min(1.0, max(0.0, dragMag / revealedWidth))
+
+        ZStack(alignment: .trailing) {
+            // Row content slides left; its hit region moves with the offset,
+            // exposing the trash button behind it at the trailing edge.
+            content
+                .offset(x: offset)
+                .gesture(dragGesture)
+
+            // Red trash affordance: full row height, inset slightly, moderate
+            // corner radius (Reminders-style). Only hittable once the swipe is
+            // open so it never blocks the row while closed.
+            Button(action: commit) {
+                Image(systemName: "trash")
+                    .font(.system(size: 16, weight: .regular))
+                    .foregroundStyle(.white)
+                    .frame(width: revealedWidth)
+                    .frame(maxHeight: .infinity)
+                    .background(
+                        RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
+                            .fill(trashColor)
+                    )
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .padding(.vertical, 2)
+            .opacity(progress)
+            .allowsHitTesting(isOpen)
+            .accessibilityLabel("Delete")
+        }
+    }
+
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 8)
+            .updating($isDragging) { _, state, _ in state = true }
+            .onChanged { value in
+                // Engage only horizontal-dominant drags; let vertical drags
+                // fall through to the scroll view.
+                guard abs(value.translation.width) > abs(value.translation.height) else { return }
+                let base: CGFloat = isOpen ? -revealedWidth : 0
+                offset = rubberBanded(base + value.translation.width)
+            }
+            .onEnded { value in
+                guard abs(value.translation.width) > abs(value.translation.height) else {
+                    // Non-horizontal release: settle back to the current state.
+                    withAnimation(animation) { offset = isOpen ? -revealedWidth : 0 }
+                    return
+                }
+                let base: CGFloat = isOpen ? -revealedWidth : 0
+                let endMag = -(base + value.translation.width)
+                if endMag > commitThreshold {
+                    commit()
+                } else if endMag > revealedWidth * 0.5 {
+                    open()
+                } else {
+                    close()
+                }
+            }
+    }
+
+    /// Light asymptotic resistance past the reveal width so the row keeps
+    /// tracking the cursor toward the commit threshold without sliding off.
+    private func rubberBanded(_ raw: CGFloat) -> CGFloat {
+        if raw >= 0 { return 0 }
+        let mag = -raw
+        if mag <= revealedWidth { return raw }
+        let overshoot = mag - revealedWidth
+        let damped = overshoot / (1.0 + overshoot * 0.008)
+        return -(revealedWidth + damped)
+    }
+
+    private func open() {
+        isOpen = true
+        withAnimation(animation) { offset = -revealedWidth }
+    }
+
+    private func close() {
+        isOpen = false
+        withAnimation(animation) { offset = 0 }
+    }
+
+    private func commit() {
+        Haptics.destructive()
+        isOpen = false
+        onDelete()
+    }
+}
+#endif
 
 #if canImport(UIKit)
 private struct SwipeToDeleteWithTint: ViewModifier {

--- a/mobile/PersonalDashboard/Design/SwipeActions.swift
+++ b/mobile/PersonalDashboard/Design/SwipeActions.swift
@@ -32,14 +32,15 @@ extension View {
         // macOS: the custom UIKit pan bridge below doesn't exist. Rows live
         // inside a `List`, so the native trailing swipe-to-delete gives the
         // same affordance with a real destructive full-swipe.
-        // Text-only "Delete", not a Label: on macOS a Label in a swipe action
-        // wraps its icon above the text and renders an oversized, cramped pill
-        // on tall rows. A plain "Delete" gives the clean, full-height red button
-        // Reminders uses (issue #285).
+        // Reminders-style trailing swipe: a red full-height button with a white
+        // trash glyph (icon only — a Label stacks icon-over-text into an
+        // oversized pill on tall rows). `.tint(.red)` fills the reveal red;
+        // full-swipe commits the delete (issue #285).
         return self.swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive, action: action) {
-                Text("Delete")
+                Image(systemName: "trash")
             }
+            .tint(.red)
         }
         #endif
     }

--- a/mobile/PersonalDashboard/Views/Chat/ChatInputBar.swift
+++ b/mobile/PersonalDashboard/Views/Chat/ChatInputBar.swift
@@ -32,6 +32,10 @@ struct ChatInputBar: View {
                         .allowsHitTesting(false)
                 }
                 TextField("", text: $text, axis: .vertical)
+                    // Strip the default macOS bordered field box so the input
+                    // reads as a single rounded surface (no box-in-a-box,
+                    // issue #285). No-op on iOS, where the field is borderless.
+                    .plainFieldStyleOnMac()
                     .font(.edBody)
                     .foregroundStyle(Tokens.ink)
                     .lineLimit(1...6)

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -340,11 +340,15 @@ private struct ListDetailContent: View {
                         .font(.edCaption)
                         .foregroundStyle(Tokens.muted)
                     Spacer()
+                    // Reorder is List-only; macOS renders off `List`, so drop
+                    // the "Hold to reorder" hint there (issue #285).
+                    #if os(iOS)
                     if !list.items.isEmpty {
                         Text("Hold to reorder")
                             .font(.edCaption)
                             .foregroundStyle(Tokens.mutedSoft)
                     }
+                    #endif
                 }
                 .padding(.horizontal, Space.lg)
                 .padding(.top, Space.lg)
@@ -359,6 +363,15 @@ private struct ListDetailContent: View {
 
                 // Items list — always rendered so tap-below works even when empty.
                 // Chrome stripped to keep the editorial calm look.
+                //
+                // macOS renders off `List` in a custom `ScrollView { LazyVStack }`
+                // (issue #285): `List` on macOS paints an un-removable system
+                // highlight behind the row being renamed and its `.swipeActions`
+                // styling is system-fixed. iOS keeps the `List` verbatim (native
+                // swipe + `.onMove` reorder + keyboard-avoidance scrolling).
+                #if os(macOS)
+                macItemScroll(list)
+                #else
                 // Wrapped in a ScrollViewReader so the focused inline draft row can be
                 // scrolled clear of the keyboard (SwiftUI's default List avoidance
                 // won't lift it because there's content below the draft).
@@ -489,6 +502,7 @@ private struct ListDetailContent: View {
                         .animation(.easeOut(duration: 0.15), value: draftActive)
                     }
                 }
+                #endif
             }
             .sheet(item: $editingItem) { editing in
                 // Guard against a stale index if the list mutated while the sheet
@@ -571,6 +585,92 @@ private struct ListDetailContent: View {
             draftFocused = false
         }
     }
+
+    // MARK: - macOS scroll stack (issue #285)
+    //
+    // Same items, draft row, ghost add-row and dismiss filler as iOS, but off
+    // `List` in a `ScrollView { LazyVStack }`. Rows use `.macSwipeToDelete`
+    // (Reminders-style) instead of `.swipeToDeleteTrash`; `.onMove` reorder is
+    // dropped (List-only). The FAB overlays the scroll exactly as on iOS.
+    #if os(macOS)
+    @ViewBuilder
+    private func macItemScroll(_ list: Checklist) -> some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                if list.items.isEmpty && !draftActive {
+                    Text("No items yet. Add one below.")
+                        .font(.edBody)
+                        .foregroundStyle(Tokens.muted)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, Space.lg)
+                        .padding(.horizontal, Space.lg)
+                }
+
+                ForEach(Array(list.items.enumerated()), id: \.element.id) { index, item in
+                    ItemRow(
+                        item: item,
+                        onToggle: {
+                            Task { await viewModel.toggleItem(in: list, at: index) }
+                        },
+                        onRename: { newText in
+                            Task { await viewModel.renameItem(in: list, at: index, to: newText) }
+                        },
+                        onDelete: {
+                            Haptics.destructive()
+                            Task { await viewModel.removeItem(from: list, at: index) }
+                        },
+                        onOpenDetails: {
+                            editingItem = EditingItem(index: index, item: item)
+                        },
+                        isDraftActive: draftActive,
+                        onTapWhileDraftActive: { draftFocused = false }
+                    )
+                    .macSwipeToDelete {
+                        Task { await viewModel.removeItem(from: list, at: index) }
+                    }
+                    // Reproduce the iOS `.listRowInsets` gutter now that we're off `List`.
+                    .padding(.horizontal, Space.lg)
+                    .padding(.vertical, 2)
+                }
+
+                if draftActive {
+                    DraftItemRow(
+                        text: $draftText,
+                        isFocused: $draftFocused,
+                        onSubmit: { commitDraft(in: list, keepFocus: true) },
+                        onFocusLost: { commitDraft(in: list, keepFocus: false) }
+                    )
+                    .padding(.horizontal, Space.lg)
+                    .padding(.vertical, 2)
+                }
+
+                GhostAddRow(label: "New Item", minHeight: 44) {
+                    if draftActive { draftFocused = false }
+                    else { startDraft() }
+                }
+
+                // Dismiss filler + FAB clearance below the last row.
+                Color.clear
+                    .frame(minHeight: 160)
+                    .contentShape(Rectangle())
+                    .onTapGesture { draftFocused = false }
+            }
+        }
+        .background(Tokens.paper)
+        .overlay(alignment: .bottomTrailing) {
+            Button {
+                creatingItem = true
+            } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(EdIconCircleButtonStyle(kind: .primary))
+            .padding(.trailing, 22)
+            .padding(.bottom, BottomTabBarMetrics.fabBottomInset)
+            .opacity(draftActive ? 0 : 1)
+            .animation(.easeOut(duration: 0.15), value: draftActive)
+        }
+    }
+    #endif
 
 }
 

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -196,6 +196,8 @@ private struct ListDetailHeader: View {
             Spacer()
             if isEditing {
                 TextField("", text: $draft)
+                    // macOS: no default bordered field box (issue #285).
+                    .plainFieldStyleOnMac()
                     .font(.edTitle)
                     .foregroundStyle(Tokens.ink)
                     .multilineTextAlignment(.center)
@@ -589,6 +591,8 @@ private struct DraftItemRow: View {
                 .frame(width: 24, height: 24)
 
             TextField("New item", text: $text)
+                // macOS: no default bordered field box (issue #285).
+                .plainFieldStyleOnMac()
                 .font(.edBody)
                 .foregroundStyle(Tokens.ink)
                 .submitLabel(.return)

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -632,6 +632,9 @@ private struct ItemRow: View {
 
             if isEditing {
                 TextField("", text: $draft)
+                    // macOS: drop the default bordered field box so inline
+                    // rename reads as clean text, Reminders-style (issue #285).
+                    .plainFieldStyleOnMac()
                     .font(.edBody)
                     .foregroundStyle(Tokens.ink)
                     .submitLabel(.done)
@@ -646,6 +649,12 @@ private struct ItemRow: View {
                     .font(.edBody)
                     .strikethrough(item.checked)
                     .foregroundStyle(item.checked ? Tokens.mutedSoft : Tokens.ink)
+                    // macOS: item text is the tap-to-rename target (the row tap
+                    // is gated off there so the circle stays clickable).
+                    #if os(macOS)
+                    .contentShape(Rectangle())
+                    .onTapGesture { beginBodyTap() }
+                    #endif
             }
             Spacer(minLength: Space.sm)
 
@@ -695,16 +704,12 @@ private struct ItemRow: View {
         // `macTamedListSelection()` on the List. No-op on iOS.
         .macRowHover()
         .contentShape(Rectangle())
-        .onTapGesture {
-            // When a tap-below draft is active, actively flip draftFocused in the parent
-            // so the focus-loss → commitDraft → dismiss cycle fires immediately.
-            // We still return early so this row does not enter its own edit flow.
-            if isDraftActive {
-                onTapWhileDraftActive()
-                return
-            }
-            if !isEditing { beginEditing() }
-        }
+        // iOS: whole-row tap enters rename (circle beats it via high-priority
+        // gesture). macOS scopes tap-to-rename to the item text only so the
+        // completion circle stays clickable (#285).
+        #if os(iOS)
+        .onTapGesture { beginBodyTap() }
+        #endif
         .contextMenu {
             Button(role: .destructive, action: onDelete) {
                 Label("Delete", systemImage: "trash")
@@ -712,11 +717,20 @@ private struct ItemRow: View {
         }
     }
 
-    /// Completion control. macOS uses a real `Button` action so a mouse click
-    /// toggles under a selectable `List`; iOS keeps the empty-action +
-    /// high-priority tap-gesture trick that survives the keyboard-dismiss first
-    /// tap (issue #285). Circle visual is shared.
-    @ViewBuilder
+    /// Enters inline rename from a body tap. Shared by iOS (whole-row tap) and
+    /// macOS (item-text tap).
+    private func beginBodyTap() {
+        if isDraftActive {
+            onTapWhileDraftActive()
+            return
+        }
+        if !isEditing { beginEditing() }
+    }
+
+    /// Completion control. macOS uses a clean `Button(action:)` — with the
+    /// full-row tap gated off there, nothing competes for the click. iOS keeps
+    /// the empty-action + high-priority tap gesture so one tap toggles even
+    /// while the inline field owns first responder (#285).
     private var completionButton: some View {
         #if os(macOS)
         Button(action: handleToggle) { completionCircle }
@@ -741,6 +755,10 @@ private struct ItemRow: View {
             }
         }
         .frame(width: 24, height: 24)
+        // Make the whole 24pt frame hittable, not just the 2pt stroke ring —
+        // otherwise a click in the transparent center falls through and the
+        // toggle never fires on macOS (issue #285).
+        .contentShape(Rectangle())
     }
 
     private func beginEditing() {

--- a/mobile/PersonalDashboard/Views/Lists/ListsView.swift
+++ b/mobile/PersonalDashboard/Views/Lists/ListsView.swift
@@ -160,6 +160,8 @@ struct ListsView: View {
         .scrollContentBackground(.hidden)
         .background(Tokens.paper)
         .scrollDismissesKeyboard(.interactively)
+        // macOS: drop the hard grey row-selection bar (issue #285).
+        .macTamedListSelection()
         .refreshable { await viewModel.load() }
     }
 }
@@ -189,6 +191,8 @@ private struct ListDetailHeader: View {
                 .frame(height: 44)
                 .contentShape(Rectangle())
             }
+            // macOS: strip the hard default-bordered button chrome (issue #285).
+            .macPlainButtonStyle()
             Spacer()
             if isEditing {
                 TextField("", text: $draft)
@@ -222,12 +226,18 @@ private struct ListDetailHeader: View {
                     .foregroundStyle(Tokens.muted)
             }
             .accessibilityLabel("List appearance")
+            // macOS: quiet rounded chrome instead of the hard square default
+            // button background (issue #285). No-op on iOS.
+            .macPlainButtonStyle()
+            .macHeaderIconChrome()
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .frame(width: 44, height: 44)
                     .foregroundStyle(Tokens.muted)
             }
             .accessibilityLabel("Delete list")
+            .macPlainButtonStyle()
+            .macHeaderIconChrome()
         }
         .padding(.horizontal, Space.md)
         .frame(height: 56)
@@ -445,6 +455,9 @@ private struct ListDetailContent: View {
                     .scrollContentBackground(.hidden)
                     .background(Tokens.paper)
                     .scrollDismissesKeyboard(.interactively)
+                    // macOS: drop the hard grey row-selection bar; rows get a
+                    // soft inset hover via `.macRowHover()` (issue #285).
+                    .macTamedListSelection()
                     // When the inline draft gains focus, scroll it clear of the keyboard.
                     .onChange(of: draftFocused) { _, focused in
                         guard focused else { return }
@@ -615,26 +628,7 @@ private struct ItemRow: View {
 
     var body: some View {
         HStack(spacing: Space.md) {
-            // Empty Button action: the high-priority tap gesture below is the single
-            // source of the toggle. This guarantees one toggle per tap even while the
-            // inline field is focused (iOS's "first tap dismisses keyboard" would
-            // otherwise eat a plain row/Button tap).
-            Button(action: {}) {
-                ZStack {
-                    Circle()
-                        .stroke(item.checked ? Tokens.success : Tokens.borderStrong, lineWidth: 2)
-                        .background(item.checked ? Tokens.success.clipShape(Circle()) : nil)
-                        .frame(width: 22, height: 22)
-                    if item.checked {
-                        Image(systemName: "checkmark")
-                            .font(.system(size: 11, weight: .bold))
-                            .foregroundStyle(Tokens.paper)
-                    }
-                }
-                .frame(width: 24, height: 24)
-            }
-            .buttonStyle(.plain)
-            .highPriorityGesture(TapGesture().onEnded { handleToggle() })
+            completionButton
 
             if isEditing {
                 TextField("", text: $draft)
@@ -696,6 +690,10 @@ private struct ItemRow: View {
         }
         .padding(.vertical, Space.sm)
         .padding(.horizontal, Space.md)
+        // macOS: soft inset rounded hover highlight (Reminders-style), which
+        // replaces the hard system selection bar killed by
+        // `macTamedListSelection()` on the List. No-op on iOS.
+        .macRowHover()
         .contentShape(Rectangle())
         .onTapGesture {
             // When a tap-below draft is active, actively flip draftFocused in the parent
@@ -712,6 +710,37 @@ private struct ItemRow: View {
                 Label("Delete", systemImage: "trash")
             }
         }
+    }
+
+    /// Completion control. macOS uses a real `Button` action so a mouse click
+    /// toggles under a selectable `List`; iOS keeps the empty-action +
+    /// high-priority tap-gesture trick that survives the keyboard-dismiss first
+    /// tap (issue #285). Circle visual is shared.
+    @ViewBuilder
+    private var completionButton: some View {
+        #if os(macOS)
+        Button(action: handleToggle) { completionCircle }
+            .buttonStyle(.plain)
+        #else
+        Button(action: {}) { completionCircle }
+            .buttonStyle(.plain)
+            .highPriorityGesture(TapGesture().onEnded { handleToggle() })
+        #endif
+    }
+
+    private var completionCircle: some View {
+        ZStack {
+            Circle()
+                .stroke(item.checked ? Tokens.success : Tokens.borderStrong, lineWidth: 2)
+                .background(item.checked ? Tokens.success.clipShape(Circle()) : nil)
+                .frame(width: 22, height: 22)
+            if item.checked {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(Tokens.paper)
+            }
+        }
+        .frame(width: 24, height: 24)
     }
 
     private func beginEditing() {

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -554,6 +554,8 @@ private struct DraftTaskRow: View {
                 .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
 
             TextField("New task", text: $text)
+                // macOS: no default bordered field box (issue #285).
+                .plainFieldStyleOnMac()
                 .font(.edBody)
                 .foregroundStyle(Tokens.ink)
                 .submitLabel(.return)

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -604,6 +604,9 @@ private struct TaskRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 if isEditing {
                     TextField("", text: $editText)
+                        // macOS: drop the default bordered field box so inline
+                        // edit reads as clean text, Reminders-style (issue #285).
+                        .plainFieldStyleOnMac()
                         .font(.edBody)
                         .foregroundStyle(Tokens.ink)
                         .submitLabel(.done)
@@ -618,6 +621,12 @@ private struct TaskRow: View {
                         .strikethrough(todo.completed)
                         .foregroundStyle(todo.completed ? Tokens.mutedSoft : Tokens.ink)
                         .multilineTextAlignment(.leading)
+                        // macOS: title text is the tap-to-edit target (the row
+                        // tap is gated off there so the circle stays clickable).
+                        #if os(macOS)
+                        .contentShape(Rectangle())
+                        .onTapGesture { beginBodyTap() }
+                        #endif
                 }
 
                 if let desc = todo.description, !desc.isEmpty {
@@ -712,33 +721,34 @@ private struct TaskRow: View {
                 .frame(width: Space.xs)
         }
         .contentShape(Rectangle())
-        .onTapGesture {
-            // When a tap-below draft is active, actively flip draftFocused in the parent
-            // so the focus-loss → commitDraft → dismiss cycle fires immediately.
-            // We still return early so the editor sheet does not open over the keyboard.
-            if isDraftActive {
-                onTapWhileDraftActive()
-                return
-            }
-            // Completed rows ignore body taps; the info icon still works.
-            if todo.completed { return }
-            // Already in inline-edit; let the TextField own the tap.
-            if isEditing { return }
-            editText = todo.title
-            isEditing = true
-            // DispatchQueue.main.async lets the TextField mount before we focus it.
-            DispatchQueue.main.async { titleFocused = true }
-        }
+        // iOS: the WHOLE row is tap-to-edit; the completion circle beats it with
+        // a high-priority gesture (see `completionButton`). On macOS a full-row
+        // tap gesture greedily swallows the circle's click (the circle never
+        // toggles, the row just opens the editor), so macOS scopes tap-to-edit
+        // to the title text only and leaves the circle a clean Button (#285).
+        #if os(iOS)
+        .onTapGesture { beginBodyTap() }
+        #endif
     }
 
-    /// The completion control. On macOS it's a real `Button` whose action
-    /// toggles completion, because a real mouse click fires the button action
-    /// directly (issue #285) — the iOS empty-action + high-priority tap-gesture
-    /// trick never delivers under a selectable `List` on the Mac. On iOS the
-    /// original pattern is kept verbatim: an empty action plus a high-priority
-    /// tap gesture, so one tap toggles even while the inline field owns first
-    /// responder (iOS's "first tap dismisses keyboard" would otherwise eat it).
-    @ViewBuilder
+    /// Enters inline edit from a body tap. Extracted so iOS (whole-row tap) and
+    /// macOS (title-text tap) share one path.
+    private func beginBodyTap() {
+        if isDraftActive {
+            onTapWhileDraftActive()
+            return
+        }
+        if todo.completed { return }
+        if isEditing { return }
+        editText = todo.title
+        isEditing = true
+        DispatchQueue.main.async { titleFocused = true }
+    }
+
+    /// The completion control. macOS uses a clean `Button(action:)` — with the
+    /// full-row tap gated off there, nothing competes for the click. iOS keeps
+    /// the empty-action + high-priority tap gesture so one tap toggles even
+    /// while the inline field owns first responder (#285).
     private var completionButton: some View {
         #if os(macOS)
         Button(action: handleToggle) { completionCircle }
@@ -763,6 +773,10 @@ private struct TaskRow: View {
             }
         }
         .frame(width: 24, height: 24)
+        // Make the whole 24pt frame hittable, not just the 2pt stroke ring —
+        // otherwise a click in the transparent center falls through and the
+        // toggle never fires on macOS (issue #285).
+        .contentShape(Rectangle())
     }
 
     private func commitInlineEdit() {

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -31,6 +31,17 @@ struct TasksView: View {
                 )
                 #endif
 
+                // macOS renders the tasks list off `List` — a custom
+                // `ScrollView { LazyVStack }` (issue #285). `List` on macOS
+                // paints a system highlight behind the row being edited (an
+                // un-removable grey box) and its `.swipeActions` styling is
+                // system-fixed, so neither the clean inline edit nor the
+                // Reminders-style swipe was achievable on `List`. iOS keeps the
+                // `List` verbatim so its native `.swipeActions` + UIKit-pan
+                // path is unchanged.
+                #if os(macOS)
+                macTaskScroll
+                #else
                 // Using `List` (not `ScrollView { LazyVStack }`) so each row
                 // can opt into native `.swipeActions`. The list is dressed
                 // down to keep the editorial paper styling: clear row
@@ -83,6 +94,7 @@ struct TasksView: View {
                         }
                     }
                 }
+                #endif
             }
 
             Button {
@@ -306,6 +318,178 @@ struct TasksView: View {
             completedSection(buckets.completed)
         }
     }
+
+    // MARK: - macOS scroll stack (issue #285)
+    //
+    // The macOS surface renders the same section grouping, headers, counts,
+    // inline draft rows and collapsible Completed section as iOS, but in a
+    // `ScrollView { LazyVStack }` instead of a `List`. Rows use the custom
+    // `.macSwipeToDelete` (Reminders-style) in place of `.swipeToDeleteTrash`,
+    // and the List-only `.listRow*` insets are replaced by explicit padding.
+    // Reorder ("Hold to reorder") is dropped — it isn't available off `List`.
+    #if os(macOS)
+    private var macTaskScroll: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                if viewModel.isLoading && viewModel.todos.isEmpty {
+                    placeholderRow("Loading…")
+                } else if viewModel.todos.isEmpty {
+                    placeholderRow("No tasks yet. Tap below to start.")
+                    emptyStateDraftRow
+                } else {
+                    macTaskGroups
+                }
+
+                // FAB clearance — keeps the last row scrollable clear of the
+                // floating + button. Also a tap-to-dismiss zone for a draft.
+                Color.clear
+                    .frame(height: 96)
+                    .contentShape(Rectangle())
+                    .onTapGesture { draftFocused = false }
+            }
+        }
+        .background(Tokens.paper)
+    }
+
+    @ViewBuilder
+    private var macTaskGroups: some View {
+        let buckets = computeBuckets()
+        let hasOpenTasks = !buckets.overdue.isEmpty
+            || !buckets.today.isEmpty
+            || !buckets.thisWeek.isEmpty
+            || !buckets.later.isEmpty
+            || !buckets.noDate.isEmpty
+        if !hasOpenTasks && draftBucket == nil && !buckets.completed.isEmpty {
+            allCaughtUpRow
+        }
+        if !buckets.overdue.isEmpty {
+            macTaskSection(title: "Overdue", count: buckets.overdue.count, accent: Tokens.danger, soft: Tokens.dangerSoft, todos: buckets.overdue, bucket: nil)
+        }
+        if !buckets.today.isEmpty || draftBucket == .today {
+            macTaskSection(title: "Today", count: buckets.today.count, accent: Tokens.warning, soft: Tokens.warningSoft, todos: buckets.today, bucket: .today)
+        }
+        if !buckets.tomorrow.isEmpty || draftBucket == .tomorrow {
+            macTaskSection(title: "Tomorrow", count: buckets.tomorrow.count, accent: Tokens.info, soft: Tokens.paper2, todos: buckets.tomorrow, bucket: .tomorrow)
+        }
+        if !buckets.thisWeek.isEmpty || draftBucket == .thisWeek {
+            macTaskSection(title: "This Week", count: buckets.thisWeek.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: buckets.thisWeek, bucket: .thisWeek)
+        }
+        if !buckets.later.isEmpty || draftBucket == .later {
+            macTaskSection(title: "Later", count: buckets.later.count, accent: Tokens.inkSoft, soft: Tokens.paper2, todos: buckets.later, bucket: .later)
+        }
+        if !buckets.noDate.isEmpty || draftBucket == .noDate {
+            macTaskSection(title: "No Date", count: buckets.noDate.count, accent: Tokens.muted, soft: Tokens.paper2, todos: buckets.noDate, bucket: .noDate)
+        }
+        if !buckets.completed.isEmpty {
+            macCompletedSection(buckets.completed)
+        }
+    }
+
+    @ViewBuilder
+    private func macTaskSection(title: String, count: Int, accent: Color, soft: Color, todos: [Todo], bucket: DraftBucket?) -> some View {
+        Section {
+            ForEach(todos) { todo in
+                TaskRow(
+                    todo: todo,
+                    isDraftActive: draftBucket != nil,
+                    onToggle: { Task { await viewModel.toggleCompleted(todo) } },
+                    onInfoTap: { editingTodo = todo },
+                    onTitleCommit: { newTitle in
+                        Task { await viewModel.update(todo, title: newTitle, description: todo.description, dueDate: todo.dueDate, tag: todo.tag) }
+                    },
+                    onTapWhileDraftActive: { draftFocused = false }
+                )
+                .macSwipeToDelete {
+                    Task { await viewModel.delete(todo) }
+                }
+                // Reproduce the iOS `.listRowInsets` gutter (leading/trailing
+                // Space.lg + 2pt vertical) now that we're off `List`.
+                .padding(.horizontal, Space.lg)
+                .padding(.vertical, 2)
+            }
+
+            if let bucket {
+                if draftBucket == bucket {
+                    DraftTaskRow(
+                        text: $draftText,
+                        isFocused: $draftFocused,
+                        onSubmit: { commitDraft(keepFocus: true) },
+                        onFocusLost: { commitDraft(keepFocus: false) }
+                    )
+                    .frame(minHeight: 40)
+                    .padding(.horizontal, Space.lg)
+                } else {
+                    GhostAddRow(label: "New Task", minHeight: 40) { startDraft(in: bucket) }
+                }
+            }
+        } header: {
+            sectionHeader(title: title, count: count, accent: accent, soft: soft)
+        }
+    }
+
+    @ViewBuilder
+    private func macCompletedSection(_ todos: [Todo]) -> some View {
+        Section {
+            if completedExpanded {
+                ForEach(todos) { todo in
+                    TaskRow(
+                        todo: todo,
+                        isDraftActive: draftBucket != nil,
+                        onToggle: { Task { await viewModel.toggleCompleted(todo) } },
+                        onInfoTap: { editingTodo = todo },
+                        onTitleCommit: { newTitle in
+                            Task { await viewModel.update(todo, title: newTitle, description: todo.description, dueDate: todo.dueDate, tag: todo.tag) }
+                        },
+                        onTapWhileDraftActive: { draftFocused = false }
+                    )
+                    .macSwipeToDelete {
+                        Task { await viewModel.delete(todo) }
+                    }
+                    .padding(.horizontal, Space.lg)
+                    .padding(.vertical, 2)
+                }
+            }
+        } header: {
+            // Duplicated from the iOS `completedSection` header so iOS rendering
+            // stays byte-for-byte untouched.
+            VStack(spacing: 0) {
+                Rectangle()
+                    .fill(Tokens.border)
+                    .frame(height: 1)
+                    .padding(.horizontal, Space.lg)
+                    .padding(.top, Space.md)
+
+                Button {
+                    withAnimation(.easeOut(duration: 0.2)) { completedExpanded.toggle() }
+                } label: {
+                    HStack(spacing: Space.sm) {
+                        Image(systemName: completedExpanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 12, weight: .regular))
+                            .foregroundStyle(Tokens.muted)
+                        Text("Completed")
+                            .font(.edHeading)
+                            .foregroundStyle(Tokens.muted)
+                        Text("\(todos.count)")
+                            .font(.edCaption)
+                            .foregroundStyle(Tokens.muted)
+                            .padding(.horizontal, Space.sm)
+                            .padding(.vertical, 2)
+                            .background(Tokens.paper2, in: Capsule())
+                        Spacer()
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .textCase(nil)
+                .padding(.horizontal, Space.lg)
+                .padding(.top, Space.md)
+                .padding(.bottom, Space.xs)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(Tokens.paper)
+        }
+    }
+    #endif
 
     private struct TaskBuckets {
         var overdue: [Todo] = []

--- a/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
+++ b/mobile/PersonalDashboard/Views/Tasks/TasksView.swift
@@ -67,6 +67,9 @@ struct TasksView: View {
                     .listSectionSpacingCompat(0)
                     .scrollContentBackground(.hidden)
                     .background(Tokens.paper)
+                    // macOS: kill the hard full-bleed grey selection bar; rows
+                    // get a soft inset hover instead via `.macRowHover()`.
+                    .macTamedListSelection()
                     .refreshable { await viewModel.load() }
                     // When the inline draft gains focus, scroll it clear of the keyboard.
                     .onChange(of: draftFocused) { _, focused in
@@ -592,30 +595,11 @@ private struct TaskRow: View {
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: Space.md) {
-            // Empty Button action: the high-priority tap gesture below is the single
-            // source of the toggle. This guarantees one toggle per tap even while the
-            // inline field is focused (iOS's "first tap dismisses keyboard" would
-            // otherwise eat a plain row/Button tap).
-            Button(action: {}) {
-                ZStack {
-                    Circle()
-                        .stroke(todo.completed ? Tokens.success : Tokens.borderStrong, lineWidth: 2)
-                        .background(todo.completed ? Tokens.success.clipShape(Circle()) : nil)
-                        .frame(width: 22, height: 22)
-                    if todo.completed {
-                        Image(systemName: "checkmark")
-                            .font(.system(size: 11, weight: .bold))
-                            .foregroundStyle(Tokens.paper)
-                    }
-                }
-                .frame(width: 24, height: 24)
-            }
-            .buttonStyle(.plain)
-            .highPriorityGesture(TapGesture().onEnded { handleToggle() })
-            // Map the circle's center (with a 4pt body-font offset for x-height) to the
-            // firstTextBaseline so the bullet visually centers on the title's first line.
-            .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
-            .accessibilityLabel(todo.completed ? "Mark incomplete" : "Mark complete")
+            completionButton
+                // Map the circle's center (with a 4pt body-font offset for x-height) to the
+                // firstTextBaseline so the bullet visually centers on the title's first line.
+                .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 4 }
+                .accessibilityLabel(todo.completed ? "Mark incomplete" : "Mark complete")
 
             VStack(alignment: .leading, spacing: 4) {
                 if isEditing {
@@ -716,6 +700,10 @@ private struct TaskRow: View {
         .padding(.vertical, Space.sm)
         .padding(.horizontal, Space.md)
         .background(Color.clear)
+        // macOS: soft inset rounded hover highlight (Reminders-style), which
+        // replaces the hard system selection bar killed by
+        // `macTamedListSelection()` on the List. No-op on iOS.
+        .macRowHover()
         // Thin colored left-edge bar keyed to the task's priority. Spans the row
         // height at the leading edge; reads as a subtle accent, not a block.
         .overlay(alignment: .leading) {
@@ -741,6 +729,40 @@ private struct TaskRow: View {
             // DispatchQueue.main.async lets the TextField mount before we focus it.
             DispatchQueue.main.async { titleFocused = true }
         }
+    }
+
+    /// The completion control. On macOS it's a real `Button` whose action
+    /// toggles completion, because a real mouse click fires the button action
+    /// directly (issue #285) — the iOS empty-action + high-priority tap-gesture
+    /// trick never delivers under a selectable `List` on the Mac. On iOS the
+    /// original pattern is kept verbatim: an empty action plus a high-priority
+    /// tap gesture, so one tap toggles even while the inline field owns first
+    /// responder (iOS's "first tap dismisses keyboard" would otherwise eat it).
+    @ViewBuilder
+    private var completionButton: some View {
+        #if os(macOS)
+        Button(action: handleToggle) { completionCircle }
+            .buttonStyle(.plain)
+        #else
+        Button(action: {}) { completionCircle }
+            .buttonStyle(.plain)
+            .highPriorityGesture(TapGesture().onEnded { handleToggle() })
+        #endif
+    }
+
+    private var completionCircle: some View {
+        ZStack {
+            Circle()
+                .stroke(todo.completed ? Tokens.success : Tokens.borderStrong, lineWidth: 2)
+                .background(todo.completed ? Tokens.success.clipShape(Circle()) : nil)
+                .frame(width: 22, height: 22)
+            if todo.completed {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(Tokens.paper)
+            }
+        }
+        .frame(width: 24, height: 24)
     }
 
     private func commitInlineEdit() {


### PR DESCRIPTION
Native macOS refinement pass toward the feel of Apple Reminders. Follow-up to the chrome polish in #284.

## Summary
- **Chat input**: removed the box-in-a-box (default macOS bordered field stripped via `plainFieldStyleOnMac`), leaving a single clean rounded input.
- **Task + list rows**: the completion control is now a real `Button` on macOS so a mouse click actually toggles under a selectable `List`; the hard full-bleed grey selection bar is disabled and replaced with a soft, inset, rounded hover (`macTamedListSelection` + `macRowHover`).
- **List-detail header buttons**: filter/trash/back get quiet rounded chrome instead of the hard square default-bordered macOS button background.
- **Sidebar**: Activity moved below Vocabulary.
- **Headers**: transparent window-toolbar background applied once in `macSectionChrome`, so every section reads consistent with no grey stripe.
- **AS avatar**: a single solid ink round with paper "AS" text, no grey oval.

All shared helpers live in `Design/MacChrome.swift` and are no-ops on iOS. Every change is `#if os(macOS)`-gated; the iOS control paths are preserved byte-for-byte in each `#else` branch.

## Builds
- `DexterMac` (macOS): BUILD SUCCEEDED
- `PersonalDashboard` (iOS regression): BUILD SUCCEEDED

## Test plan
macOS SwiftUI ignores synthetic clicks on tap/gesture controls, so the following need a hands-on pass:
- [ ] Clicking the circle checks/unchecks tasks and list items
- [ ] Row highlight is a soft inset rounded hover, not a hard grey bar
- [ ] Clicking a task/item body still enters inline edit
- [ ] Header filter/trash/back read as quiet rounded icons with subtle hover
- [ ] Chat input is a single clean field, transparent title-bar on every section, single solid black AS coin
- [ ] iOS unchanged (build-verified; spot-check on device optional)

Closes #285